### PR TITLE
업데이트 내역과 알림 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ AGENTS.md
 .omo/
 .sisyphus/
 .playwright-mcp/
-.omo/
 
 # Local Lost Ark research fixtures
 docs/lostark-api-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ AGENTS.md
 .claude/
 .serena/
 .agent/
+.omo/
 .sisyphus/
 .playwright-mcp/
 .omo/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,43 @@
+# Spec Simulator Design Contract
+
+## Direction
+
+The `/spec-simulator` page follows the actual Korean Lost Ark utility pattern: a **practical calculator dashboard**, not a cinematic SaaS lab. Real references such as LoPEC, LoaChart, ILOA, LoaCalc/Icepeng, and LoaUp prioritize fast character lookup, white card surfaces, compact feature grids, dense native controls, and clear result comparison. The page should feel like a reliable game utility tool while preserving simulator behavior, formulas, model parsing, route registration, API calls, storage, and callback signatures.
+
+## Tokens
+
+- **Palette:** preserve the existing Tailwind Lost Ark palette: `la-gold`, `la-gold-light`, `la-gold-dark`, `la-dark`, `la-dark-card`, `la-dark-surface`, plus neutral `gray-*` and semantic green/red/blue/purple/amber accents already used by the simulator.
+- **Surface:** light mode leads with `gray-50` and white cards; dark mode uses the existing `la-dark` cards. Gradients must be subtle and background-only, never the page's main personality.
+- **Typography:** keep the app font stack and Tailwind scale. Hero stays compact (`text-2xl` to `text-3xl`); score numerals use `tabular-nums`; labels stay compact at `text-[10px]` to `text-xs` for dense controls.
+- **Spacing:** use Tailwind spacing scale only: panel padding `p-4 sm:p-5`, page gutters `px-3 sm:px-4 lg:px-6`, grids `gap-3` to `gap-6`.
+- **Shape and elevation:** reference calculators mostly use restrained `8px-16px` radii. Core surfaces use `rounded-xl`; nested controls use `rounded-lg`; elevation is light and functional, with gold used for selected/changed states only.
+
+## Page-Scoped Primitives
+
+- `.spec-lab-shell`: simulator-only utility dashboard background wrapper.
+- `.spec-lab-card`: restrained white/dark card surface for hero, active character, summary, rail, modal blocks.
+- `.spec-lab-panel`: dense calculator panel shell for each tuning group.
+- `.spec-control`: shared native select/input visual shell, preserving browser select behavior and all existing option values.
+- `.spec-mini-button`: compact bulk action/reset buttons with gold focus/hover affordance.
+- `.spec-chip`: small status/category chips used for counts, grade markers, and telemetry labels.
+
+All component code may still use Tailwind utilities directly when the utility is layout-specific. Repeated visual chrome should use the page-scoped primitives above.
+
+## Responsive Rules
+
+- Mobile: single-column flow, horizontal scroll only where it already exists for category rail/gems, sticky score summary below the nav.
+- Tablet: search, active character, and score summary stay stacked but compact.
+- Desktop: `all` category uses a utility dashboard layout with core systems in the left column and gear/accessory/systems panels in the larger right column. Focused categories collapse to a single wide workbench.
+
+## Accessibility
+
+- All interactive controls must retain native keyboard behavior.
+- New focus styles use `focus-visible:ring-2 focus-visible:ring-la-gold/40` or stronger.
+- Dialog surfaces must remain `role="dialog"` and `aria-modal="true"`; label the Ark Grid gem editor title with `aria-labelledby`.
+- Avoid semantic regressions: keep form/search roles, links, button types, select option values, and existing Korean labels.
+
+## Accepted Debt
+
+- The page continues to use native `<select>` controls rather than custom selects to preserve behavior and avoid new dependencies.
+- Some dense simulator panels keep compact typography because the feature is a game calculator, not a marketing page.
+- `useSpecScoreSimulator.ts`, parser/model files, data tables, and formula code are intentionally outside this design scope.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,9 +5,4 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-  <url>
-    <loc>https://lokki.vercel.app/changelog</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://lokki.vercel.app/changelog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,7 @@ jest.mock('./pages/Compare', () => () => <div>Compare Page</div>);
 jest.mock('./pages/Enhancement', () => () => <div>Enhancement Page</div>);
 jest.mock('./pages/Market', () => () => <div>Market Page</div>);
 jest.mock('./pages/Spending', () => () => <div>Spending Page</div>);
+jest.mock('./pages/Changelog', () => () => <div>Changelog Page</div>);
 jest.mock('./pages/NotFound', () => () => <div>Not Found Page</div>);
 
 import App from './App';
@@ -71,10 +72,28 @@ test('marks unknown routes as noindex without reusing the home canonical', () =>
   );
 });
 
+test('normalizes the changelog trailing slash for metadata and canonical URL', () => {
+  mockPathname = '/changelog/';
+
+  render(<App />);
+
+  expect(document.title).toBe('업데이트 내역 - 로아끼욧');
+  expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
+    'content',
+    '로아끼욧에 추가되거나 개선된 기능을 날짜순으로 확인하세요.',
+  );
+  expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'index, follow');
+  expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://lokki.vercel.app/changelog',
+  );
+});
+
 test('keeps the sitemap scoped to the SPA root document', () => {
   const sitemap = readFileSync(join(process.cwd(), 'public', 'sitemap.xml'), 'utf8');
 
   expect(sitemap).toContain('<loc>https://lokki.vercel.app/</loc>');
   expect(sitemap).not.toContain('<loc>https://lokki.vercel.app/market</loc>');
   expect(sitemap).not.toContain('<loc>https://lokki.vercel.app/character</loc>');
+  expect(sitemap).not.toContain('<loc>https://lokki.vercel.app/changelog</loc>');
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,19 +4,17 @@ import { render, screen } from '@testing-library/react';
 
 let mockPathname = '/';
 
-jest.mock(
-  'react-router-dom',
-  () => {
-    const React = require('react');
-    return {
-      BrowserRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-      Routes: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-      Route: ({ element }: { element: React.ReactElement }) => element,
-      useLocation: () => ({ pathname: mockPathname }),
-    };
-  },
-  { virtual: true },
-);
+// BrowserRouter만 MemoryRouter로 바꾼다. Routes/Route/useLocation을 stub하면
+// 모든 라우트가 동시에 렌더되어 경로 매칭(오타, 누락)이 검증되지 않는다.
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  const React = require('react');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(actual.MemoryRouter, { initialEntries: [mockPathname] }, children),
+  };
+});
 
 jest.mock('./pages/Home', () => () => <div>Home Page</div>);
 jest.mock('./pages/Character', () => () => <div>Character Page</div>);
@@ -41,6 +39,23 @@ test('renders the home route', () => {
 
   expect(screen.getByText('Home Page')).toBeInTheDocument();
   expect(document.title).toBe('로아끼욧 - 로스트아크 캐릭터 조회·주간 골드 계산기');
+});
+
+test('matches the changelog route to the changelog page', () => {
+  mockPathname = '/changelog';
+
+  render(<App />);
+
+  expect(screen.getByText('Changelog Page')).toBeInTheDocument();
+  expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
+});
+
+test('falls back to the not found page for unmatched routes', () => {
+  mockPathname = '/missing-route';
+
+  render(<App />);
+
+  expect(screen.getByText('Not Found Page')).toBeInTheDocument();
 });
 
 test('updates SEO metadata for the current route', () => {
@@ -86,6 +101,21 @@ test('normalizes the changelog trailing slash for metadata and canonical URL', (
   expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
     'href',
     'https://lokki.vercel.app/changelog',
+  );
+});
+
+// trailing slash 정규화는 /changelog 전용이 아니라 모든 라우트에 적용된다.
+// 이전에는 /market/ 이 NOT_FOUND_SEO(noindex)로 폴백됐으므로 회귀 지점을 함께 고정한다.
+test('normalizes the trailing slash for pre-existing routes as well', () => {
+  mockPathname = '/market/';
+
+  render(<App />);
+
+  expect(document.title).toBe('로스트아크 거래소 검색 - 로아끼욧');
+  expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'index, follow');
+  expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://lokki.vercel.app/market',
   );
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Compare from './pages/Compare';
 import Enhancement from './pages/Enhancement';
 import Spending from './pages/Spending';
 import Market from './pages/Market';
+import Changelog from './pages/Changelog';
 import NotFound from './pages/NotFound';
 import { RouteSeo } from './components/RouteSeo';
 import { PwaChunkProvider, usePwaChunk } from './context/PwaChunkContext';
@@ -55,6 +56,7 @@ const AppContent: React.FC = () => {
           <Route path="/enhancement" element={<Enhancement />} />
           <Route path="/market" element={<Market />} />
           <Route path="/spending" element={<Spending />} />
+          <Route path="/changelog" element={<Changelog />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Market from './pages/Market';
 import Changelog from './pages/Changelog';
 import NotFound from './pages/NotFound';
 import { RouteSeo } from './components/RouteSeo';
+import { ROUTES } from './utils/routes';
 import { PwaChunkProvider, usePwaChunk } from './context/PwaChunkContext';
 import { ThemeProvider } from './context/ThemeContext';
 
@@ -56,7 +57,7 @@ const AppContent: React.FC = () => {
           <Route path="/enhancement" element={<Enhancement />} />
           <Route path="/market" element={<Market />} />
           <Route path="/spending" element={<Spending />} />
-          <Route path="/changelog" element={<Changelog />} />
+          <Route path={ROUTES.changelog} element={<Changelog />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/components/ChangelogBell.test.tsx
+++ b/src/components/ChangelogBell.test.tsx
@@ -1,5 +1,7 @@
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+let mockPathname = '/';
 
 jest.mock(
   'react-router-dom',
@@ -11,7 +13,7 @@ jest.mock(
           {children}
         </a>
       ),
-      useLocation: () => ({ pathname: '/' }),
+      useLocation: () => ({ pathname: mockPathname }),
     };
   },
   { virtual: true },
@@ -28,24 +30,25 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-test('moves focus into the portal and cycles Tab within the open panel', async () => {
+beforeEach(() => {
+  mockPathname = '/';
+});
+
+test('exposes a non-modal region without trapping Tab in the open panel', async () => {
   jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
-  renderBell();
+  render(
+    <>
+      <ChangelogBell />
+      <button type="button">다음 탐색 대상</button>
+    </>,
+  );
 
-  await userEvent.click(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' }));
-  const panel = await screen.findByRole('dialog', { name: '최근 업데이트' });
-  const links = within(panel).getAllByRole('link');
-  const firstLink = links.at(0);
-  const lastLink = links.at(-1);
-  if (!(firstLink instanceof HTMLElement) || !(lastLink instanceof HTMLElement)) {
-    throw new TypeError('Expected focusable changelog links');
-  }
+  const toggleButton = screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' });
+  await userEvent.click(toggleButton);
+  await screen.findByRole('region', { name: '최근 업데이트' });
 
-  await waitFor(() => expect(document.activeElement).toBe(firstLink));
-  await userEvent.tab({ shift: true });
-  expect(document.activeElement).toBe(lastLink);
   await userEvent.tab();
-  expect(document.activeElement).toBe(firstLink);
+  expect(document.activeElement).toBe(screen.getByRole('button', { name: '다음 탐색 대상' }));
 });
 
 test('restores button focus and clears NEW labels after closing', async () => {
@@ -79,6 +82,7 @@ test('marks only visible unseen preview revisions when opening', async () => {
 test('clamps the portal panel within a narrow viewport', async () => {
   jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
   const initialInnerWidth = window.innerWidth;
+  const initialClientWidth = document.documentElement.clientWidth;
   const buttonRect: DOMRect = {
     bottom: 40,
     height: 40,
@@ -93,14 +97,41 @@ test('clamps the portal panel within a narrow viewport', async () => {
 
   try {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 320 });
-    jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(288);
-    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(buttonRect);
+    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: 320 });
+    const panelRect: DOMRect = {
+      bottom: 0,
+      height: 100,
+      left: 0,
+      right: 288,
+      top: 0,
+      width: 288,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement): DOMRect {
+      return this.id === 'navbar-changelog-panel' ? panelRect : buttonRect;
+    });
     renderBell();
     await userEvent.click(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' }));
-    const panel = await screen.findByRole('dialog', { name: '최근 업데이트' });
+    const panel = await screen.findByRole('region', { name: '최근 업데이트' });
 
-    expect(Number.parseFloat(panel.style.right)).toBeLessThanOrEqual(24);
+    expect(Number.parseFloat(panel.style.right)).toBe(24);
   } finally {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: initialInnerWidth });
+    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: initialClientWidth });
   }
+});
+
+test('treats the changelog trailing slash as the changelog route', () => {
+  mockPathname = '/changelog/';
+  const latestEntry = CHANGELOG[0];
+  if (!latestEntry) throw new TypeError('Expected at least one changelog entry');
+  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([latestEntry]);
+  const markSeen = jest.spyOn(changelogState, 'markChangelogSeen');
+
+  renderBell();
+
+  expect(markSeen).toHaveBeenCalledWith();
+  expect(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' })).toBeInTheDocument();
 });

--- a/src/components/ChangelogBell.test.tsx
+++ b/src/components/ChangelogBell.test.tsx
@@ -1,137 +1,153 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-let mockPathname = '/';
-
-jest.mock(
-  'react-router-dom',
-  () => {
-    const React = require('react');
-    return {
-      Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
-        <a href={to} {...rest}>
-          {children}
-        </a>
-      ),
-      useLocation: () => ({ pathname: mockPathname }),
-    };
-  },
-  { virtual: true },
-);
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { CHANGELOG } from '../data/changelog';
-import * as changelogState from '../utils/changelogState';
 import ChangelogBell from './ChangelogBell';
 
-const renderBell = () => render(<ChangelogBell />);
+const SEEN_IDS_KEY = 'changelogSeenIds';
+const PREVIEW_COUNT = 3;
 
-afterEach(() => {
-  cleanup();
-  jest.restoreAllMocks();
-});
+const readStoredIds = (): unknown => JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? 'null');
 
-beforeEach(() => {
-  mockPathname = '/';
-});
-
-test('exposes a non-modal region without trapping Tab in the open panel', async () => {
-  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
+/** 실제 react-router-dom을 사용한다. useLocation을 stub하면 "라우트 진입 시 읽음 처리"가
+ *  라우팅이 아니라 stub을 검증하게 되어 회귀를 잡지 못한다. */
+const renderBell = (initialPath = '/', extra?: React.ReactNode) =>
   render(
-    <>
+    <MemoryRouter initialEntries={[initialPath]}>
       <ChangelogBell />
-      <button type="button">다음 탐색 대상</button>
-    </>,
+      {extra}
+      <Routes>
+        <Route path="/" element={<p>홈 화면</p>} />
+        <Route path="/changelog" element={<p>업데이트 내역 화면</p>} />
+      </Routes>
+    </MemoryRouter>,
   );
 
-  const toggleButton = screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' });
-  await userEvent.click(toggleButton);
+const allSeenLabel = '업데이트 알림, 새 소식 없음';
+const unseenLabel = (count: number) => `업데이트 알림, 새 소식 ${count}건`;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('counts every unread entry in the accessible name and shows the unread dot', () => {
+  const { container } = renderBell();
+
+  expect(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) })).toBeInTheDocument();
+  expect(container.querySelector('span[aria-hidden]')).toBeInTheDocument();
+});
+
+test('Tab moves from the toggle button straight into the open panel', async () => {
+  renderBell('/', <button type="button">다음 탐색 대상</button>);
+
+  const toggleButton = screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) });
+  userEvent.click(toggleButton);
+
+  const panel = await screen.findByRole('region', { name: '최근 업데이트' });
+  const firstPanelLink = panel.querySelector('a');
+
+  userEvent.tab();
+
+  expect(document.activeElement).toBe(firstPanelLink);
+});
+
+test('opening marks the whole changelog seen so no unread remainder is stranded', async () => {
+  const { container } = renderBell();
+
+  userEvent.click(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) }));
+
+  expect(readStoredIds()).toEqual(CHANGELOG.map((entry) => entry.id));
+  expect(screen.getByRole('button', { name: allSeenLabel })).toBeInTheDocument();
+  expect(container.querySelector('span[aria-hidden]')).not.toBeInTheDocument();
+});
+
+test('keeps NEW markers visible in the panel after the badge clears, then drops them on reopen', async () => {
+  renderBell();
+
+  const button = screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) });
+  userEvent.click(button);
+
+  expect(await screen.findAllByText('새 소식')).toHaveLength(PREVIEW_COUNT);
+
+  userEvent.click(screen.getByRole('button', { name: allSeenLabel }));
+  userEvent.click(screen.getByRole('button', { name: allSeenLabel }));
+
+  expect(screen.queryByText('새 소식')).not.toBeInTheDocument();
+});
+
+test('read state survives a remount', async () => {
+  const { unmount } = renderBell();
+  userEvent.click(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) }));
+  unmount();
+
+  renderBell();
+
+  expect(screen.getByRole('button', { name: allSeenLabel })).toBeInTheDocument();
+});
+
+test('Escape closes the panel and returns focus to the toggle button', async () => {
+  renderBell();
+
+  const button = screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) });
+  userEvent.click(button);
   await screen.findByRole('region', { name: '최근 업데이트' });
 
-  await userEvent.tab();
-  expect(document.activeElement).toBe(screen.getByRole('button', { name: '다음 탐색 대상' }));
+  userEvent.keyboard('{Escape}');
+
+  expect(screen.queryByRole('region', { name: '최근 업데이트' })).not.toBeInTheDocument();
+  expect(document.activeElement).toBe(screen.getByRole('button', { name: allSeenLabel }));
 });
 
-test('restores button focus and clears NEW labels after closing', async () => {
-  const latestEntry = CHANGELOG[0];
-  if (!latestEntry) throw new TypeError('Expected at least one changelog entry');
-  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([latestEntry]);
+test('an outside click closes the panel without stealing focus from the clicked element', async () => {
+  renderBell('/', <button type="button">바깥 버튼</button>);
+
+  userEvent.click(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) }));
+  await screen.findByRole('region', { name: '최근 업데이트' });
+
+  const outsideButton = screen.getByRole('button', { name: '바깥 버튼' });
+  userEvent.click(outsideButton);
+
+  expect(screen.queryByRole('region', { name: '최근 업데이트' })).not.toBeInTheDocument();
+  expect(document.activeElement).toBe(outsideButton);
+});
+
+test('a click inside the panel does not close it', async () => {
   renderBell();
 
-  const button = screen.getByRole('button', { name: '업데이트 알림, 새 소식 1건' });
-  await userEvent.click(button);
-  expect(await screen.findByText('NEW')).toBeInTheDocument();
+  userEvent.click(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) }));
+  const panel = await screen.findByRole('region', { name: '최근 업데이트' });
 
-  await userEvent.keyboard('{Escape}');
-  expect(document.activeElement).toBe(button);
-  await userEvent.click(button);
+  userEvent.click(screen.getByText('최근 업데이트'));
 
-  expect(screen.queryByText('NEW')).not.toBeInTheDocument();
+  expect(panel).toBeInTheDocument();
 });
 
-test('marks only visible unseen preview revisions when opening', async () => {
-  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue(CHANGELOG);
-  const markSeen = jest.spyOn(changelogState, 'markChangelogSeen');
+test('following a preview link navigates to the changelog and closes the panel', () => {
   renderBell();
 
-  await userEvent.click(screen.getByRole('button', { name: `업데이트 알림, 새 소식 ${CHANGELOG.length}건` }));
+  userEvent.click(screen.getByRole('button', { name: unseenLabel(CHANGELOG.length) }));
+  const [newest] = CHANGELOG;
+  if (!newest) throw new TypeError('Expected a changelog entry');
 
-  expect(markSeen).toHaveBeenCalledWith(CHANGELOG.slice(0, 3).map((entry) => entry.id));
+  userEvent.click(screen.getByRole('link', { name: new RegExp(newest.title) }));
+
+  expect(screen.getByText('업데이트 내역 화면')).toBeInTheDocument();
+  expect(screen.queryByRole('region', { name: '최근 업데이트' })).not.toBeInTheDocument();
+  expect(readStoredIds()).toEqual(CHANGELOG.map((entry) => entry.id));
 });
 
+test('entering the changelog route marks everything seen', () => {
+  renderBell('/changelog');
 
-test('clamps the portal panel within a narrow viewport', async () => {
-  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
-  const initialInnerWidth = window.innerWidth;
-  const initialClientWidth = document.documentElement.clientWidth;
-  const buttonRect: DOMRect = {
-    bottom: 40,
-    height: 40,
-    left: 200,
-    right: 240,
-    top: 0,
-    width: 40,
-    x: 200,
-    y: 0,
-    toJSON: () => ({}),
-  };
-
-  try {
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 320 });
-    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: 320 });
-    const panelRect: DOMRect = {
-      bottom: 0,
-      height: 100,
-      left: 0,
-      right: 288,
-      top: 0,
-      width: 288,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    };
-    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement): DOMRect {
-      return this.id === 'navbar-changelog-panel' ? panelRect : buttonRect;
-    });
-    renderBell();
-    await userEvent.click(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' }));
-    const panel = await screen.findByRole('region', { name: '최근 업데이트' });
-
-    expect(Number.parseFloat(panel.style.right)).toBe(24);
-  } finally {
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: initialInnerWidth });
-    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: initialClientWidth });
-  }
+  expect(readStoredIds()).toEqual(CHANGELOG.map((entry) => entry.id));
+  expect(screen.getByRole('button', { name: allSeenLabel })).toBeInTheDocument();
 });
 
 test('treats the changelog trailing slash as the changelog route', () => {
-  mockPathname = '/changelog/';
-  const latestEntry = CHANGELOG[0];
-  if (!latestEntry) throw new TypeError('Expected at least one changelog entry');
-  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([latestEntry]);
-  const markSeen = jest.spyOn(changelogState, 'markChangelogSeen');
+  renderBell('/changelog/');
 
-  renderBell();
-
-  expect(markSeen).toHaveBeenCalledWith();
-  expect(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' })).toBeInTheDocument();
+  expect(readStoredIds()).toEqual(CHANGELOG.map((entry) => entry.id));
+  expect(screen.getByRole('button', { name: allSeenLabel })).toBeInTheDocument();
 });

--- a/src/components/ChangelogBell.test.tsx
+++ b/src/components/ChangelogBell.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock(
+  'react-router-dom',
+  () => {
+    const React = require('react');
+    return {
+      Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+        <a href={to} {...rest}>
+          {children}
+        </a>
+      ),
+      useLocation: () => ({ pathname: '/' }),
+    };
+  },
+  { virtual: true },
+);
+
+import { CHANGELOG } from '../data/changelog';
+import * as changelogState from '../utils/changelogState';
+import ChangelogBell from './ChangelogBell';
+
+const renderBell = () => render(<ChangelogBell />);
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+test('moves focus into the portal and cycles Tab within the open panel', async () => {
+  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
+  renderBell();
+
+  await userEvent.click(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' }));
+  const panel = await screen.findByRole('dialog', { name: '최근 업데이트' });
+  const links = within(panel).getAllByRole('link');
+  const firstLink = links.at(0);
+  const lastLink = links.at(-1);
+  if (!(firstLink instanceof HTMLElement) || !(lastLink instanceof HTMLElement)) {
+    throw new TypeError('Expected focusable changelog links');
+  }
+
+  await waitFor(() => expect(document.activeElement).toBe(firstLink));
+  await userEvent.tab({ shift: true });
+  expect(document.activeElement).toBe(lastLink);
+  await userEvent.tab();
+  expect(document.activeElement).toBe(firstLink);
+});
+
+test('restores button focus and clears NEW labels after closing', async () => {
+  const latestEntry = CHANGELOG[0];
+  if (!latestEntry) throw new TypeError('Expected at least one changelog entry');
+  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([latestEntry]);
+  renderBell();
+
+  const button = screen.getByRole('button', { name: '업데이트 알림, 새 소식 1건' });
+  await userEvent.click(button);
+  expect(await screen.findByText('NEW')).toBeInTheDocument();
+
+  await userEvent.keyboard('{Escape}');
+  expect(document.activeElement).toBe(button);
+  await userEvent.click(button);
+
+  expect(screen.queryByText('NEW')).not.toBeInTheDocument();
+});
+
+test('marks only visible unseen preview revisions when opening', async () => {
+  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue(CHANGELOG);
+  const markSeen = jest.spyOn(changelogState, 'markChangelogSeen');
+  renderBell();
+
+  await userEvent.click(screen.getByRole('button', { name: `업데이트 알림, 새 소식 ${CHANGELOG.length}건` }));
+
+  expect(markSeen).toHaveBeenCalledWith(CHANGELOG.slice(0, 3).map((entry) => entry.id));
+});
+
+
+test('clamps the portal panel within a narrow viewport', async () => {
+  jest.spyOn(changelogState, 'readUnseenEntries').mockReturnValue([]);
+  const initialInnerWidth = window.innerWidth;
+  const buttonRect: DOMRect = {
+    bottom: 40,
+    height: 40,
+    left: 200,
+    right: 240,
+    top: 0,
+    width: 40,
+    x: 200,
+    y: 0,
+    toJSON: () => ({}),
+  };
+
+  try {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 320 });
+    jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(288);
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(buttonRect);
+    renderBell();
+    await userEvent.click(screen.getByRole('button', { name: '업데이트 알림, 새 소식 없음' }));
+    const panel = await screen.findByRole('dialog', { name: '최근 업데이트' });
+
+    expect(Number.parseFloat(panel.style.right)).toBeLessThanOrEqual(24);
+  } finally {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: initialInnerWidth });
+  }
+});

--- a/src/components/ChangelogBell.tsx
+++ b/src/components/ChangelogBell.tsx
@@ -1,32 +1,33 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { CHANGELOG, formatChangelogDate } from '../data/changelog';
 import { markChangelogSeen, readUnseenEntries } from '../utils/changelogState';
+import { ROUTES, normalizePathname } from '../utils/routes';
 
-const CHANGELOG_PATH = '/changelog';
 const PREVIEW_COUNT = 3;
 
 /** NavBar 우측의 업데이트 알림 버튼.
  *  확인 상태를 이 컴포넌트가 소유한다. Changelog 페이지에서 확인 처리를 하면
  *  effect 실행 순서(자식 → 부모)상 NavBar가 먼저 계산을 끝내 배지가 갱신되지 않으므로,
- *  "페이지 진입"과 "드롭다운 열기" 두 시점을 모두 여기서 확인 처리한다. */
+ *  "페이지 진입"과 "드롭다운 열기" 두 시점을 모두 여기서 확인 처리한다.
+ *
+ *  패널은 포털이 아니라 버튼 바로 옆 DOM에 absolute로 렌더한다.
+ *  포털을 쓰면 document.body 끝에 붙어 Tab 순서가 버튼과 끊기고, 그걸 메우려면
+ *  non-modal 위젯에 modal용 focus trap을 씌워야 한다. DOM 순서를 읽기 순서와
+ *  일치시키면 Tab이 버튼 → 패널로 자연히 이어져 trap도 포커스 복원도 필요 없다. */
 const ChangelogBell: React.FC = () => {
   const { pathname } = useLocation();
   const [isOpen, setIsOpen] = useState(false);
-  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
   const [unseenIds, setUnseenIds] = useState<readonly string[]>([]);
   // 드롭다운을 열면 배지는 즉시 사라지지만, 패널 안에서는 어떤 항목이 새 것이었는지 계속 보여야 한다.
   const [highlightIds, setHighlightIds] = useState<readonly string[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setIsOpen(false);
 
-    const normalizedPathname = pathname === '/' ? pathname : pathname.replace(/\/+$/, '');
-
-    if (normalizedPathname === CHANGELOG_PATH) {
+    if (normalizePathname(pathname) === ROUTES.changelog) {
       markChangelogSeen();
       setUnseenIds([]);
       setHighlightIds([]);
@@ -36,54 +37,33 @@ const ChangelogBell: React.FC = () => {
     setUnseenIds(readUnseenEntries().map((entry) => entry.id));
   }, [pathname]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isOpen) {
       setHighlightIds([]);
-      setPosition(null);
       return;
     }
-
-    const panel = panelRef.current;
-    if (!(panel instanceof HTMLElement)) return;
-
-    const updatePosition = () => {
-      const rect = buttonRef.current?.getBoundingClientRect();
-      if (!rect) return;
-
-      const viewportPadding = 8;
-      const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
-      const panelWidth = panel.getBoundingClientRect().width;
-      const maxRight = Math.max(viewportPadding, viewportWidth - Math.ceil(panelWidth) - viewportPadding);
-      setPosition({
-        top: rect.bottom + viewportPadding,
-        right: Math.min(Math.max(viewportWidth - rect.right, viewportPadding), maxRight),
-      });
-    };
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      if (buttonRef.current?.contains(target) || panel.contains(target)) return;
+      if (containerRef.current?.contains(target)) return;
       setIsOpen(false);
     };
 
+    // Escape는 사용자가 패널 안에 있을 수 있는 유일한 닫기 경로다.
+    // 바깥 클릭이나 링크 이동에서 포커스를 되돌리면 사용자가 방금 고른 대상을 빼앗는다.
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsOpen(false);
+      if (event.key !== 'Escape') return;
+      setIsOpen(false);
+      buttonRef.current?.focus();
     };
 
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
     document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKeyDown);
 
-    const toggleButton = buttonRef.current;
     return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
-      toggleButton?.focus();
     };
   }, [isOpen]);
 
@@ -93,74 +73,20 @@ const ChangelogBell: React.FC = () => {
   const handleToggle = () => {
     const willOpen = !isOpen;
 
+    // 벨을 여는 행위를 "최근 소식을 확인했다"로 본다. 프리뷰에 보이는 항목만 읽음 처리하면
+    // 미확인이 PREVIEW_COUNT를 넘길 때 배지가 영구히 남는다.
     // setState updater는 순수해야 하며 StrictMode에서 두 번 호출된다. 저장은 updater 밖에서 한 번만.
-    const visibleUnseenIds = previewEntries
-      .map((entry) => entry.id)
-      .filter((id) => unseenIds.includes(id));
-
-    if (willOpen && visibleUnseenIds.length > 0) {
-      setHighlightIds(visibleUnseenIds);
-      markChangelogSeen(visibleUnseenIds);
-      setUnseenIds(unseenIds.filter((id) => !visibleUnseenIds.includes(id)));
+    if (willOpen && unseenCount > 0) {
+      setHighlightIds(unseenIds);
+      markChangelogSeen();
+      setUnseenIds([]);
     }
 
     setIsOpen(willOpen);
   };
 
-  const panel = isOpen && typeof document !== 'undefined'
-    ? createPortal(
-        <div
-          id="navbar-changelog-panel"
-          ref={panelRef}
-          role="region"
-          aria-label="최근 업데이트"
-          className="fixed z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-gray-200/70 bg-white p-2 shadow-lg shadow-black/5 dark:border-white/10 dark:bg-la-dark dark:shadow-black/30"
-          style={{ top: position?.top ?? 0, right: position?.right ?? 8 }}
-        >
-          <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-            최근 업데이트
-          </p>
-          {previewEntries.length === 0 ? (
-            <p className="px-2 py-3 text-sm text-gray-600 dark:text-gray-300">등록된 내역이 없습니다.</p>
-          ) : (
-            <ul className="flex flex-col">
-              {previewEntries.map((entry) => (
-                <li key={entry.id}>
-                  <Link
-                    to={CHANGELOG_PATH}
-                    className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:hover:bg-white/5"
-                  >
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="break-keep text-sm font-medium text-gray-800 dark:text-gray-200">
-                        {entry.title}
-                      </span>
-                      {highlightIds.includes(entry.id) && (
-                        <span className="rounded-full border border-la-gold/25 bg-la-gold/10 px-1.5 py-0.5 text-[9px] font-bold leading-none text-la-gold-dark dark:text-la-gold">
-                          NEW
-                        </span>
-                      )}
-                    </span>
-                    <time dateTime={entry.date} className="text-xs text-gray-600 dark:text-gray-300">
-                      {formatChangelogDate(entry.date)}
-                    </time>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-          <Link
-            to={CHANGELOG_PATH}
-            className="mt-1 block rounded-lg px-2 py-2 text-center text-xs font-bold text-la-gold-dark transition-colors hover:bg-la-gold/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-la-gold"
-          >
-            전체 업데이트 내역 보기
-          </Link>
-        </div>,
-        document.body
-      )
-    : null;
-
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <button
         ref={buttonRef}
         type="button"
@@ -184,8 +110,60 @@ const ChangelogBell: React.FC = () => {
           />
         )}
       </button>
-      {panel}
-    </>
+      {/* 버튼 기준(absolute right-0)으로 두면 벨 오른쪽에 테마·메뉴 버튼이 있어
+          좁은 화면에서 패널이 왼쪽 화면 밖으로 밀려난다(320px에서 left: -72px).
+          sticky nav는 상단 전폭이므로 fixed의 기준 박스가 nav든 뷰포트든 결과가 같다. */}
+      {isOpen && (
+        <div
+          id="navbar-changelog-panel"
+          role="region"
+          aria-label="최근 업데이트"
+          className="fixed right-2 top-16 z-50 max-h-[calc(100dvh-4.5rem)] w-72 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-xl border border-gray-200/70 bg-white p-2 shadow-lg shadow-black/5 dark:border-white/10 dark:bg-la-dark dark:shadow-black/30"
+        >
+          <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+            최근 업데이트
+          </p>
+          {previewEntries.length === 0 ? (
+            <p className="px-2 py-3 text-sm text-gray-600 dark:text-gray-300">
+              아직 등록된 업데이트 내역이 없습니다.
+            </p>
+          ) : (
+            <ul className="flex flex-col">
+              {previewEntries.map((entry) => (
+                <li key={entry.id}>
+                  <Link
+                    to={ROUTES.changelog}
+                    className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:hover:bg-white/5"
+                  >
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="break-keep text-sm font-medium text-gray-800 dark:text-gray-200">
+                        {entry.title}
+                      </span>
+                      {highlightIds.includes(entry.id) && (
+                        <span className="rounded-full border border-la-gold/25 bg-la-gold/10 px-1.5 py-0.5 text-[9px] font-bold leading-none text-la-gold-deep dark:text-la-gold">
+                          새 소식
+                        </span>
+                      )}
+                    </span>
+                    <time dateTime={entry.date} className="text-xs text-gray-600 dark:text-gray-300">
+                      {formatChangelogDate(entry.date)}
+                    </time>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+          {previewEntries.length > 0 && (
+            <Link
+              to={ROUTES.changelog}
+              className="mt-1 block rounded-lg px-2 py-2 text-center text-xs font-bold text-la-gold-deep transition-colors hover:bg-la-gold/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-la-gold"
+            >
+              전체 업데이트 내역 보기
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/ChangelogBell.tsx
+++ b/src/components/ChangelogBell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { CHANGELOG, formatChangelogDate } from '../data/changelog';
@@ -34,42 +34,71 @@ const ChangelogBell: React.FC = () => {
     setUnseenIds(readUnseenEntries().map((entry) => entry.id));
   }, [pathname]);
 
-  useEffect(() => {
-    if (!isOpen) return;
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setHighlightIds([]);
+      setPosition(null);
+      return;
+    }
 
+    const panel = panelRef.current;
+    if (!(panel instanceof HTMLElement)) return;
+
+    const focusableSelector = 'a[href], button:not([disabled])';
     const updatePosition = () => {
       const rect = buttonRef.current?.getBoundingClientRect();
       if (!rect) return;
+
+      const viewportPadding = 8;
+      const maxRight = Math.max(viewportPadding, window.innerWidth - panel.offsetWidth - viewportPadding);
       setPosition({
-        top: rect.bottom + 8,
-        right: Math.max(window.innerWidth - rect.right, 8),
+        top: rect.bottom + viewportPadding,
+        right: Math.min(Math.max(window.innerWidth - rect.right, viewportPadding), maxRight),
       });
     };
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      if (buttonRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target) || panel.contains(target)) return;
       setIsOpen(false);
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      setIsOpen(false);
-      buttonRef.current?.focus();
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
+      const first = focusables.at(0);
+      const last = focusables.at(-1);
+      if (!(first instanceof HTMLElement) || !(last instanceof HTMLElement)) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
 
     updatePosition();
+    panel.querySelector<HTMLElement>(focusableSelector)?.focus();
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);
     document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKeyDown);
 
+    const toggleButton = buttonRef.current;
     return () => {
       window.removeEventListener('resize', updatePosition);
       window.removeEventListener('scroll', updatePosition, true);
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
+      toggleButton?.focus();
     };
   }, [isOpen]);
 
@@ -80,16 +109,20 @@ const ChangelogBell: React.FC = () => {
     const willOpen = !isOpen;
 
     // setState updater는 순수해야 하며 StrictMode에서 두 번 호출된다. 저장은 updater 밖에서 한 번만.
-    if (willOpen && unseenCount > 0) {
-      setHighlightIds(unseenIds);
-      markChangelogSeen();
-      setUnseenIds([]);
+    const visibleUnseenIds = previewEntries
+      .map((entry) => entry.id)
+      .filter((id) => unseenIds.includes(id));
+
+    if (willOpen && visibleUnseenIds.length > 0) {
+      setHighlightIds(visibleUnseenIds);
+      markChangelogSeen(visibleUnseenIds);
+      setUnseenIds(unseenIds.filter((id) => !visibleUnseenIds.includes(id)));
     }
 
     setIsOpen(willOpen);
   };
 
-  const panel = isOpen && position && typeof document !== 'undefined'
+  const panel = isOpen && typeof document !== 'undefined'
     ? createPortal(
         <div
           id="navbar-changelog-panel"
@@ -97,7 +130,7 @@ const ChangelogBell: React.FC = () => {
           role="dialog"
           aria-label="최근 업데이트"
           className="fixed z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-gray-200/70 bg-white p-2 shadow-lg shadow-black/5 dark:border-white/10 dark:bg-la-dark dark:shadow-black/30"
-          style={{ top: position.top, right: position.right }}
+          style={{ top: position?.top ?? 0, right: position?.right ?? 8 }}
         >
           <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">
             최근 업데이트
@@ -122,8 +155,8 @@ const ChangelogBell: React.FC = () => {
                         </span>
                       )}
                     </span>
-                    <time dateTime={entry.id} className="text-xs text-gray-400 dark:text-gray-500">
-                      {formatChangelogDate(entry.id)}
+                    <time dateTime={entry.date} className="text-xs text-gray-400 dark:text-gray-500">
+                      {formatChangelogDate(entry.date)}
                     </time>
                   </Link>
                 </li>
@@ -148,6 +181,7 @@ const ChangelogBell: React.FC = () => {
         type="button"
         className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white"
         aria-label={unseenCount > 0 ? `업데이트 알림, 새 소식 ${unseenCount}건` : '업데이트 알림, 새 소식 없음'}
+        aria-haspopup="dialog"
         aria-controls={isOpen ? 'navbar-changelog-panel' : undefined}
         aria-expanded={isOpen}
         onClick={handleToggle}

--- a/src/components/ChangelogBell.tsx
+++ b/src/components/ChangelogBell.tsx
@@ -24,7 +24,9 @@ const ChangelogBell: React.FC = () => {
   useEffect(() => {
     setIsOpen(false);
 
-    if (pathname === CHANGELOG_PATH) {
+    const normalizedPathname = pathname === '/' ? pathname : pathname.replace(/\/+$/, '');
+
+    if (normalizedPathname === CHANGELOG_PATH) {
       markChangelogSeen();
       setUnseenIds([]);
       setHighlightIds([]);
@@ -44,16 +46,17 @@ const ChangelogBell: React.FC = () => {
     const panel = panelRef.current;
     if (!(panel instanceof HTMLElement)) return;
 
-    const focusableSelector = 'a[href], button:not([disabled])';
     const updatePosition = () => {
       const rect = buttonRef.current?.getBoundingClientRect();
       if (!rect) return;
 
       const viewportPadding = 8;
-      const maxRight = Math.max(viewportPadding, window.innerWidth - panel.offsetWidth - viewportPadding);
+      const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+      const panelWidth = panel.getBoundingClientRect().width;
+      const maxRight = Math.max(viewportPadding, viewportWidth - Math.ceil(panelWidth) - viewportPadding);
       setPosition({
         top: rect.bottom + viewportPadding,
-        right: Math.min(Math.max(window.innerWidth - rect.right, viewportPadding), maxRight),
+        right: Math.min(Math.max(viewportWidth - rect.right, viewportPadding), maxRight),
       });
     };
 
@@ -65,28 +68,10 @@ const ChangelogBell: React.FC = () => {
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-        return;
-      }
-      if (event.key !== 'Tab') return;
-
-      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
-      const first = focusables.at(0);
-      const last = focusables.at(-1);
-      if (!(first instanceof HTMLElement) || !(last instanceof HTMLElement)) return;
-
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
+      if (event.key === 'Escape') setIsOpen(false);
     };
 
     updatePosition();
-    panel.querySelector<HTMLElement>(focusableSelector)?.focus();
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);
     document.addEventListener('pointerdown', handlePointerDown);
@@ -127,26 +112,26 @@ const ChangelogBell: React.FC = () => {
         <div
           id="navbar-changelog-panel"
           ref={panelRef}
-          role="dialog"
+          role="region"
           aria-label="최근 업데이트"
           className="fixed z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-gray-200/70 bg-white p-2 shadow-lg shadow-black/5 dark:border-white/10 dark:bg-la-dark dark:shadow-black/30"
           style={{ top: position?.top ?? 0, right: position?.right ?? 8 }}
         >
-          <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+          <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">
             최근 업데이트
           </p>
           {previewEntries.length === 0 ? (
-            <p className="px-2 py-3 text-sm text-gray-500 dark:text-gray-400">등록된 내역이 없습니다.</p>
+            <p className="px-2 py-3 text-sm text-gray-600 dark:text-gray-300">등록된 내역이 없습니다.</p>
           ) : (
             <ul className="flex flex-col">
               {previewEntries.map((entry) => (
                 <li key={entry.id}>
                   <Link
                     to={CHANGELOG_PATH}
-                    className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 dark:hover:bg-white/5"
+                    className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:hover:bg-white/5"
                   >
-                    <span className="flex items-center gap-1.5">
-                      <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="break-keep text-sm font-medium text-gray-800 dark:text-gray-200">
                         {entry.title}
                       </span>
                       {highlightIds.includes(entry.id) && (
@@ -155,7 +140,7 @@ const ChangelogBell: React.FC = () => {
                         </span>
                       )}
                     </span>
-                    <time dateTime={entry.date} className="text-xs text-gray-400 dark:text-gray-500">
+                    <time dateTime={entry.date} className="text-xs text-gray-600 dark:text-gray-300">
                       {formatChangelogDate(entry.date)}
                     </time>
                   </Link>
@@ -165,7 +150,7 @@ const ChangelogBell: React.FC = () => {
           )}
           <Link
             to={CHANGELOG_PATH}
-            className="mt-1 block rounded-lg px-2 py-2 text-center text-xs font-bold text-la-gold-dark transition-colors hover:bg-la-gold/10 dark:text-la-gold"
+            className="mt-1 block rounded-lg px-2 py-2 text-center text-xs font-bold text-la-gold-dark transition-colors hover:bg-la-gold/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-la-gold"
           >
             전체 업데이트 내역 보기
           </Link>
@@ -179,9 +164,8 @@ const ChangelogBell: React.FC = () => {
       <button
         ref={buttonRef}
         type="button"
-        className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white"
+        className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white"
         aria-label={unseenCount > 0 ? `업데이트 알림, 새 소식 ${unseenCount}건` : '업데이트 알림, 새 소식 없음'}
-        aria-haspopup="dialog"
         aria-controls={isOpen ? 'navbar-changelog-panel' : undefined}
         aria-expanded={isOpen}
         onClick={handleToggle}

--- a/src/components/ChangelogBell.tsx
+++ b/src/components/ChangelogBell.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Link, useLocation } from 'react-router-dom';
+import { CHANGELOG, formatChangelogDate } from '../data/changelog';
+import { markChangelogSeen, readUnseenEntries } from '../utils/changelogState';
+
+const CHANGELOG_PATH = '/changelog';
+const PREVIEW_COUNT = 3;
+
+/** NavBar 우측의 업데이트 알림 버튼.
+ *  확인 상태를 이 컴포넌트가 소유한다. Changelog 페이지에서 확인 처리를 하면
+ *  effect 실행 순서(자식 → 부모)상 NavBar가 먼저 계산을 끝내 배지가 갱신되지 않으므로,
+ *  "페이지 진입"과 "드롭다운 열기" 두 시점을 모두 여기서 확인 처리한다. */
+const ChangelogBell: React.FC = () => {
+  const { pathname } = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
+  const [unseenIds, setUnseenIds] = useState<readonly string[]>([]);
+  // 드롭다운을 열면 배지는 즉시 사라지지만, 패널 안에서는 어떤 항목이 새 것이었는지 계속 보여야 한다.
+  const [highlightIds, setHighlightIds] = useState<readonly string[]>([]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setIsOpen(false);
+
+    if (pathname === CHANGELOG_PATH) {
+      markChangelogSeen();
+      setUnseenIds([]);
+      setHighlightIds([]);
+      return;
+    }
+
+    setUnseenIds(readUnseenEntries().map((entry) => entry.id));
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updatePosition = () => {
+      const rect = buttonRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setPosition({
+        top: rect.bottom + 8,
+        right: Math.max(window.innerWidth - rect.right, 8),
+      });
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (buttonRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const unseenCount = unseenIds.length;
+  const previewEntries = CHANGELOG.slice(0, PREVIEW_COUNT);
+
+  const handleToggle = () => {
+    const willOpen = !isOpen;
+
+    // setState updater는 순수해야 하며 StrictMode에서 두 번 호출된다. 저장은 updater 밖에서 한 번만.
+    if (willOpen && unseenCount > 0) {
+      setHighlightIds(unseenIds);
+      markChangelogSeen();
+      setUnseenIds([]);
+    }
+
+    setIsOpen(willOpen);
+  };
+
+  const panel = isOpen && position && typeof document !== 'undefined'
+    ? createPortal(
+        <div
+          id="navbar-changelog-panel"
+          ref={panelRef}
+          role="dialog"
+          aria-label="최근 업데이트"
+          className="fixed z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-gray-200/70 bg-white p-2 shadow-lg shadow-black/5 dark:border-white/10 dark:bg-la-dark dark:shadow-black/30"
+          style={{ top: position.top, right: position.right }}
+        >
+          <p className="px-2 pb-1 pt-1 text-xs font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+            최근 업데이트
+          </p>
+          {previewEntries.length === 0 ? (
+            <p className="px-2 py-3 text-sm text-gray-500 dark:text-gray-400">등록된 내역이 없습니다.</p>
+          ) : (
+            <ul className="flex flex-col">
+              {previewEntries.map((entry) => (
+                <li key={entry.id}>
+                  <Link
+                    to={CHANGELOG_PATH}
+                    className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 dark:hover:bg-white/5"
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                        {entry.title}
+                      </span>
+                      {highlightIds.includes(entry.id) && (
+                        <span className="rounded-full border border-la-gold/25 bg-la-gold/10 px-1.5 py-0.5 text-[9px] font-bold leading-none text-la-gold-dark dark:text-la-gold">
+                          NEW
+                        </span>
+                      )}
+                    </span>
+                    <time dateTime={entry.id} className="text-xs text-gray-400 dark:text-gray-500">
+                      {formatChangelogDate(entry.id)}
+                    </time>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link
+            to={CHANGELOG_PATH}
+            className="mt-1 block rounded-lg px-2 py-2 text-center text-xs font-bold text-la-gold-dark transition-colors hover:bg-la-gold/10 dark:text-la-gold"
+          >
+            전체 업데이트 내역 보기
+          </Link>
+        </div>,
+        document.body
+      )
+    : null;
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white"
+        aria-label={unseenCount > 0 ? `업데이트 알림, 새 소식 ${unseenCount}건` : '업데이트 알림, 새 소식 없음'}
+        aria-controls={isOpen ? 'navbar-changelog-panel' : undefined}
+        aria-expanded={isOpen}
+        onClick={handleToggle}
+      >
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1h6z"
+          />
+        </svg>
+        {unseenCount > 0 && (
+          <span
+            aria-hidden
+            className="absolute right-2 top-2 h-2 w-2 rounded-full bg-la-gold ring-2 ring-white dark:ring-la-dark"
+          />
+        )}
+      </button>
+      {panel}
+    </>
+  );
+};
+
+export default ChangelogBell;

--- a/src/components/NavBar.test.tsx
+++ b/src/components/NavBar.test.tsx
@@ -27,6 +27,17 @@ const renderNavBar = () =>
     </ThemeProvider>,
   );
 
+beforeEach(() => {
+  // NavBar가 ChangelogBell을 통해 읽음 상태를 읽으므로 테스트 간 저장소를 격리한다.
+  window.localStorage.clear();
+});
+
+test('renders the changelog bell in the header', () => {
+  renderNavBar();
+
+  expect(screen.getByRole('button', { name: /업데이트 알림/ })).toBeInTheDocument();
+});
+
 test('theme toggle button switches label and root class on click', async () => {
   renderNavBar();
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
+import ChangelogBell from './ChangelogBell';
 
 const NavBar: React.FC = () => {
   const { pathname } = useLocation();
@@ -249,6 +250,7 @@ const NavBar: React.FC = () => {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          <ChangelogBell />
           <button
             type="button"
             onClick={toggleDarkMode}

--- a/src/components/RouteSeo.tsx
+++ b/src/components/RouteSeo.tsx
@@ -75,6 +75,13 @@ const ROUTE_SEO: readonly RouteSeoEntry[] = [
       '로스트아크 강화, 거래소, 콘텐츠 준비에 사용한 골드 지출을 기록하고 관리하세요.',
     robots: 'index, follow',
   },
+  {
+    path: '/changelog',
+    title: '업데이트 내역 - 로아끼욧',
+    description:
+      '로아끼욧에 추가되거나 개선된 기능을 날짜순으로 확인하세요.',
+    robots: 'index, follow',
+  },
 ];
 
 const NOT_FOUND_SEO: RouteSeoEntry = {

--- a/src/components/RouteSeo.tsx
+++ b/src/components/RouteSeo.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { FC } from 'react';
 import { useLocation } from 'react-router-dom';
+import { ROUTES, normalizePathname } from '../utils/routes';
 
 type RouteSeoEntry = {
   readonly path: string;
@@ -76,7 +77,7 @@ const ROUTE_SEO: readonly RouteSeoEntry[] = [
     robots: 'index, follow',
   },
   {
-    path: '/changelog',
+    path: ROUTES.changelog,
     title: '업데이트 내역 - 로아끼욧',
     description:
       '로아끼욧에 추가되거나 개선된 기능을 날짜순으로 확인하세요.',
@@ -92,7 +93,7 @@ const NOT_FOUND_SEO: RouteSeoEntry = {
 };
 
 function findSeoEntry(pathname: string): RouteSeoEntry {
-  const normalizedPathname = pathname === '/' ? pathname : pathname.replace(/\/+$/, '');
+  const normalizedPathname = normalizePathname(pathname);
   return ROUTE_SEO.find((entry) => entry.path === normalizedPathname) ?? NOT_FOUND_SEO;
 }
 

--- a/src/components/RouteSeo.tsx
+++ b/src/components/RouteSeo.tsx
@@ -92,7 +92,8 @@ const NOT_FOUND_SEO: RouteSeoEntry = {
 };
 
 function findSeoEntry(pathname: string): RouteSeoEntry {
-  return ROUTE_SEO.find((entry) => entry.path === pathname) ?? NOT_FOUND_SEO;
+  const normalizedPathname = pathname === '/' ? pathname : pathname.replace(/\/+$/, '');
+  return ROUTE_SEO.find((entry) => entry.path === normalizedPathname) ?? NOT_FOUND_SEO;
 }
 
 function setNamedMeta(name: string, content: string): void {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -71,8 +71,5 @@ export const CHANGELOG: readonly ChangelogEntry[] = [
   },
 ];
 
-/** 최신 항목의 id. 사용자가 전체 내역을 확인했을 때 저장할 기준값. */
-export const LATEST_CHANGELOG_ID: string = CHANGELOG[0]?.id ?? '';
-
-/** 표시용 날짜 문자열. id('2026-07-28')를 '2026.07.28'로 변환. */
-export const formatChangelogDate = (id: string): string => id.split('-').join('.');
+/** 표시용 날짜 문자열. entry.date('2026-07-28')를 '2026.07.28'로 변환. */
+export const formatChangelogDate = (date: string): string => date.split('-').join('.');

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,0 +1,73 @@
+/** 사용자에게 노출되는 업데이트 내역의 단일 진실 공급원(SoT).
+ *  /changelog 페이지와 NavBar 알림 배지가 모두 이 배열을 읽는다.
+ *
+ *  작성 규칙:
+ *  - 개발 용어가 아니라 사용자가 체감하는 변화를 쓴다. ("리팩터링" X, "계산이 더 정확해졌습니다" O)
+ *  - id는 'YYYY-MM-DD'. 사전순 비교가 곧 시간순 비교라서 확인 여부 판정에 파싱이 필요 없다.
+ *    (semver를 쓰면 '1.10.0' < '1.9.0'이 true가 되어 문자열 비교가 깨진다.)
+ *  - CHANGELOG는 항상 최신 항목이 먼저 오도록 내림차순 유지. */
+
+export type ChangelogTag = 'added' | 'improved' | 'fixed';
+
+export type ChangelogItem = {
+  readonly tag: ChangelogTag;
+  readonly text: string;
+};
+
+export type ChangelogEntry = {
+  /** 확인 상태 비교 및 정렬 기준. 'YYYY-MM-DD' 형식. */
+  readonly id: string;
+  /** 목록에 표시할 한 줄 요약. */
+  readonly title: string;
+  readonly items: readonly ChangelogItem[];
+};
+
+export const CHANGELOG_TAG_LABEL: Readonly<Record<ChangelogTag, string>> = {
+  added: '추가',
+  improved: '개선',
+  fixed: '수정',
+};
+
+export const CHANGELOG: readonly ChangelogEntry[] = [
+  {
+    id: '2026-08-03',
+    title: '전투력 시뮬레이터 편집과 계산 보정',
+    items: [
+      { tag: 'added', text: '업데이트 내역 페이지와 새 소식 알림을 추가했습니다.' },
+      { tag: 'improved', text: '장비 티어와 공용 선택 옵션을 더 쉽게 조정할 수 있게 정리했습니다.' },
+      { tag: 'fixed', text: '공용 각인, 완갑, 97돌 기본 공격력 계산이 더 정확하게 반영되도록 보정했습니다.' },
+      { tag: 'fixed', text: '아크 그리드 이름과 광휘 보석 타입 표시가 비어 보이는 문제를 줄였습니다.' },
+    ],
+  },
+  {
+    id: '2026-07-31',
+    title: '전투력 시뮬레이터 장비 계산 확장',
+    items: [
+      { tag: 'added', text: '완갑 장비를 시뮬레이션에 포함해 전투력 변화를 확인할 수 있게 했습니다.' },
+      { tag: 'improved', text: '전투력 기준 계산 경로를 보강해 LoPEC 기준 수치와 비교하기 쉬워졌습니다.' },
+      { tag: 'fixed', text: '보석과 연마 효과가 전투력 계산에 반영되는 방식을 보정했습니다.' },
+    ],
+  },
+  {
+    id: '2026-07-28',
+    title: '전투력 시뮬레이터 계산 보완',
+    items: [
+      { tag: 'improved', text: '전투력 시뮬레이터의 아크 그리드 계산 정확도를 높였습니다.' },
+      { tag: 'improved', text: '아크 그리드 설정 화면을 분리해 조작이 쉬워졌습니다.' },
+    ],
+  },
+  {
+    id: '2026-07-20',
+    title: '전투력 시뮬레이터 공개 (Beta)',
+    items: [
+      { tag: 'added', text: '장비·보석·각인·아크 그리드를 바꿔가며 전투력 변화를 확인할 수 있습니다.' },
+      { tag: 'added', text: '캐릭터 조회 결과를 시뮬레이터로 바로 불러올 수 있습니다.' },
+    ],
+  },
+];
+
+/** 최신 항목의 id. 사용자가 전체 내역을 확인했을 때 저장할 기준값. */
+export const LATEST_CHANGELOG_ID: string = CHANGELOG[0]?.id ?? '';
+
+/** 표시용 날짜 문자열. id('2026-07-28')를 '2026.07.28'로 변환. */
+export const formatChangelogDate = (id: string): string => id.split('-').join('.');

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -3,8 +3,8 @@
  *
  *  작성 규칙:
  *  - 개발 용어가 아니라 사용자가 체감하는 변화를 쓴다. ("리팩터링" X, "계산이 더 정확해졌습니다" O)
- *  - id는 'YYYY-MM-DD'. 사전순 비교가 곧 시간순 비교라서 확인 여부 판정에 파싱이 필요 없다.
- *    (semver를 쓰면 '1.10.0' < '1.9.0'이 true가 되어 문자열 비교가 깨진다.)
+ *  - id는 날짜와 분리된 불변 revision id로 작성하며 중복하지 않는다.
+ *  - date는 화면에 표시할 'YYYY-MM-DD' 형식이다.
  *  - CHANGELOG는 항상 최신 항목이 먼저 오도록 내림차순 유지. */
 
 export type ChangelogTag = 'added' | 'improved' | 'fixed';
@@ -15,8 +15,10 @@ export type ChangelogItem = {
 };
 
 export type ChangelogEntry = {
-  /** 확인 상태 비교 및 정렬 기준. 'YYYY-MM-DD' 형식. */
+  /** 확인 상태와 React key에 사용하는 불변 revision id. */
   readonly id: string;
+  /** 화면에 표시할 날짜. 'YYYY-MM-DD' 형식. */
+  readonly date: string;
   /** 목록에 표시할 한 줄 요약. */
   readonly title: string;
   readonly items: readonly ChangelogItem[];
@@ -30,7 +32,8 @@ export const CHANGELOG_TAG_LABEL: Readonly<Record<ChangelogTag, string>> = {
 
 export const CHANGELOG: readonly ChangelogEntry[] = [
   {
-    id: '2026-08-03',
+    id: 'release-004',
+    date: '2026-08-03',
     title: '전투력 시뮬레이터 편집과 계산 보정',
     items: [
       { tag: 'added', text: '업데이트 내역 페이지와 새 소식 알림을 추가했습니다.' },
@@ -40,16 +43,17 @@ export const CHANGELOG: readonly ChangelogEntry[] = [
     ],
   },
   {
-    id: '2026-07-31',
+    id: 'release-003',
+    date: '2026-07-31',
     title: '전투력 시뮬레이터 장비 계산 확장',
     items: [
       { tag: 'added', text: '완갑 장비를 시뮬레이션에 포함해 전투력 변화를 확인할 수 있게 했습니다.' },
-      { tag: 'improved', text: '전투력 기준 계산 경로를 보강해 LoPEC 기준 수치와 비교하기 쉬워졌습니다.' },
       { tag: 'fixed', text: '보석과 연마 효과가 전투력 계산에 반영되는 방식을 보정했습니다.' },
     ],
   },
   {
-    id: '2026-07-28',
+    id: 'release-002',
+    date: '2026-07-28',
     title: '전투력 시뮬레이터 계산 보완',
     items: [
       { tag: 'improved', text: '전투력 시뮬레이터의 아크 그리드 계산 정확도를 높였습니다.' },
@@ -57,7 +61,8 @@ export const CHANGELOG: readonly ChangelogEntry[] = [
     ],
   },
   {
-    id: '2026-07-20',
+    id: 'release-001',
+    date: '2026-07-20',
     title: '전투력 시뮬레이터 공개 (Beta)',
     items: [
       { tag: 'added', text: '장비·보석·각인·아크 그리드를 바꿔가며 전투력 변화를 확인할 수 있습니다.' },

--- a/src/pages/Changelog.test.tsx
+++ b/src/pages/Changelog.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+
+import { CHANGELOG, CHANGELOG_TAG_LABEL, type ChangelogEntry } from '../data/changelog';
+
+jest.mock(
+  'react-router-dom',
+  () => {
+    const React = require('react');
+    return {
+      Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+        <a href={to} {...rest}>
+          {children}
+        </a>
+      ),
+      useLocation: () => ({ pathname: '/changelog' }),
+    };
+  },
+  { virtual: true },
+);
+
+jest.mock('../components/NavBar', () => () => <nav />);
+
+// CHANGELOG를 테스트별로 갈아끼우기 위해 getter로 노출한다. 빈 상태는 데이터로만 재현할 수 있다.
+let mockChangelog: readonly ChangelogEntry[] = [];
+jest.mock('../data/changelog', () => {
+  const actual = jest.requireActual('../data/changelog');
+  return {
+    ...actual,
+    get CHANGELOG() {
+      return mockChangelog;
+    },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Changelog = require('./Changelog').default;
+
+const realChangelog = jest.requireActual('../data/changelog').CHANGELOG as readonly ChangelogEntry[];
+
+beforeEach(() => {
+  mockChangelog = realChangelog;
+});
+
+test('renders every changelog entry with its date and title', () => {
+  render(<Changelog />);
+
+  expect(screen.getByRole('heading', { level: 1, name: '업데이트 내역' })).toBeInTheDocument();
+
+  realChangelog.forEach((entry) => {
+    expect(screen.getByRole('heading', { level: 2, name: entry.title })).toBeInTheDocument();
+  });
+
+  const [newest] = realChangelog;
+  if (!newest) throw new TypeError('Expected a changelog entry');
+  expect(screen.getByText(newest.date.split('-').join('.'))).toHaveAttribute('datetime', newest.date);
+});
+
+test('labels each item with its Korean tag', () => {
+  render(<Changelog />);
+
+  const usedTags = new Set(realChangelog.flatMap((entry) => entry.items.map((item) => item.tag)));
+  expect(usedTags.size).toBeGreaterThan(0);
+
+  usedTags.forEach((tag) => {
+    expect(screen.getAllByText(CHANGELOG_TAG_LABEL[tag]).length).toBeGreaterThan(0);
+  });
+});
+
+test('renders the empty state when there are no entries', () => {
+  mockChangelog = [];
+
+  render(<Changelog />);
+
+  expect(screen.getByText('아직 등록된 업데이트 내역이 없습니다.')).toBeInTheDocument();
+  expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+});
+
+test('keeps the module-level changelog export non-empty so the page is not shipped blank', () => {
+  expect(CHANGELOG.length).toBeGreaterThan(0);
+});

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -38,10 +38,10 @@ const Changelog: React.FC = () => {
                 <GlassCard className="p-5 animate-fade-in">
                   <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
                     <time
-                      dateTime={entry.id}
+                      dateTime={entry.date}
                       className="text-xs font-bold text-la-gold-dark dark:text-la-gold"
                     >
-                      {formatChangelogDate(entry.id)}
+                      {formatChangelogDate(entry.date)}
                     </time>
                     <h2 className="text-base font-bold text-gray-900 dark:text-white">{entry.title}</h2>
                   </div>

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import NavBar from '../components/NavBar';
+import GlassCard from '../components/GlassCard';
+import {
+  CHANGELOG,
+  CHANGELOG_TAG_LABEL,
+  formatChangelogDate,
+  type ChangelogTag,
+} from '../data/changelog';
+
+const TAG_CLASS: Readonly<Record<ChangelogTag, string>> = {
+  added: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  improved: 'border-la-gold/25 bg-la-gold/10 text-la-gold-dark dark:text-la-gold',
+  fixed: 'border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-400',
+};
+
+const Changelog: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-la-dark transition-colors duration-300">
+      <NavBar />
+      <main className="max-w-3xl mx-auto px-4 py-8">
+        <header className="mb-6">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">업데이트 내역</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            로아끼욧에 추가되거나 개선된 내용을 정리했습니다.
+          </p>
+        </header>
+
+        {CHANGELOG.length === 0 ? (
+          <GlassCard className="p-8 text-center">
+            <p className="text-sm text-gray-500 dark:text-gray-400">아직 등록된 업데이트 내역이 없습니다.</p>
+          </GlassCard>
+        ) : (
+          <ol className="flex flex-col gap-4">
+            {CHANGELOG.map((entry) => (
+              <li key={entry.id}>
+                <GlassCard className="p-5 animate-fade-in">
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <time
+                      dateTime={entry.id}
+                      className="text-xs font-bold text-la-gold-dark dark:text-la-gold"
+                    >
+                      {formatChangelogDate(entry.id)}
+                    </time>
+                    <h2 className="text-base font-bold text-gray-900 dark:text-white">{entry.title}</h2>
+                  </div>
+                  <ul className="mt-3 flex flex-col gap-2">
+                    {entry.items.map((item) => (
+                      <li key={item.text} className="flex items-start gap-2">
+                        <span
+                          className={`mt-0.5 inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-bold ${TAG_CLASS[item.tag]}`}
+                        >
+                          {CHANGELOG_TAG_LABEL[item.tag]}
+                        </span>
+                        <span className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                          {item.text}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </GlassCard>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <div className="mt-8 text-center">
+          <Link
+            to="/"
+            className="text-sm font-medium text-gray-500 transition-colors hover:text-la-gold-dark dark:text-gray-400 dark:hover:text-la-gold"
+          >
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Changelog;

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -11,7 +11,7 @@ import {
 
 const TAG_CLASS: Readonly<Record<ChangelogTag, string>> = {
   added: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-  improved: 'border-la-gold/25 bg-la-gold/10 text-la-gold-dark dark:text-la-gold',
+  improved: 'border-la-gold/25 bg-la-gold/10 text-la-gold-deep dark:text-la-gold',
   fixed: 'border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-400',
 };
 
@@ -39,7 +39,7 @@ const Changelog: React.FC = () => {
                   <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
                     <time
                       dateTime={entry.date}
-                      className="text-xs font-bold text-la-gold-dark dark:text-la-gold"
+                      className="text-xs font-bold text-la-gold-deep dark:text-la-gold"
                     >
                       {formatChangelogDate(entry.date)}
                     </time>
@@ -68,7 +68,7 @@ const Changelog: React.FC = () => {
         <div className="mt-8 text-center">
           <Link
             to="/"
-            className="text-sm font-medium text-gray-500 transition-colors hover:text-la-gold-dark dark:text-gray-400 dark:hover:text-la-gold"
+            className="text-sm font-medium text-gray-500 transition-colors hover:text-la-gold-deep dark:text-gray-400 dark:hover:text-la-gold"
           >
             홈으로 돌아가기
           </Link>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,3 +6,10 @@ import '@testing-library/jest-dom';
 
 // jsdom does not implement window.scrollTo; NavBar's mobile drawer scroll-lock calls it on cleanup.
 window.scrollTo = jest.fn();
+
+// jest 27의 jsdom에는 TextEncoder/TextDecoder가 없다. react-router 7이 모듈 로드 시점에 참조한다.
+if (typeof globalThis.TextEncoder === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { TextEncoder, TextDecoder } = require('util');
+  Object.assign(globalThis, { TextEncoder, TextDecoder });
+}

--- a/src/utils/changelogState.test.ts
+++ b/src/utils/changelogState.test.ts
@@ -1,7 +1,9 @@
 import { CHANGELOG, type ChangelogEntry } from '../data/changelog';
 import { markChangelogSeen, readUnseenEntries, selectUnseenEntries } from './changelogState';
 
-const SEEN_IDS_KEY = 'changelogLastSeenId';
+const SEEN_IDS_KEY = 'changelogSeenIds';
+
+const readStored = (): unknown => JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? 'null');
 
 const entries: readonly ChangelogEntry[] = [
   { id: 'revision-a', date: '2026-08-03', title: 'Newest', items: [] },
@@ -14,15 +16,11 @@ beforeEach(() => {
 });
 
 test('selects entries whose revision ids were not seen', () => {
-  const unseenEntries = selectUnseenEntries(entries, ['revision-z']);
-
-  expect(unseenEntries).toEqual([entries[0], entries[2]]);
+  expect(selectUnseenEntries(entries, ['revision-z'])).toEqual([entries[0], entries[2]]);
 });
 
 test('keeps same-date additions unseen when a different same-date revision was seen', () => {
-  const unseenEntries = selectUnseenEntries(entries, ['revision-a']);
-
-  expect(unseenEntries).toEqual([entries[1], entries[2]]);
+  expect(selectUnseenEntries(entries, ['revision-a'])).toEqual([entries[1], entries[2]]);
 });
 
 test('returns every changelog entry when local storage is empty', () => {
@@ -37,6 +35,13 @@ test('reads seen revision ids from a stored JSON array', () => {
   expect(readUnseenEntries()).toEqual(CHANGELOG.filter((entry) => entry.id !== seenEntry.id));
 });
 
+test('marks every changelog entry seen when called without arguments', () => {
+  markChangelogSeen();
+
+  expect(readStored()).toEqual(CHANGELOG.map((entry) => entry.id));
+  expect(readUnseenEntries()).toEqual([]);
+});
+
 test('merges newly seen revisions with partially persisted state', () => {
   const existingEntry = CHANGELOG[1];
   const newlySeenEntry = CHANGELOG[0];
@@ -45,44 +50,74 @@ test('merges newly seen revisions with partially persisted state', () => {
 
   markChangelogSeen([newlySeenEntry.id]);
 
-  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
-    existingEntry.id,
-    newlySeenEntry.id,
-  ]);
-});
-
-test('treats malformed JSON-like storage as a legacy revision id', () => {
-  const malformedValue = '["release-004"';
-  window.localStorage.setItem(SEEN_IDS_KEY, malformedValue);
-
-  expect(readUnseenEntries()).toEqual(CHANGELOG);
-
-  const newlySeenEntry = CHANGELOG[0];
-  if (!newlySeenEntry) throw new TypeError('Expected a changelog entry');
-  markChangelogSeen([newlySeenEntry.id]);
-  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
-    malformedValue,
-    newlySeenEntry.id,
-  ]);
-});
-
-test('migrates a legacy date scalar to revision ids at or before that date', () => {
-  window.localStorage.setItem(SEEN_IDS_KEY, '2026-07-31');
-
-  expect(readUnseenEntries()).toEqual(CHANGELOG.filter((entry) => entry.date > '2026-07-31'));
-  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual(
-    CHANGELOG.filter((entry) => entry.date <= '2026-07-31').map((entry) => entry.id),
+  expect(readUnseenEntries()).toEqual(
+    CHANGELOG.filter((entry) => entry.id !== existingEntry.id && entry.id !== newlySeenEntry.id),
   );
 });
 
-test('keeps an invalid date-shaped scalar as a legacy revision id', () => {
-  const legacyId = '2026-99-99';
-  window.localStorage.setItem(SEEN_IDS_KEY, legacyId);
+test('persists seen ids in changelog order regardless of the order they were seen', () => {
+  const [newest, second] = CHANGELOG;
+  if (!newest || !second) throw new TypeError('Expected changelog entries');
 
-  markChangelogSeen(['release-current']);
+  markChangelogSeen([second.id]);
+  markChangelogSeen([newest.id]);
 
-  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
-    legacyId,
-    'release-current',
-  ]);
+  expect(readStored()).toEqual([newest.id, second.id]);
+});
+
+test('ignores an empty seen list instead of clobbering persisted state', () => {
+  const seenEntry = CHANGELOG[0];
+  if (!seenEntry) throw new TypeError('Expected a changelog entry');
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify([seenEntry.id]));
+
+  markChangelogSeen([]);
+
+  expect(readStored()).toEqual([seenEntry.id]);
+});
+
+test('drops revision ids that no longer exist in the changelog', () => {
+  const seenEntry = CHANGELOG[0];
+  if (!seenEntry) throw new TypeError('Expected a changelog entry');
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify(['retired-999', seenEntry.id]));
+
+  markChangelogSeen([seenEntry.id]);
+
+  expect(readStored()).toEqual([seenEntry.id]);
+});
+
+test('discards malformed storage instead of adopting it as a revision id', () => {
+  window.localStorage.setItem(SEEN_IDS_KEY, '["release-004"');
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG);
+
+  markChangelogSeen();
+
+  expect(readStored()).toEqual(CHANGELOG.map((entry) => entry.id));
+});
+
+test('discards a non-array stored value', () => {
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify({ id: 'release-004' }));
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG);
+});
+
+test('drops non-string members of a stored array', () => {
+  const seenEntry = CHANGELOG[0];
+  if (!seenEntry) throw new TypeError('Expected a changelog entry');
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify([seenEntry.id, 42, null]));
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG.filter((entry) => entry.id !== seenEntry.id));
+});
+
+test('degrades to "everything unseen" when storage writes fail', () => {
+  const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    throw new DOMException('quota', 'QuotaExceededError');
+  });
+
+  try {
+    expect(() => markChangelogSeen()).not.toThrow();
+    expect(readUnseenEntries()).toEqual(CHANGELOG);
+  } finally {
+    setItem.mockRestore();
+  }
 });

--- a/src/utils/changelogState.test.ts
+++ b/src/utils/changelogState.test.ts
@@ -1,11 +1,17 @@
-import type { ChangelogEntry } from '../data/changelog';
-import { selectUnseenEntries } from './changelogState';
+import { CHANGELOG, type ChangelogEntry } from '../data/changelog';
+import { markChangelogSeen, readUnseenEntries, selectUnseenEntries } from './changelogState';
+
+const SEEN_IDS_KEY = 'changelogLastSeenId';
 
 const entries: readonly ChangelogEntry[] = [
   { id: 'revision-a', date: '2026-08-03', title: 'Newest', items: [] },
   { id: 'revision-z', date: '2026-08-03', title: 'Same date update', items: [] },
   { id: 'revision-b', date: '2026-07-31', title: 'Older', items: [] },
 ];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
 
 test('selects entries whose revision ids were not seen', () => {
   const unseenEntries = selectUnseenEntries(entries, ['revision-z']);
@@ -17,4 +23,66 @@ test('keeps same-date additions unseen when a different same-date revision was s
   const unseenEntries = selectUnseenEntries(entries, ['revision-a']);
 
   expect(unseenEntries).toEqual([entries[1], entries[2]]);
+});
+
+test('returns every changelog entry when local storage is empty', () => {
+  expect(readUnseenEntries()).toEqual(CHANGELOG);
+});
+
+test('reads seen revision ids from a stored JSON array', () => {
+  const seenEntry = CHANGELOG[1];
+  if (!seenEntry) throw new TypeError('Expected a second changelog entry');
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify([seenEntry.id]));
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG.filter((entry) => entry.id !== seenEntry.id));
+});
+
+test('merges newly seen revisions with partially persisted state', () => {
+  const existingEntry = CHANGELOG[1];
+  const newlySeenEntry = CHANGELOG[0];
+  if (!existingEntry || !newlySeenEntry) throw new TypeError('Expected changelog entries');
+  window.localStorage.setItem(SEEN_IDS_KEY, JSON.stringify([existingEntry.id]));
+
+  markChangelogSeen([newlySeenEntry.id]);
+
+  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
+    existingEntry.id,
+    newlySeenEntry.id,
+  ]);
+});
+
+test('treats malformed JSON-like storage as a legacy revision id', () => {
+  const malformedValue = '["release-004"';
+  window.localStorage.setItem(SEEN_IDS_KEY, malformedValue);
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG);
+
+  const newlySeenEntry = CHANGELOG[0];
+  if (!newlySeenEntry) throw new TypeError('Expected a changelog entry');
+  markChangelogSeen([newlySeenEntry.id]);
+  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
+    malformedValue,
+    newlySeenEntry.id,
+  ]);
+});
+
+test('migrates a legacy date scalar to revision ids at or before that date', () => {
+  window.localStorage.setItem(SEEN_IDS_KEY, '2026-07-31');
+
+  expect(readUnseenEntries()).toEqual(CHANGELOG.filter((entry) => entry.date > '2026-07-31'));
+  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual(
+    CHANGELOG.filter((entry) => entry.date <= '2026-07-31').map((entry) => entry.id),
+  );
+});
+
+test('keeps an invalid date-shaped scalar as a legacy revision id', () => {
+  const legacyId = '2026-99-99';
+  window.localStorage.setItem(SEEN_IDS_KEY, legacyId);
+
+  markChangelogSeen(['release-current']);
+
+  expect(JSON.parse(window.localStorage.getItem(SEEN_IDS_KEY) ?? '[]')).toEqual([
+    legacyId,
+    'release-current',
+  ]);
 });

--- a/src/utils/changelogState.test.ts
+++ b/src/utils/changelogState.test.ts
@@ -1,0 +1,20 @@
+import type { ChangelogEntry } from '../data/changelog';
+import { selectUnseenEntries } from './changelogState';
+
+const entries: readonly ChangelogEntry[] = [
+  { id: 'revision-a', date: '2026-08-03', title: 'Newest', items: [] },
+  { id: 'revision-z', date: '2026-08-03', title: 'Same date update', items: [] },
+  { id: 'revision-b', date: '2026-07-31', title: 'Older', items: [] },
+];
+
+test('selects entries whose revision ids were not seen', () => {
+  const unseenEntries = selectUnseenEntries(entries, ['revision-z']);
+
+  expect(unseenEntries).toEqual([entries[0], entries[2]]);
+});
+
+test('keeps same-date additions unseen when a different same-date revision was seen', () => {
+  const unseenEntries = selectUnseenEntries(entries, ['revision-a']);
+
+  expect(unseenEntries).toEqual([entries[1], entries[2]]);
+});

--- a/src/utils/changelogState.ts
+++ b/src/utils/changelogState.ts
@@ -7,9 +7,20 @@ import { safeLocalStorage } from './safeStorage';
 
 // 기존 키 컨벤션(ThemeContext의 'isDarkMode')에 맞춰 접두사 없는 camelCase를 사용.
 const SEEN_IDS_KEY = 'changelogLastSeenId';
+const LEGACY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidLegacyDate = (value: string): boolean => {
+  if (!LEGACY_DATE_PATTERN.test(value)) return false;
+
+  const parsedDate = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsedDate.getTime()) && parsedDate.toISOString().startsWith(value);
+};
 
 const parseSeenIds = (storedValue: string | null): readonly string[] => {
   if (storedValue === null) return [];
+  if (isValidLegacyDate(storedValue)) {
+    return CHANGELOG.filter((entry) => entry.date <= storedValue).map((entry) => entry.id);
+  }
   if (!storedValue.startsWith('[')) return [storedValue];
 
   try {
@@ -23,7 +34,16 @@ const parseSeenIds = (storedValue: string | null): readonly string[] => {
   }
 };
 
-const readSeenIds = (): readonly string[] => parseSeenIds(safeLocalStorage.getItem(SEEN_IDS_KEY));
+const readSeenIds = (): readonly string[] => {
+  const storedValue = safeLocalStorage.getItem(SEEN_IDS_KEY);
+  const seenIds = parseSeenIds(storedValue);
+
+  if (storedValue !== null && isValidLegacyDate(storedValue)) {
+    safeLocalStorage.setItem(SEEN_IDS_KEY, JSON.stringify(seenIds));
+  }
+
+  return seenIds;
+};
 
 /** 지정한 항목을 확인한 것으로 표시. 생략하면 전체 내역의 모든 revision id를 저장한다. */
 export const markChangelogSeen = (seenIds: readonly string[] = CHANGELOG.map((entry) => entry.id)): void => {

--- a/src/utils/changelogState.ts
+++ b/src/utils/changelogState.ts
@@ -1,38 +1,50 @@
 /** 업데이트 내역 확인 상태 관리.
- *  "사용자가 마지막으로 확인한 항목 id"만 저장하고, 그보다 새로운 항목을 미확인으로 본다.
- *  항목별 확인 여부를 개별 저장하지 않으므로 항목이 늘어도 저장 용량이 일정하다. */
+ *  사용자가 확인한 revision id 목록을 저장하고, 저장되지 않은 항목을 미확인으로 본다.
+ *  드롭다운은 표시된 항목만 읽음 처리하고, 전체 페이지는 모든 항목을 읽음 처리한다. */
 
-import { CHANGELOG, LATEST_CHANGELOG_ID, type ChangelogEntry } from '../data/changelog';
+import { CHANGELOG, type ChangelogEntry } from '../data/changelog';
 import { safeLocalStorage } from './safeStorage';
 
 // 기존 키 컨벤션(ThemeContext의 'isDarkMode')에 맞춰 접두사 없는 camelCase를 사용.
-const LAST_SEEN_KEY = 'changelogLastSeenId';
+const SEEN_IDS_KEY = 'changelogLastSeenId';
 
-/** 저장된 마지막 확인 id. 저장값이 없거나 storage 접근이 막힌 환경에서는 null. */
-export const readLastSeenId = (): string | null => safeLocalStorage.getItem(LAST_SEEN_KEY);
+const parseSeenIds = (storedValue: string | null): readonly string[] => {
+  if (storedValue === null) return [];
+  if (!storedValue.startsWith('[')) return [storedValue];
 
-/** 전체 내역을 확인한 것으로 표시. 최신 항목 id를 기준값으로 저장한다. */
-export const markChangelogSeen = (): void => {
-  if (LATEST_CHANGELOG_ID.length === 0) return;
-  safeLocalStorage.setItem(LAST_SEEN_KEY, LATEST_CHANGELOG_ID);
+  try {
+    const parsed: unknown = JSON.parse(storedValue);
+    if (!Array.isArray(parsed)) return [storedValue];
+
+    return parsed.filter((entry): entry is string => typeof entry === 'string');
+  } catch (error) {
+    if (error instanceof SyntaxError) return [storedValue];
+    throw error;
+  }
+};
+
+const readSeenIds = (): readonly string[] => parseSeenIds(safeLocalStorage.getItem(SEEN_IDS_KEY));
+
+/** 지정한 항목을 확인한 것으로 표시. 생략하면 전체 내역의 모든 revision id를 저장한다. */
+export const markChangelogSeen = (seenIds: readonly string[] = CHANGELOG.map((entry) => entry.id)): void => {
+  if (seenIds.length === 0) return;
+
+  const mergedSeenIds = Array.from(new Set([...readSeenIds(), ...seenIds]));
+  safeLocalStorage.setItem(SEEN_IDS_KEY, JSON.stringify(mergedSeenIds));
 };
 
 /**
  * 아직 확인하지 않은 항목만 골라낸다.
  *
- * @param entries    id 내림차순으로 정렬된 전체 내역
- * @param lastSeenId 마지막으로 확인한 항목 id. 저장값이 없으면 null
+ * @param entries 최신 항목이 먼저 오도록 정렬된 전체 내역
+ * @param seenIds 사용자가 확인한 항목 id 목록
  * @returns 미확인 항목 (입력과 같은 내림차순 유지)
  */
 export const selectUnseenEntries = (
   entries: readonly ChangelogEntry[],
-  lastSeenId: string | null,
-): readonly ChangelogEntry[] => {
-  if (lastSeenId === null) return entries;
-
-  return entries.filter((entry) => entry.id > lastSeenId);
-};
+  seenIds: readonly string[],
+): readonly ChangelogEntry[] => entries.filter((entry) => !seenIds.includes(entry.id));
 
 /** 현재 저장 상태를 기준으로 계산한 미확인 항목. NavBar 배지가 이 결과를 사용한다. */
 export const readUnseenEntries = (): readonly ChangelogEntry[] =>
-  selectUnseenEntries(CHANGELOG, readLastSeenId());
+  selectUnseenEntries(CHANGELOG, readSeenIds());

--- a/src/utils/changelogState.ts
+++ b/src/utils/changelogState.ts
@@ -1,56 +1,45 @@
 /** 업데이트 내역 확인 상태 관리.
  *  사용자가 확인한 revision id 목록을 저장하고, 저장되지 않은 항목을 미확인으로 본다.
- *  드롭다운은 표시된 항목만 읽음 처리하고, 전체 페이지는 모든 항목을 읽음 처리한다. */
+ *  드롭다운을 열거나 전체 페이지에 진입하면 모든 항목을 읽음 처리한다. */
 
 import { CHANGELOG, type ChangelogEntry } from '../data/changelog';
 import { safeLocalStorage } from './safeStorage';
 
 // 기존 키 컨벤션(ThemeContext의 'isDarkMode')에 맞춰 접두사 없는 camelCase를 사용.
-const SEEN_IDS_KEY = 'changelogLastSeenId';
-const LEGACY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SEEN_IDS_KEY = 'changelogSeenIds';
 
-const isValidLegacyDate = (value: string): boolean => {
-  if (!LEGACY_DATE_PATTERN.test(value)) return false;
+/** 현재 changelog에 실제로 존재하는 revision id. 저장 대상은 이 집합으로 한정한다. */
+const KNOWN_IDS: readonly string[] = CHANGELOG.map((entry) => entry.id);
 
-  const parsedDate = new Date(`${value}T00:00:00Z`);
-  return !Number.isNaN(parsedDate.getTime()) && parsedDate.toISOString().startsWith(value);
-};
-
+/** 저장된 값을 revision id 목록으로 해석한다.
+ *  이 키는 changelog 기능과 함께 도입되어 이전 포맷이 존재하지 않으므로,
+ *  string[] 이외의 값은 마이그레이션 대상이 아니라 손상된 상태로 보고 버린다. */
 const parseSeenIds = (storedValue: string | null): readonly string[] => {
   if (storedValue === null) return [];
-  if (isValidLegacyDate(storedValue)) {
-    return CHANGELOG.filter((entry) => entry.date <= storedValue).map((entry) => entry.id);
-  }
-  if (!storedValue.startsWith('[')) return [storedValue];
 
   try {
     const parsed: unknown = JSON.parse(storedValue);
-    if (!Array.isArray(parsed)) return [storedValue];
+    if (!Array.isArray(parsed)) return [];
 
     return parsed.filter((entry): entry is string => typeof entry === 'string');
-  } catch (error) {
-    if (error instanceof SyntaxError) return [storedValue];
-    throw error;
+  } catch {
+    return [];
   }
 };
 
-const readSeenIds = (): readonly string[] => {
-  const storedValue = safeLocalStorage.getItem(SEEN_IDS_KEY);
-  const seenIds = parseSeenIds(storedValue);
-
-  if (storedValue !== null && isValidLegacyDate(storedValue)) {
-    safeLocalStorage.setItem(SEEN_IDS_KEY, JSON.stringify(seenIds));
-  }
-
-  return seenIds;
-};
+const readSeenIds = (): readonly string[] => parseSeenIds(safeLocalStorage.getItem(SEEN_IDS_KEY));
 
 /** 지정한 항목을 확인한 것으로 표시. 생략하면 전체 내역의 모든 revision id를 저장한다. */
-export const markChangelogSeen = (seenIds: readonly string[] = CHANGELOG.map((entry) => entry.id)): void => {
+export const markChangelogSeen = (seenIds: readonly string[] = KNOWN_IDS): void => {
   if (seenIds.length === 0) return;
 
-  const mergedSeenIds = Array.from(new Set([...readSeenIds(), ...seenIds]));
-  safeLocalStorage.setItem(SEEN_IDS_KEY, JSON.stringify(mergedSeenIds));
+  // 기존 저장값과 병합해 부분 확인(일부 id만 전달)에도 이전 상태가 남게 한다.
+  // KNOWN_IDS로 필터링해 (1) 손상되거나 삭제된 id가 눌러앉지 않게 하고
+  // (2) 저장 크기를 현재 changelog 길이로 묶으며 (3) 저장 순서를 결정론적으로 만든다.
+  const mergedSeenIds = new Set([...readSeenIds(), ...seenIds]);
+  const nextSeenIds: readonly string[] = KNOWN_IDS.filter((id) => mergedSeenIds.has(id));
+
+  safeLocalStorage.setItem(SEEN_IDS_KEY, JSON.stringify(nextSeenIds));
 };
 
 /**

--- a/src/utils/changelogState.ts
+++ b/src/utils/changelogState.ts
@@ -1,0 +1,38 @@
+/** 업데이트 내역 확인 상태 관리.
+ *  "사용자가 마지막으로 확인한 항목 id"만 저장하고, 그보다 새로운 항목을 미확인으로 본다.
+ *  항목별 확인 여부를 개별 저장하지 않으므로 항목이 늘어도 저장 용량이 일정하다. */
+
+import { CHANGELOG, LATEST_CHANGELOG_ID, type ChangelogEntry } from '../data/changelog';
+import { safeLocalStorage } from './safeStorage';
+
+// 기존 키 컨벤션(ThemeContext의 'isDarkMode')에 맞춰 접두사 없는 camelCase를 사용.
+const LAST_SEEN_KEY = 'changelogLastSeenId';
+
+/** 저장된 마지막 확인 id. 저장값이 없거나 storage 접근이 막힌 환경에서는 null. */
+export const readLastSeenId = (): string | null => safeLocalStorage.getItem(LAST_SEEN_KEY);
+
+/** 전체 내역을 확인한 것으로 표시. 최신 항목 id를 기준값으로 저장한다. */
+export const markChangelogSeen = (): void => {
+  if (LATEST_CHANGELOG_ID.length === 0) return;
+  safeLocalStorage.setItem(LAST_SEEN_KEY, LATEST_CHANGELOG_ID);
+};
+
+/**
+ * 아직 확인하지 않은 항목만 골라낸다.
+ *
+ * @param entries    id 내림차순으로 정렬된 전체 내역
+ * @param lastSeenId 마지막으로 확인한 항목 id. 저장값이 없으면 null
+ * @returns 미확인 항목 (입력과 같은 내림차순 유지)
+ */
+export const selectUnseenEntries = (
+  entries: readonly ChangelogEntry[],
+  lastSeenId: string | null,
+): readonly ChangelogEntry[] => {
+  if (lastSeenId === null) return entries;
+
+  return entries.filter((entry) => entry.id > lastSeenId);
+};
+
+/** 현재 저장 상태를 기준으로 계산한 미확인 항목. NavBar 배지가 이 결과를 사용한다. */
+export const readUnseenEntries = (): readonly ChangelogEntry[] =>
+  selectUnseenEntries(CHANGELOG, readLastSeenId());

--- a/src/utils/routes.test.ts
+++ b/src/utils/routes.test.ts
@@ -1,0 +1,11 @@
+import { normalizePathname } from './routes';
+
+test.each([
+  ['/changelog', '/changelog'],
+  ['/changelog/', '/changelog'],
+  ['/changelog///', '/changelog'],
+  ['/', '/'],
+  ['//', '/'],
+])('normalizes %s to %s', (input, expected) => {
+  expect(normalizePathname(input)).toBe(expected);
+});

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,0 +1,11 @@
+/** 라우트 경로 상수와 경로 정규화.
+ *  SEO 메타 조회와 "현재 이 라우트인가?" 판정이 서로 다른 규칙을 쓰면
+ *  한쪽만 바뀌었을 때 조용히 어긋나므로 한 곳에서 정의한다. */
+
+export const ROUTES = {
+  changelog: '/changelog',
+} as const;
+
+/** 뒤따르는 슬래시를 제거한 경로. 루트('/', '//')는 항상 '/'로 수렴한다. */
+export const normalizePathname = (pathname: string): string =>
+  pathname.replace(/\/+$/, '') || '/';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
         'la-gold': '#F5A623',
         'la-gold-light': '#FFD080',
         'la-gold-dark': '#C47F17',
+        // 라이트 모드 소형 텍스트용. la-gold-dark(#C47F17)는 흰 배경에서 약 3.3:1이라
+        // 14px 미만 텍스트의 WCAG AA(4.5:1)를 넘지 못한다. 이 값은 약 5.9:1.
+        'la-gold-deep': '#8A5A0F',
         'la-dark': '#0D1117',
         'la-dark-card': '#161B22',
         'la-dark-surface': '#1C2128',


### PR DESCRIPTION
## intent
사용자가 최근 업데이트를 앱 안에서 확인하고, 새 변경사항이 있을 때 내비게이션에서 바로 알아볼 수 있게 합니다.

## changes
- changelog data: 날짜순 업데이트 데이터와 태그 라벨을 추가하고, 2026-07-20 ~ 2026-08-03 전투력 시뮬레이터 변경사항을 사용자 문장으로 정리했습니다.
- changelog state: 확인한 revision id 목록을 localStorage에 저장하고, 저장되지 않은 항목을 미확인으로 계산합니다. 저장값은 `string[]`만 받아들이며 현재 changelog id와의 교집합만 남깁니다.
- changelog UI: `/changelog` 페이지와 NavBar 업데이트 알림 벨/프리뷰 드롭다운을 추가했습니다.
- route metadata: `/changelog` 라우트와 SEO 메타를 등록하고, 경로 상수·trailing slash 정규화를 `src/utils/routes.ts`로 공용화했습니다.
- test infra: jest가 실제 `react-router-dom`을 해석할 수 있도록 `moduleNameMapper`와 `TextEncoder` 폴리필을 추가했습니다.
- docs/config: 스펙 시뮬레이터 디자인 계약 문서를 추가하고 `.omo/`를 git ignore에 포함했습니다.

## scope
선언 범위를 넘어 **외부에서 관찰 가능한 동작이 바뀐 항목**을 먼저 명시합니다.

- **전 라우트 SEO 정규화 (contract change)**: `findSeoEntry`가 trailing slash를 제거하므로 `/changelog/`뿐 아니라 `/market/`, `/character/` 등 기존 9개 라우트의 동작이 바뀝니다. 이전에는 `NOT_FOUND_SEO`로 폴백해 `noindex, follow` + 자기 자신 canonical이었고, 이제 실제 엔트리로 해석되어 `index, follow` + 슬래시 없는 canonical이 됩니다. 개선 방향이지만 크롤러 가시 변경이므로 `/market/` 회귀 테스트를 함께 추가했습니다.
- **jest 설정 변경 (전역)**: `package.json`에 `jest.moduleNameMapper` 2개 항목, `src/setupTests.ts`에 `TextEncoder`/`TextDecoder` 폴리필이 추가되어 모든 테스트 스위트에 적용됩니다.
- **디자인 토큰 추가**: `tailwind.config.js`에 `la-gold-deep`(`#8A5A0F`)을 추가했습니다. 기존 `la-gold-dark` 사용처는 변경하지 않았고, changelog 표면의 소형 텍스트 5곳에만 적용했습니다.

파일 목록:
- `src/data/changelog.ts`, `src/utils/changelogState.ts`, `src/utils/routes.ts`
- `src/pages/Changelog.tsx`, `src/components/ChangelogBell.tsx`
- `src/components/NavBar.tsx`, `src/App.tsx`, `src/components/RouteSeo.tsx`
- `package.json`, `src/setupTests.ts`, `tailwind.config.js`, `DESIGN.md`, `.gitignore`
- 테스트: `changelogState.test.ts`, `routes.test.ts`, `ChangelogBell.test.tsx`, `Changelog.test.tsx`, `NavBar.test.tsx`, `App.test.tsx`

## risk
surface: NavBar, `/changelog` route, 전 라우트 SEO 메타, jest 설정, localStorage 읽음 상태 | severity: low-medium | mitigation: SEO 변경은 `/market/` 테스트로 고정, 알림 패널은 브라우저에서 320px·데스크톱·라이트/다크 실측, 저장 상태는 손상값·쓰기 실패·pruning까지 테스트로 고정.

## verification
- [x] typecheck: `npx tsc --noEmit` → exit 0
- [x] test: `CI=true npm test -- --watchAll=false` → **30 passed / 31 suites, 199 passed / 200 tests**
- [x] build: `npm run build` → Compiled successfully (main.js 161.13 kB, CSS 12.18 kB). 빌드 CSS에 `#8a5a0f`가 실제로 방출되는 것까지 확인했습니다.
- [x] 브라우저 QA (localhost:3001, Chrome):
  - 벨에서 Tab 1회 → 패널 첫 링크로 진입 (`panel.contains(activeElement) === true`)
  - 패널 열린 채 테마 토글 클릭 → 포커스가 테마 버튼에 유지 (벨이 빼앗지 않음)
  - 열기 시 `changelogSeenIds`에 전체 id 4건 저장, 배지 소멸
  - 320px: 패널 `left 24 / right 312`, 양쪽 오버플로우 없음, 가로 스크롤 없음
  - `새 소식` 배지 computed color `rgb(138, 90, 15)` 확인
  - 라이트/다크 모드 `/changelog` 렌더 확인
- [ ] **알려진 실패 1건 (pre-existing, 이 PR과 무관)**: `src/utils/lopecSimulator.invenFormula.test.ts` › `uses displayed main stat as the Serka armor denominator when supplied`. 해당 파일은 이 브랜치 diff에 없으며 `origin/main`에서도 실패합니다. 별도 처리가 필요합니다.

## context
전투력 시뮬레이터 개선이 여러 차례 있었지만 사용자가 앱 안에서 변경 내역을 볼 곳이 없었습니다. 단일 데이터 소스에서 changelog 페이지와 알림 진입점을 함께 제공해, 앞으로의 업데이트도 한 곳에서 알릴 수 있게 합니다.

## alternatives
- 정적 문서에만 changelog를 두기: 앱에서 발견되지 않아 기각.
- 항목별 읽음 플래그 저장: 날짜순 changelog에는 과한 구조. 다만 "마지막 확인 날짜" 스칼라도 같은 날짜에 항목이 추가되면 놓치므로, 확인한 revision id 집합을 저장하는 방식을 택했습니다.
- 알림 패널을 `createPortal`로 body에 렌더: 초기 구현이었으나 Tab 순서가 버튼과 끊겨 키보드로 패널에 도달하기 어려웠습니다. non-modal 위젯에 modal용 focus trap을 씌우는 대신 DOM 순서를 읽기 순서와 일치시키는 방향으로 바꿨고, 그 결과 포지셔닝 계산 코드도 함께 제거됐습니다.

## breaking-changes
none — 기존 라우트 계약이나 API 동작을 바꾸지 않습니다. 위 scope의 SEO 정규화는 기존 라우트를 더 정확한 메타로 해석하는 방향이라 소비자 측 대응이 필요하지 않습니다.

## migration
none — 스키마·환경변수·의존성 마이그레이션이 없습니다. localStorage 키는 `changelogSeenIds`이며, 개발 중 사용하던 `changelogLastSeenId`는 배포된 적이 없어 마이그레이션 코드를 두지 않았습니다. 프리뷰 배포에서 옛 키를 가진 브라우저는 해당 값이 무시되고 알림을 한 번 더 보게 됩니다.

## rollback
이 브랜치의 changelog 관련 커밋을 revert합니다. 데이터 손실 위험은 없습니다 — 유지되는 값은 클라이언트 localStorage의 읽음 상태 뿐입니다. jest 설정 변경(`moduleNameMapper`, `TextEncoder` 폴리필)을 함께 되돌리면 테스트는 revert 이전 상태로 복귀합니다.

## monitoring
머지 후 확인할 것:
- `/changelog`가 배포된 SPA fallback에서 정상 로드되는지
- 기존 라우트의 trailing slash URL(`/market/` 등)이 슬래시 없는 canonical로 수렴하는지
- 알림 벨을 연 뒤 재방문 시 배지가 다시 뜨지 않는지 (localStorage 쓰기 실패 시 매번 다시 뜹니다)

## references
- Related: branch `feat/9-changelog`
- Related: PR #10 — 최근 시뮬레이터 변경사항을 changelog 항목으로 요약했습니다.
