### PR TITLE
벨가르딘 업데이트 내역 추가

### DIFF
--- a/src/components/ChangelogBell.tsx
+++ b/src/components/ChangelogBell.tsx
@@ -135,12 +135,12 @@ const ChangelogBell: React.FC = () => {
                     to={ROUTES.changelog}
                     className="flex flex-col gap-0.5 rounded-lg px-2 py-2 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:hover:bg-white/5"
                   >
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="break-keep text-sm font-medium text-gray-800 dark:text-gray-200">
+                    <span className="flex min-w-0 items-start gap-1.5">
+                      <span className="min-w-0 flex-1 break-keep text-sm font-medium leading-5 text-gray-800 dark:text-gray-200">
                         {entry.title}
                       </span>
                       {highlightIds.includes(entry.id) && (
-                        <span className="rounded-full border border-la-gold/25 bg-la-gold/10 px-1.5 py-0.5 text-[9px] font-bold leading-none text-la-gold-deep dark:text-la-gold">
+                        <span className="mt-0.5 inline-flex h-4 flex-none items-center rounded-full border border-la-gold/25 bg-la-gold/10 px-1.5 text-[9px] font-bold leading-none text-la-gold-deep dark:text-la-gold">
                           새 소식
                         </span>
                       )}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -32,6 +32,17 @@ export const CHANGELOG_TAG_LABEL: Readonly<Record<ChangelogTag, string>> = {
 
 export const CHANGELOG: readonly ChangelogEntry[] = [
   {
+    id: 'release-005',
+    date: '2026-08-04',
+    title: '벨가르딘 레이드 골드와 카드 화면 추가',
+    items: [
+      { tag: 'added', text: '주간 골드 계산기에 벨가르딘 그림자 레이드 골드와 코어 보상을 추가했습니다.' },
+      { tag: 'improved', text: '레이드 카드에 대표 이미지를 더해 선택한 레이드를 더 쉽게 구분할 수 있게 했습니다.' },
+      { tag: 'improved', text: '레이드 변경 화면에서 참여 가능한 레이드와 선택 상태를 더 보기 좋게 정리했습니다.' },
+      { tag: 'fixed', text: '같은 레이드의 여러 난이도가 동시에 골드 계산에 들어가지 않도록 조정했습니다.' },
+    ],
+  },
+  {
     id: 'release-004',
     date: '2026-08-03',
     title: '전투력 시뮬레이터 편집과 계산 보정',


### PR DESCRIPTION
## intent
Users can see the Belgardin raid update in the in-app changelog, and the new-news marker stays visually stable in the notification dropdown.

## changes
- changelog: add `release-005` for Belgardin raid gold/core rewards, raid image cards, raid picker improvements, and duplicate difficulty prevention.
- notification UI: keep the `새 소식` marker fixed-size while long Korean changelog titles wrap in the remaining width.

## risk
surface: changelog data and NavBar changelog dropdown | severity: low | mitigation: targeted component test, production build, and mobile/desktop browser QA on localhost:3001.

## verification
- [x] build: `yarn build` compiled successfully.
- [x] test: `yarn test --watchAll=false --runTestsByPath src/components/ChangelogBell.test.tsx` passed 11/11 tests.
- [x] manual: Playwright checked `localhost:3001` at 375px and 1280px; dropdown stays inside viewport and `새 소식` markers render at stable 39x16 sizing.

## references
- Refs #13: Belgardin raid gold and raid card UI merge.

## context
PR #13 added Belgardin raid data and updated the raid card experience. This follow-up makes that user-visible through the changelog branch and fixes the notification marker sizing that became noticeable with the longer Korean title.

## alternatives
- Add only the changelog entry: rejected because the new title exposed the existing marker sizing issue in the dropdown.
- Shorten the user-facing title to avoid wrapping: rejected because it hides useful context instead of fixing the layout.

## breaking-changes
none - rationale: the change only adds a changelog entry and adjusts presentation classes in the notification dropdown.

## migration
none - rationale: no data schema, dependency, environment, or persisted storage format changes.

## rollback
Revert `a3c1bb5` if the changelog entry or marker layout needs to be removed. Data-loss risk: none; users may simply see one fewer changelog item after rollback.

## monitoring
After merge, verify the Vercel preview and production header at mobile width once to confirm the notification panel keeps the same sizing outside the local dev server.

## scope
- `src/data/changelog.ts`
- `src/components/ChangelogBell.tsx`