### PR TITLE
완갑 장비 표시와 계산 지원

### DIFF
--- a/src/components/simulation/SpecScoreEquipmentPanel.test.tsx
+++ b/src/components/simulation/SpecScoreEquipmentPanel.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { SpecScoreEquipmentPanel } from './SpecScoreEquipmentPanel';
+import { ARMLET_POWER_BY_LEVEL } from '../../data/specScore/lopecCoefficients';
+import { equipment } from '../../utils/lopecSimulator.testUtils';
+import type { EquipMod } from './specScoreSimulatorTypes';
+
+const ARMLET_ICON = 'https://example.com/armlet.png';
+
+const armletAt = (normalLevel: number, grade = '고대') =>
+  equipment('armlet', {
+    normalLevel,
+    tier: grade,
+    raw: {
+      Type: '완갑',
+      Name: `+${normalLevel} 운명의 전율 완갑`,
+      Icon: ARMLET_ICON,
+      Grade: grade,
+      Tooltip: '{}',
+    },
+  });
+
+/** 패널을 렌더링하고 완갑 아이콘 엘리먼트를 돌려준다. alt=""라 role=img로는 조회되지 않는다. */
+const renderPanel = (normalLevel: number, mods: Partial<Record<'armlet', EquipMod>> = {}): HTMLImageElement => {
+  const { container } = render(
+    <SpecScoreEquipmentPanel
+      visible={true}
+      equipment={{ armlet: armletAt(normalLevel) }}
+      equipmentMods={mods}
+      equipmentCount={1}
+      changedCount={0}
+      summaryLabel="테스트"
+      onEquipmentChange={jest.fn()}
+      onApplyBulkEquipment={jest.fn()}
+    />,
+  );
+
+  const icon = container.querySelector('img');
+  if (!icon) throw new Error('Missing armlet icon');
+  return icon;
+};
+
+describe('SpecScoreEquipmentPanel armlet grade source', () => {
+  it('keeps the API grade and icon while the armlet is untouched', () => {
+    // Given: +9는 지원 레벨이라 계수 테이블에도 grade/icon이 있다.
+    expect(ARMLET_POWER_BY_LEVEL[9].grade).not.toBe('고대');
+
+    // When
+    const icon = renderPanel(9);
+
+    // Then
+    expect(screen.getByText('고대')).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', ARMLET_ICON);
+  });
+
+  it('keeps the API grade when the same level is re-selected', () => {
+    // Given / When: 값이 같은 재선택은 상태 변화가 아니다.
+    const icon = renderPanel(9, { armlet: { normalLevel: 9 } });
+
+    // Then
+    expect(screen.getByText('고대')).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', ARMLET_ICON);
+  });
+
+  it('switches to the coefficient table once a different level is selected', () => {
+    // Given / When
+    const icon = renderPanel(9, { armlet: { normalLevel: 15 } });
+
+    // Then
+    expect(screen.getByText(ARMLET_POWER_BY_LEVEL[15].grade)).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', ARMLET_POWER_BY_LEVEL[15].icon);
+  });
+
+  it('shows the unsupported API level with its API grade', () => {
+    // Given / When: +13은 ARMLET_SELECT_LEVELS에 없지만 표시는 원본을 따른다.
+    const icon = renderPanel(13);
+
+    // Then
+    expect(screen.getByText('고대')).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', ARMLET_ICON);
+  });
+});

--- a/src/components/simulation/SpecScoreEquipmentPanel.tsx
+++ b/src/components/simulation/SpecScoreEquipmentPanel.tsx
@@ -129,7 +129,8 @@ export const SpecScoreEquipmentPanel = ({
             const armletLevel = resolveArmletLevel(curNormal);
             const armletPower = armletLevel === null ? null : ARMLET_POWER_BY_LEVEL[armletLevel];
             const armletIsUnequipped = curNormal === ARMLET_UNEQUIPPED_LEVEL;
-            const armletIsModified = m?.normalLevel !== undefined;
+            // 등급/아이콘 출처는 API가 권위다. 값이 실제로 달라진 경우에만 계수 테이블로 넘어간다.
+            const armletIsModified = curNormal !== cur.normalLevel;
             const armletGrade = armletIsUnequipped
               ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].grade
               : armletIsModified && armletPower !== null

--- a/src/components/simulation/SpecScoreEquipmentPanel.tsx
+++ b/src/components/simulation/SpecScoreEquipmentPanel.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { ARMLET_LEVELS, ARMLET_POWER_BY_LEVEL, resolveArmletLevel, type EquipSlot } from '../../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, ARMLET_SELECT_LEVELS, ARMLET_UNEQUIPPED_LEVEL, resolveArmletLevel, type EquipSlot } from '../../data/specScore/lopecCoefficients';
 import type { EquipmentState, EquipmentTier } from '../../utils/equipmentState';
 import { gradeFrame } from '../../utils/equipmentColors';
 import { SpecSelect } from './SpecSelect';
@@ -26,7 +26,7 @@ const SLOT_LABEL: Record<EquipSlot, string> = {
   armlet: '완갑',
 };
 
-const SLOT_ORDER: EquipSlot[] = ['weapon', 'helmet', 'shoulder', 'armor', 'pants', 'gloves', 'armlet'];
+const SLOT_ORDER: EquipSlot[] = ['weapon', 'armlet', 'helmet', 'shoulder', 'armor', 'pants', 'gloves'];
 const TIER_OPTIONS = ['유물', '업화', '전율'] as const;
 const TIER_LABELS: Record<(typeof TIER_OPTIONS)[number], string> = {
   유물: '유물',
@@ -127,8 +127,20 @@ export const SpecScoreEquipmentPanel = ({
           const quality = extractQuality(cur.raw.Tooltip);
           if (slot === 'armlet') {
             const armletLevel = resolveArmletLevel(curNormal);
-            const armletPower = ARMLET_POWER_BY_LEVEL[armletLevel];
-            const armletFrame = gradeFrame(armletPower.grade, 'bg');
+            const armletPower = armletLevel === null ? null : ARMLET_POWER_BY_LEVEL[armletLevel];
+            const armletIsUnequipped = curNormal === ARMLET_UNEQUIPPED_LEVEL;
+            const armletIsModified = m?.normalLevel !== undefined;
+            const armletGrade = armletIsUnequipped
+              ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].grade
+              : armletIsModified && armletPower !== null
+                ? armletPower.grade
+                : cur.raw.Grade;
+            const armletIcon = armletIsUnequipped
+              ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].icon
+              : armletIsModified && armletPower !== null
+                ? armletPower.icon
+                : cur.raw.Icon;
+            const armletFrame = gradeFrame(armletGrade, 'bg');
             return (
               <div
                 key={slot}
@@ -140,28 +152,28 @@ export const SpecScoreEquipmentPanel = ({
                     style={armletFrame.style}
                   >
                     <img
-                      src={armletPower.icon}
+                      src={armletIcon}
                       alt=""
-                      className={`h-full w-full object-contain ${armletLevel === 0 ? 'opacity-45 grayscale' : ''}`}
+                      className={`h-full w-full object-contain ${armletIsUnequipped ? 'opacity-45 grayscale' : ''}`}
                     />
                   </div>
                   <span className="absolute top-0.5 left-0.5 rounded bg-black/70 px-1 text-[9px] font-bold leading-tight text-white">
                     완갑
                   </span>
                   <span className="absolute bottom-0.5 left-0.5 right-0.5 rounded bg-black/70 text-center text-[9px] font-bold leading-tight text-amber-300">
-                    {armletPower.grade}
+                    {armletGrade}
                   </span>
                 </div>
                 <div className="grid flex-1 grid-cols-1 gap-1 text-[11px] sm:grid-cols-2">
                   <div className="flex min-w-0 items-center gap-1">
                     <SpecSelect
-                      value={armletLevel}
+                      value={curNormal}
                       onChange={(value) => onEquipmentChange(slot, { normalLevel: Number(value) })}
-                      items={ARMLET_LEVELS.map((level) => ({
+                      items={ARMLET_SELECT_LEVELS.map((level) => ({
                         value: level,
-                        label: level === 0 ? '미착용' : String(level),
+                        label: level === ARMLET_UNEQUIPPED_LEVEL ? '미착용' : String(level),
                       }))}
-                      ariaLabel="완갑 레벨"
+                      ariaLabel={`완갑 레벨 ${armletIsUnequipped ? '미착용' : curNormal}`}
                       className="w-20 flex-shrink-0"
                     />
                   </div>

--- a/src/components/simulation/specScoreSimulatorModel.test.ts
+++ b/src/components/simulation/specScoreSimulatorModel.test.ts
@@ -1,4 +1,5 @@
 import { buildModifiedSpecScoreData, EMPTY_MODS } from './specScoreSimulatorModel';
+import { ARMLET_POWER_BY_LEVEL } from '../../data/specScore/lopecCoefficients';
 import type { Mods, SpecScoreRawData } from './specScoreSimulatorTypes';
 import { charStatsFor, effect, emptyGems, engravings, equipment } from '../../utils/lopecSimulator.testUtils';
 import type { StoneState } from '../../utils/polishState';
@@ -125,5 +126,79 @@ describe('buildModifiedSpecScoreData equipment tier changes', () => {
       equipmentFamily: 'egir',
       isInherited: false,
     }));
+  });
+});
+
+describe('buildModifiedSpecScoreData armlet levels', () => {
+  const armletAt = (normalLevel: number, grade = '고대') =>
+    equipment('armlet', {
+      normalLevel,
+      tier: grade,
+      raw: {
+        Type: '완갑',
+        Name: `+${normalLevel} 운명의 전율 완갑`,
+        Icon: 'https://example.com/armlet.png',
+        Grade: grade,
+        Tooltip: '{}',
+      },
+    });
+
+  it('keeps an unsupported API level and its API grade when the armlet is untouched', () => {
+    // Given: +13은 ARMLET_SELECT_LEVELS에 없는 실제 착용 레벨이다.
+    const raw = { ...createRawData(), equip: { armlet: armletAt(13) } };
+
+    // When
+    const modified = buildModifiedSpecScoreData(raw, EMPTY_MODS);
+
+    // Then: 표시 레벨은 API 원본 그대로, 등급도 테이블로 대체되지 않는다.
+    expect(modified.equip.armlet).toEqual(expect.objectContaining({
+      normalLevel: 13,
+      advancedLevel: 0,
+      tier: '고대',
+    }));
+  });
+
+  it('applies a supported level selected from an unsupported current level', () => {
+    // Given
+    const raw = { ...createRawData(), equip: { armlet: armletAt(13) } };
+    const mods: Mods = { ...EMPTY_MODS, equip: { armlet: { normalLevel: 15 } } };
+
+    // When
+    const modified = buildModifiedSpecScoreData(raw, mods);
+
+    // Then
+    expect(modified.equip.armlet).toEqual(expect.objectContaining({
+      normalLevel: 15,
+      advancedLevel: 0,
+      tier: ARMLET_POWER_BY_LEVEL[15].grade,
+    }));
+  });
+
+  it('keeps the API grade for an untouched armlet on a supported level', () => {
+    // Given: +9는 지원 레벨이라 계수 테이블에도 grade가 있지만,
+    // 실제 착용 중인 아이템의 등급은 API가 권위다.
+    const raw = { ...createRawData(), equip: { armlet: armletAt(9) } };
+    expect(ARMLET_POWER_BY_LEVEL[9].grade).not.toBe('고대');
+
+    // When
+    const modified = buildModifiedSpecScoreData(raw, EMPTY_MODS);
+
+    // Then
+    expect(modified.equip.armlet).toEqual(expect.objectContaining({
+      normalLevel: 9,
+      tier: '고대',
+    }));
+  });
+
+  it('keeps the API grade when the same level is re-selected', () => {
+    // Given: 값이 같은 재선택은 상태 변화가 아니다.
+    const raw = { ...createRawData(), equip: { armlet: armletAt(9) } };
+    const mods: Mods = { ...EMPTY_MODS, equip: { armlet: { normalLevel: 9 } } };
+
+    // When
+    const modified = buildModifiedSpecScoreData(raw, mods);
+
+    // Then
+    expect(modified.equip.armlet).toEqual(expect.objectContaining({ tier: '고대' }));
   });
 });

--- a/src/components/simulation/specScoreSimulatorModel.ts
+++ b/src/components/simulation/specScoreSimulatorModel.ts
@@ -190,11 +190,16 @@ export const buildModifiedSpecScoreData = (
     if (slot === 'armlet') {
       const requestedLevel = mod?.normalLevel ?? current.normalLevel;
       const armletLevel = resolveArmletLevel(requestedLevel);
+      // 착용 중인 완갑의 등급은 API가 권위다.
+      // 계수 테이블 grade는 사용자가 실제로 레벨을 바꿔 가상 아이템이 된 경우에만 쓴다.
+      const isLevelChanged = requestedLevel !== current.normalLevel;
       equip[slot] = {
         ...current,
         normalLevel: requestedLevel,
         advancedLevel: 0,
-        tier: armletLevel === null ? current.tier : ARMLET_POWER_BY_LEVEL[armletLevel].grade,
+        tier: isLevelChanged && armletLevel !== null
+          ? ARMLET_POWER_BY_LEVEL[armletLevel].grade
+          : current.tier,
       };
       continue;
     }

--- a/src/components/simulation/specScoreSimulatorModel.ts
+++ b/src/components/simulation/specScoreSimulatorModel.ts
@@ -188,12 +188,13 @@ export const buildModifiedSpecScoreData = (
     if (!current) continue;
     const mod = mods.equip[slot];
     if (slot === 'armlet') {
-      const normalLevel = resolveArmletLevel(mod?.normalLevel ?? current.normalLevel);
+      const requestedLevel = mod?.normalLevel ?? current.normalLevel;
+      const armletLevel = resolveArmletLevel(requestedLevel);
       equip[slot] = {
         ...current,
-        normalLevel,
+        normalLevel: requestedLevel,
         advancedLevel: 0,
-        tier: ARMLET_POWER_BY_LEVEL[normalLevel].grade,
+        tier: armletLevel === null ? current.tier : ARMLET_POWER_BY_LEVEL[armletLevel].grade,
       };
       continue;
     }

--- a/src/components/simulation/specScoreSimulatorParsing.test.ts
+++ b/src/components/simulation/specScoreSimulatorParsing.test.ts
@@ -282,6 +282,29 @@ describe('fetchSpecScoreRawData weapon attack parsing', () => {
     expect(result.charStats.effectiveWeaponAttack).toBeCloseTo(264_890.248, 3);
   });
 
+  it('uses the lower combat baseline when parsing an unsupported armlet level', async () => {
+    // Given
+    const armlet: EquipmentItem = {
+      Type: '완갑',
+      Name: '+13 운명의 전율 완갑',
+      Icon: '',
+      Grade: '영웅',
+      Tooltip: '{}',
+    };
+    setupApiMocks([
+      equipment('무기', '무기 공격력 +100,000'),
+      armlet,
+    ], []);
+
+    // When
+    const result = await fetchSpecScoreRawData(profile);
+
+    // Then
+    expect(result.equip.armlet?.normalLevel).toBe(13);
+    expect(result.charStats.effectiveWeaponAttack).toBe(110_969);
+    expect(result.charStats.baseAttackFlatSum).toBe(2030);
+  });
+
   it('does not invent the 97-stone base attack fallback for ordinary stones', async () => {
     // Given
     setupApiMocks([

--- a/src/components/simulation/specScoreSimulatorParsing.ts
+++ b/src/components/simulation/specScoreSimulatorParsing.ts
@@ -1,5 +1,5 @@
 import type { AvatarItem, CharacterProfile, EquipmentItem } from '../../types/lostark';
-import { ARMLET_POWER_BY_LEVEL, resolveArmletLevel } from '../../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletLevel } from '../../data/specScore/lopecCoefficients';
 import { fetchArkGrid, fetchArkPassive, fetchAvatars, fetchCards, fetchEngravings, fetchEquipment, fetchGems } from '../../utils/api';
 import { parseEquipmentList } from '../../utils/equipmentState';
 import { combineAvatarPetMainStatMultiplier } from '../../utils/lopecEquipmentDelta';
@@ -182,7 +182,10 @@ export const fetchSpecScoreRawData = async (profile: CharacterProfile): Promise<
   const equip = parseEquipmentList(equipment);
   const accessories = parseAccessoryList(equipment);
   const bracelet = parseBraceletState(equipment.find((equipmentItem) => equipmentItem.Type === '팔찌'));
-  const armletPower = ARMLET_POWER_BY_LEVEL[resolveArmletLevel(equip.armlet?.normalLevel ?? 0)];
+  const armletLevel = resolveArmletLevel(equip.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  const armletPower = armletLevel === null
+    ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL]
+    : ARMLET_POWER_BY_LEVEL[armletLevel];
   const weaponTooltipAttack = extractWeaponAttack(weaponItem);
   const stoneBaseAttackBonusPercent = extractStoneBaseAttackBonusPercent(stoneItem);
   const weaponAttackPercentSum =

--- a/src/components/simulation/specScoreSimulatorParsing.ts
+++ b/src/components/simulation/specScoreSimulatorParsing.ts
@@ -1,5 +1,5 @@
 import type { AvatarItem, CharacterProfile, EquipmentItem } from '../../types/lostark';
-import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletLevel } from '../../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletCombatLevel } from '../../data/specScore/lopecCoefficients';
 import { fetchArkGrid, fetchArkPassive, fetchAvatars, fetchCards, fetchEngravings, fetchEquipment, fetchGems } from '../../utils/api';
 import { parseEquipmentList } from '../../utils/equipmentState';
 import { combineAvatarPetMainStatMultiplier } from '../../utils/lopecEquipmentDelta';
@@ -182,7 +182,7 @@ export const fetchSpecScoreRawData = async (profile: CharacterProfile): Promise<
   const equip = parseEquipmentList(equipment);
   const accessories = parseAccessoryList(equipment);
   const bracelet = parseBraceletState(equipment.find((equipmentItem) => equipmentItem.Type === '팔찌'));
-  const armletLevel = resolveArmletLevel(equip.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  const armletLevel = resolveArmletCombatLevel(equip.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
   const armletPower = armletLevel === null
     ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL]
     : ARMLET_POWER_BY_LEVEL[armletLevel];

--- a/src/components/simulation/useSpecScoreSimulator.ts
+++ b/src/components/simulation/useSpecScoreSimulator.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { resolveArmletLevel, type EquipSlot } from '../../data/specScore/lopecCoefficients';
+import type { EquipSlot } from '../../data/specScore/lopecCoefficients';
 import type { AccessorySlot, BraceletStatOption } from '../../data/specScore/polishOptions';
 import type { CharacterProfile } from '../../types/lostark';
 import type { ArkGridCoreMod, ArkGridGemEditTarget, ArkGridGemMod } from './arkGridSimulatorState';
@@ -94,7 +94,7 @@ export const useSpecScoreSimulator = (profile: CharacterProfile) => {
     const equipment = raw?.equip[slot];
     if (!equipment) return;
     const safePatch: EquipMod = slot === 'armlet'
-      ? (patch.normalLevel === undefined ? {} : { normalLevel: resolveArmletLevel(patch.normalLevel) })
+      ? (patch.normalLevel === undefined ? {} : { normalLevel: patch.normalLevel })
       : equipment.isInherited && patch.advancedLevel !== undefined
         ? { ...patch, advancedLevel: undefined }
         : patch;
@@ -156,7 +156,7 @@ export const useSpecScoreSimulator = (profile: CharacterProfile) => {
       if (!current) continue;
       if (slot === 'armlet') {
         if (patch.normalLevel !== undefined) {
-          equip[slot] = { ...mods.equip[slot], normalLevel: resolveArmletLevel(patch.normalLevel) };
+          equip[slot] = { ...mods.equip[slot], normalLevel: patch.normalLevel };
         } else if (mods.equip[slot]) {
           equip[slot] = mods.equip[slot];
         }

--- a/src/data/enhancement.test.ts
+++ b/src/data/enhancement.test.ts
@@ -1,0 +1,29 @@
+import { ARMLET_STEPS, calcExpectedAttempts, getAttemptMaterials } from './enhancement';
+
+const totalMaterial = (from: number, type: string): number => {
+  const step = ARMLET_STEPS.find((candidate) => candidate.from === from);
+  if (!step) throw new Error(`Missing armlet step ${from}`);
+
+  const attempts = calcExpectedAttempts(step, false, false);
+  const material = getAttemptMaterials(step, false, false).find((candidate) => candidate.type === type);
+  return (material?.amount ?? 0) * attempts;
+};
+
+describe('ARMLET_STEPS', () => {
+  it('keeps representative 완갑 honing totals from the Inven source table', () => {
+    expect(ARMLET_STEPS).toHaveLength(25);
+    expect(calcExpectedAttempts(ARMLET_STEPS[0], false, false)).toBe(4.85);
+    expect(totalMaterial(0, '운명의 파편')).toBeCloseTo(215_325);
+    expect(totalMaterial(0, '운명의 파괴석 결정')).toBeCloseTo(2_910);
+    expect(totalMaterial(0, '운명의 수호석 결정')).toBeCloseTo(8_730);
+    expect(totalMaterial(0, '위대한 운명의 돌파석')).toBeCloseTo(146);
+    expect(totalMaterial(0, '상급 아비도스 융화')).toBeCloseTo(107);
+
+    expect(calcExpectedAttempts(ARMLET_STEPS[24], false, false)).toBe(32.36);
+    expect(totalMaterial(24, '운명의 파편')).toBeCloseTo(1_851_889);
+    expect(totalMaterial(24, '운명의 파괴석 결정')).toBeCloseTo(41_421);
+    expect(totalMaterial(24, '운명의 수호석 결정')).toBeCloseTo(129_925);
+    expect(totalMaterial(24, '위대한 운명의 돌파석')).toBeCloseTo(3_042);
+    expect(totalMaterial(24, '상급 아비도스 융화')).toBeCloseTo(2_006);
+  });
+});

--- a/src/data/enhancement.test.ts
+++ b/src/data/enhancement.test.ts
@@ -1,4 +1,4 @@
-import { ARMLET_STEPS, calcExpectedAttempts, getAttemptMaterials } from './enhancement';
+import { ARMLET_STEPS, calcAttemptRate, calcExpectedAttempts, getAttemptMaterials, getCeiling } from './enhancement';
 
 const totalMaterial = (from: number, type: string): number => {
   const step = ARMLET_STEPS.find((candidate) => candidate.from === from);
@@ -25,5 +25,31 @@ describe('ARMLET_STEPS', () => {
     expect(totalMaterial(24, '운명의 수호석 결정')).toBeCloseTo(129_925);
     expect(totalMaterial(24, '위대한 운명의 돌파석')).toBeCloseTo(3_042);
     expect(totalMaterial(24, '상급 아비도스 융화')).toBeCloseTo(2_006);
+  });
+
+  it('uses collected armlet success rates and full-breath ceilings', () => {
+    const ranges = [
+      { from: 0, baseRate: 0.15, fullBreathRate: 0.30, breathCount: 20, noneCeiling: 11, fullBreathCeiling: 8 },
+      { from: 5, baseRate: 0.10, fullBreathRate: 0.20, breathCount: 25, noneCeiling: 15, fullBreathCeiling: 10 },
+      { from: 10, baseRate: 0.05, fullBreathRate: 0.10, breathCount: 25, noneCeiling: 26, fullBreathCeiling: 18 },
+      { from: 15, baseRate: 0.03, fullBreathRate: 0.06, breathCount: 30, noneCeiling: 40, fullBreathCeiling: 27 },
+      { from: 20, baseRate: 0.015, fullBreathRate: 0.03, breathCount: 30, noneCeiling: 76, fullBreathCeiling: 51 },
+    ];
+
+    for (const range of ranges) {
+      const step = ARMLET_STEPS.find((candidate) => candidate.from === range.from);
+      if (!step) throw new Error(`Missing armlet step ${range.from}`);
+
+      expect(calcAttemptRate(step, 0, false, false)).toBeCloseTo(range.baseRate);
+      expect(calcAttemptRate(step, 0, false, true)).toBeCloseTo(range.fullBreathRate);
+      expect(getCeiling(step, false, false)).toBe(range.noneCeiling);
+      expect(getCeiling(step, false, true)).toBe(range.fullBreathCeiling);
+      expect(getAttemptMaterials(step, false, true)).toEqual(
+        expect.arrayContaining([
+          { type: '빙하의 숨결', amount: range.breathCount },
+          { type: '용암의 숨결', amount: range.breathCount },
+        ]),
+      );
+    }
   });
 });

--- a/src/data/enhancement.test.ts
+++ b/src/data/enhancement.test.ts
@@ -1,8 +1,46 @@
 import { ARMLET_STEPS, calcAttemptRate, calcExpectedAttempts, getAttemptMaterials, getCeiling } from './enhancement';
 
-const totalMaterial = (from: number, type: string): number => {
+/**
+ * 인벤 출처 표(https://www.inven.co.kr/board/lostark/4821/110554)를 그대로 옮긴 fixture.
+ * ARMLET_STEPS는 이 총합을 expectedAttempts로 나눠 1회분으로 보관하므로,
+ * 다시 곱해 원본 총합으로 돌아오는지 25단계 전체를 round-trip 검증한다.
+ */
+const ARMLET_SOURCE_TABLE = [
+  { from: 0,  attempts: 4.85,  shard: 215_325,   destruction: 2_910,  guardian: 8_730,   leap: 146,   fusion: 107,   gold: 25_220,  silver: 1_838_000 },
+  { from: 1,  attempts: 4.85,  shard: 217_750,   destruction: 3_007,  guardian: 9_021,   leap: 150,   fusion: 112,   gold: 26_190,  silver: 1_838_000 },
+  { from: 2,  attempts: 4.85,  shard: 220_806,   destruction: 3_104,  guardian: 9_336,   leap: 155,   fusion: 116,   gold: 27_209,  silver: 1_838_000 },
+  { from: 3,  attempts: 4.85,  shard: 223_958,   destruction: 3_201,  guardian: 9_652,   leap: 160,   fusion: 121,   gold: 28_276,  silver: 1_838_000 },
+  { from: 4,  attempts: 4.85,  shard: 227_256,   destruction: 3_298,  guardian: 9_967,   leap: 165,   fusion: 126,   gold: 29_391,  silver: 1_838_000 },
+  { from: 5,  attempts: 6.64,  shard: 265_329,   destruction: 4_648,  guardian: 14_110,  leap: 239,   fusion: 179,   gold: 41_832,  silver: 2_011_200 },
+  { from: 6,  attempts: 6.64,  shard: 288_242,   destruction: 4_781,  guardian: 14_575,  leap: 252,   fusion: 186,   gold: 43_492,  silver: 2_244_320 },
+  { from: 7,  attempts: 6.64,  shard: 293_355,   destruction: 4_947,  guardian: 15_073,  leap: 266,   fusion: 193,   gold: 45_218,  silver: 2_244_320 },
+  { from: 8,  attempts: 6.64,  shard: 301_667,   destruction: 5_113,  guardian: 15_571,  leap: 279,   fusion: 199,   gold: 47_011,  silver: 2_274_320 },
+  { from: 9,  attempts: 6.64,  shard: 342_178,   destruction: 5_279,  guardian: 16_102,  leap: 292,   fusion: 206,   gold: 48_870,  silver: 2_624_320 },
+  { from: 10, attempts: 11.44, shard: 455_019,   destruction: 9_381,  guardian: 28_657,  leap: 526,   fusion: 366,   gold: 87_516,  silver: 3_076_720 },
+  { from: 11, attempts: 11.44, shard: 485_430,   destruction: 9_667,  guardian: 29_630,  leap: 549,   fusion: 378,   gold: 90_948,  silver: 3_276_720 },
+  { from: 12, attempts: 11.44, shard: 522_183,   destruction: 9_953,  guardian: 30_659,  leap: 572,   fusion: 389,   gold: 94_494,  silver: 3_536_720 },
+  { from: 13, attempts: 11.44, shard: 555_394,   destruction: 10_296, guardian: 31_689,  leap: 606,   fusion: 412,   gold: 98_270,  silver: 3_756_720 },
+  { from: 14, attempts: 11.44, shard: 598_063,   destruction: 10_639, guardian: 32_776,  leap: 641,   fusion: 435,   gold: 102_159, silver: 4_066_720 },
+  { from: 15, attempts: 17.47, shard: 792_702,   destruction: 16_771, guardian: 51_799,  leap: 1_031, fusion: 699,   gold: 162_122, silver: 4_817_360 },
+  { from: 16, attempts: 17.47, shard: 844_094,   destruction: 17_295, guardian: 53_546,  leap: 1_083, fusion: 734,   gold: 168_586, silver: 5_416_880 },
+  { from: 17, attempts: 17.47, shard: 892_359,   destruction: 17_819, guardian: 55_380,  leap: 1_136, fusion: 769,   gold: 175_224, silver: 5_696_880 },
+  { from: 18, attempts: 17.47, shard: 945_498,   destruction: 18_431, guardian: 57_302,  leap: 1_188, fusion: 804,   gold: 182_212, silver: 6_016_880 },
+  { from: 19, attempts: 17.47, shard: 994_510,   destruction: 19_042, guardian: 59_223,  leap: 1_258, fusion: 839,   gold: 189_375, silver: 6_985_680 },
+  { from: 20, attempts: 32.36, shard: 1_536_554, destruction: 36_405, guardian: 113_422, leap: 2_459, fusion: 1_618, gold: 364_697, silver: 9_459_840 },
+  { from: 21, attempts: 32.36, shard: 1_613_887, destruction: 37_538, guardian: 117_305, leap: 2_589, fusion: 1_715, gold: 379_259, silver: 11_343_120 },
+  { from: 22, attempts: 32.36, shard: 1_687_838, destruction: 38_832, guardian: 121_350, leap: 2_718, fusion: 1_812, gold: 394_145, silver: 11_623_120 },
+  { from: 23, attempts: 32.36, shard: 1_768_731, destruction: 40_126, guardian: 125_557, leap: 2_880, fusion: 1_909, gold: 409_678, silver: 13_506_400 },
+  { from: 24, attempts: 32.36, shard: 1_851_889, destruction: 41_421, guardian: 129_925, leap: 3_042, fusion: 2_006, gold: 425_858, silver: 13_836_400 },
+] as const;
+
+const armletStep = (from: number) => {
   const step = ARMLET_STEPS.find((candidate) => candidate.from === from);
   if (!step) throw new Error(`Missing armlet step ${from}`);
+  return step;
+};
+
+const totalMaterial = (from: number, type: string): number => {
+  const step = armletStep(from);
 
   const attempts = calcExpectedAttempts(step, false, false);
   const material = getAttemptMaterials(step, false, false).find((candidate) => candidate.type === type);
@@ -25,6 +63,60 @@ describe('ARMLET_STEPS', () => {
     expect(totalMaterial(24, '운명의 수호석 결정')).toBeCloseTo(129_925);
     expect(totalMaterial(24, '위대한 운명의 돌파석')).toBeCloseTo(3_042);
     expect(totalMaterial(24, '상급 아비도스 융화')).toBeCloseTo(2_006);
+  });
+
+  it('round-trips every source-table row back to its original totals', () => {
+    expect(ARMLET_STEPS.map((step) => step.from)).toEqual(ARMLET_SOURCE_TABLE.map((row) => row.from));
+
+    for (const row of ARMLET_SOURCE_TABLE) {
+      const step = armletStep(row.from);
+      const attempts = calcExpectedAttempts(step, false, false);
+
+      expect(attempts).toBe(row.attempts);
+      expect(totalMaterial(row.from, '운명의 파편')).toBeCloseTo(row.shard);
+      expect(totalMaterial(row.from, '운명의 파괴석 결정')).toBeCloseTo(row.destruction);
+      expect(totalMaterial(row.from, '운명의 수호석 결정')).toBeCloseTo(row.guardian);
+      expect(totalMaterial(row.from, '위대한 운명의 돌파석')).toBeCloseTo(row.leap);
+      expect(totalMaterial(row.from, '상급 아비도스 융화')).toBeCloseTo(row.fusion);
+      expect(step.gold * attempts).toBeCloseTo(row.gold);
+      expect(step.silver * attempts).toBeCloseTo(row.silver);
+    }
+  });
+
+  it('ignores the book booster on steps that have no book material', () => {
+    // 완갑 단계에는 bookMaterial이 없다. 책을 켜도 partial 천장이 열려서는 안 된다.
+    for (const step of ARMLET_STEPS) {
+      expect(step.bookMaterial).toBeUndefined();
+      expect(calcExpectedAttempts(step, true, false)).toBe(calcExpectedAttempts(step, false, false));
+      expect(getCeiling(step, true, false)).toBe(getCeiling(step, false, false));
+      expect(getAttemptMaterials(step, true, false)).toEqual(getAttemptMaterials(step, false, false));
+      expect(calcAttemptRate(step, 0, true, false)).toBeCloseTo(calcAttemptRate(step, 0, false, false));
+
+      // 숨결과의 조합에서도 책이 both 천장을 끌어내리지 않아야 한다.
+      expect(calcExpectedAttempts(step, true, true)).toBe(calcExpectedAttempts(step, false, true));
+    }
+  });
+
+  it('computes breath-on average attempts from the accumulating success rate', () => {
+    // 평균 모드 + 숨결은 expectedAttempts 조기 반환을 타지 않고 확률 루프를 돈다.
+    // 기대값은 밴드별 (baseRate, 증가폭, 상한, partial 천장)으로 독립 계산해 고정한다.
+    const expectedByBand = [
+      { from: 0, attempts: 2.981384 },
+      { from: 5, attempts: 4.170516 },
+      { from: 10, attempts: 7.523629 },
+      { from: 15, attempts: 11.585661 },
+      { from: 20, attempts: 21.572577 },
+    ];
+
+    for (const band of expectedByBand) {
+      const step = armletStep(band.from);
+      const attempts = calcExpectedAttempts(step, false, true);
+
+      expect(attempts).toBeCloseTo(band.attempts, 5);
+      // 평균 모드는 항상 천장보다 싸고, 무부스터보다도 싸야 한다.
+      expect(attempts).toBeLessThan(getCeiling(step, false, true));
+      expect(attempts).toBeLessThan(calcExpectedAttempts(step, false, false));
+    }
   });
 
   it('uses collected armlet success rates and full-breath ceilings', () => {

--- a/src/data/enhancement.ts
+++ b/src/data/enhancement.ts
@@ -88,6 +88,8 @@ export interface EnhancementStep {
   bookMaterial?: MaterialAmount;
   /** 빙하의 숨결 (선택, 사용 시 비용 추가) */
   breathMaterial?: MaterialAmount;
+  /** 복수 숨결 재료 (완갑처럼 빙하/용암을 함께 쓰는 경우) */
+  breathMaterials?: MaterialAmount[];
   /** 직접 골드 비용 */
   gold: number;
   /** 실링 비용 */
@@ -1196,7 +1198,6 @@ export const SERKA_WEAPON_STEPS: EnhancementStep[] = [
 
 const createArmletStep = ({
   from,
-  expectedAttempts,
   shard,
   destructionStone,
   guardianStone,
@@ -1206,7 +1207,6 @@ const createArmletStep = ({
   silver,
 }: {
   readonly from: number;
-  readonly expectedAttempts: number;
   readonly shard: number;
   readonly destructionStone: number;
   readonly guardianStone: number;
@@ -1214,52 +1214,68 @@ const createArmletStep = ({
   readonly fusion: number;
   readonly gold: number;
   readonly silver: number;
-}): EnhancementStep => ({
-  from,
-  baseSuccessRate: 1,
-  rateIncreasePerFailure: 0,
-  maxBaseSuccessRate: 1,
-  bookBonus: 0,
-  breathBonus: 0,
-  ceiling: { none: Math.ceil(expectedAttempts) },
-  expectedAttempts,
-  baseMaterials: [
-    { type: '운명의 파편', amount: shard / expectedAttempts },
-    { type: '운명의 파괴석 결정', amount: destructionStone / expectedAttempts },
-    { type: '운명의 수호석 결정', amount: guardianStone / expectedAttempts },
-    { type: '위대한 운명의 돌파석', amount: leapStone / expectedAttempts },
-    { type: '상급 아비도스 융화', amount: fusion / expectedAttempts },
-  ],
-  gold: gold / expectedAttempts,
-  silver: silver / expectedAttempts,
-});
+}): EnhancementStep => {
+  const rateBand = from < 5
+    ? { expectedAttempts: 4.85, baseSuccessRate: 0.15, rateIncreasePerFailure: 0.015, maxBaseSuccessRate: 0.30, breathCount: 20, ceiling: { none: 11, partial: 8 } }
+    : from < 10
+      ? { expectedAttempts: 6.64, baseSuccessRate: 0.10, rateIncreasePerFailure: 0.01, maxBaseSuccessRate: 0.20, breathCount: 25, ceiling: { none: 15, partial: 10 } }
+      : from < 15
+        ? { expectedAttempts: 11.44, baseSuccessRate: 0.05, rateIncreasePerFailure: 0.005, maxBaseSuccessRate: 0.10, breathCount: 25, ceiling: { none: 26, partial: 18 } }
+        : from < 20
+          ? { expectedAttempts: 17.47, baseSuccessRate: 0.03, rateIncreasePerFailure: 0.003, maxBaseSuccessRate: 0.06, breathCount: 30, ceiling: { none: 40, partial: 27 } }
+          : { expectedAttempts: 32.36, baseSuccessRate: 0.015, rateIncreasePerFailure: 0.0015, maxBaseSuccessRate: 0.03, breathCount: 30, ceiling: { none: 76, partial: 51 } };
+
+  return {
+    from,
+    baseSuccessRate: rateBand.baseSuccessRate,
+    rateIncreasePerFailure: rateBand.rateIncreasePerFailure,
+    maxBaseSuccessRate: rateBand.maxBaseSuccessRate,
+    bookBonus: 0,
+    breathBonus: rateBand.baseSuccessRate,
+    ceiling: rateBand.ceiling,
+    baseMaterials: [
+      { type: '운명의 파편', amount: shard / rateBand.expectedAttempts },
+      { type: '운명의 파괴석 결정', amount: destructionStone / rateBand.expectedAttempts },
+      { type: '운명의 수호석 결정', amount: guardianStone / rateBand.expectedAttempts },
+      { type: '위대한 운명의 돌파석', amount: leapStone / rateBand.expectedAttempts },
+      { type: '상급 아비도스 융화', amount: fusion / rateBand.expectedAttempts },
+    ],
+    breathMaterials: [
+      { type: '빙하의 숨결', amount: rateBand.breathCount },
+      { type: '용암의 숨결', amount: rateBand.breathCount },
+    ],
+    gold: gold / rateBand.expectedAttempts,
+    silver: silver / rateBand.expectedAttempts,
+    expectedAttempts: rateBand.expectedAttempts,
+  };
+};
 
 export const ARMLET_STEPS: EnhancementStep[] = [
-  createArmletStep({ from: 0, expectedAttempts: 4.85, shard: 215325, destructionStone: 2910, guardianStone: 8730, leapStone: 146, fusion: 107, gold: 25220, silver: 1838000 }),
-  createArmletStep({ from: 1, expectedAttempts: 4.85, shard: 217750, destructionStone: 3007, guardianStone: 9021, leapStone: 150, fusion: 112, gold: 26190, silver: 1838000 }),
-  createArmletStep({ from: 2, expectedAttempts: 4.85, shard: 220806, destructionStone: 3104, guardianStone: 9336, leapStone: 155, fusion: 116, gold: 27209, silver: 1838000 }),
-  createArmletStep({ from: 3, expectedAttempts: 4.85, shard: 223958, destructionStone: 3201, guardianStone: 9652, leapStone: 160, fusion: 121, gold: 28276, silver: 1838000 }),
-  createArmletStep({ from: 4, expectedAttempts: 4.85, shard: 227256, destructionStone: 3298, guardianStone: 9967, leapStone: 165, fusion: 126, gold: 29391, silver: 1838000 }),
-  createArmletStep({ from: 5, expectedAttempts: 6.64, shard: 265329, destructionStone: 4648, guardianStone: 14110, leapStone: 239, fusion: 179, gold: 41832, silver: 2011200 }),
-  createArmletStep({ from: 6, expectedAttempts: 6.64, shard: 288242, destructionStone: 4781, guardianStone: 14575, leapStone: 252, fusion: 186, gold: 43492, silver: 2244320 }),
-  createArmletStep({ from: 7, expectedAttempts: 6.64, shard: 293355, destructionStone: 4947, guardianStone: 15073, leapStone: 266, fusion: 193, gold: 45218, silver: 2244320 }),
-  createArmletStep({ from: 8, expectedAttempts: 6.64, shard: 301667, destructionStone: 5113, guardianStone: 15571, leapStone: 279, fusion: 199, gold: 47011, silver: 2274320 }),
-  createArmletStep({ from: 9, expectedAttempts: 6.64, shard: 342178, destructionStone: 5279, guardianStone: 16102, leapStone: 292, fusion: 206, gold: 48870, silver: 2624320 }),
-  createArmletStep({ from: 10, expectedAttempts: 11.44, shard: 455019, destructionStone: 9381, guardianStone: 28657, leapStone: 526, fusion: 366, gold: 87516, silver: 3076720 }),
-  createArmletStep({ from: 11, expectedAttempts: 11.44, shard: 485430, destructionStone: 9667, guardianStone: 29630, leapStone: 549, fusion: 378, gold: 90948, silver: 3276720 }),
-  createArmletStep({ from: 12, expectedAttempts: 11.44, shard: 522183, destructionStone: 9953, guardianStone: 30659, leapStone: 572, fusion: 389, gold: 94494, silver: 3536720 }),
-  createArmletStep({ from: 13, expectedAttempts: 11.44, shard: 555394, destructionStone: 10296, guardianStone: 31689, leapStone: 606, fusion: 412, gold: 98270, silver: 3756720 }),
-  createArmletStep({ from: 14, expectedAttempts: 11.44, shard: 598063, destructionStone: 10639, guardianStone: 32776, leapStone: 641, fusion: 435, gold: 102159, silver: 4066720 }),
-  createArmletStep({ from: 15, expectedAttempts: 17.47, shard: 792702, destructionStone: 16771, guardianStone: 51799, leapStone: 1031, fusion: 699, gold: 162122, silver: 4817360 }),
-  createArmletStep({ from: 16, expectedAttempts: 17.47, shard: 844094, destructionStone: 17295, guardianStone: 53546, leapStone: 1083, fusion: 734, gold: 168586, silver: 5416880 }),
-  createArmletStep({ from: 17, expectedAttempts: 17.47, shard: 892359, destructionStone: 17819, guardianStone: 55380, leapStone: 1136, fusion: 769, gold: 175224, silver: 5696880 }),
-  createArmletStep({ from: 18, expectedAttempts: 17.47, shard: 945498, destructionStone: 18431, guardianStone: 57302, leapStone: 1188, fusion: 804, gold: 182212, silver: 6016880 }),
-  createArmletStep({ from: 19, expectedAttempts: 17.47, shard: 994510, destructionStone: 19042, guardianStone: 59223, leapStone: 1258, fusion: 839, gold: 189375, silver: 6985680 }),
-  createArmletStep({ from: 20, expectedAttempts: 32.36, shard: 1536554, destructionStone: 36405, guardianStone: 113422, leapStone: 2459, fusion: 1618, gold: 364697, silver: 9459840 }),
-  createArmletStep({ from: 21, expectedAttempts: 32.36, shard: 1613887, destructionStone: 37538, guardianStone: 117305, leapStone: 2589, fusion: 1715, gold: 379259, silver: 11343120 }),
-  createArmletStep({ from: 22, expectedAttempts: 32.36, shard: 1687838, destructionStone: 38832, guardianStone: 121350, leapStone: 2718, fusion: 1812, gold: 394145, silver: 11623120 }),
-  createArmletStep({ from: 23, expectedAttempts: 32.36, shard: 1768731, destructionStone: 40126, guardianStone: 125557, leapStone: 2880, fusion: 1909, gold: 409678, silver: 13506400 }),
-  createArmletStep({ from: 24, expectedAttempts: 32.36, shard: 1851889, destructionStone: 41421, guardianStone: 129925, leapStone: 3042, fusion: 2006, gold: 425858, silver: 13836400 }),
+  createArmletStep({ from: 0, shard: 215325, destructionStone: 2910, guardianStone: 8730, leapStone: 146, fusion: 107, gold: 25220, silver: 1838000 }),
+  createArmletStep({ from: 1, shard: 217750, destructionStone: 3007, guardianStone: 9021, leapStone: 150, fusion: 112, gold: 26190, silver: 1838000 }),
+  createArmletStep({ from: 2, shard: 220806, destructionStone: 3104, guardianStone: 9336, leapStone: 155, fusion: 116, gold: 27209, silver: 1838000 }),
+  createArmletStep({ from: 3, shard: 223958, destructionStone: 3201, guardianStone: 9652, leapStone: 160, fusion: 121, gold: 28276, silver: 1838000 }),
+  createArmletStep({ from: 4, shard: 227256, destructionStone: 3298, guardianStone: 9967, leapStone: 165, fusion: 126, gold: 29391, silver: 1838000 }),
+  createArmletStep({ from: 5, shard: 265329, destructionStone: 4648, guardianStone: 14110, leapStone: 239, fusion: 179, gold: 41832, silver: 2011200 }),
+  createArmletStep({ from: 6, shard: 288242, destructionStone: 4781, guardianStone: 14575, leapStone: 252, fusion: 186, gold: 43492, silver: 2244320 }),
+  createArmletStep({ from: 7, shard: 293355, destructionStone: 4947, guardianStone: 15073, leapStone: 266, fusion: 193, gold: 45218, silver: 2244320 }),
+  createArmletStep({ from: 8, shard: 301667, destructionStone: 5113, guardianStone: 15571, leapStone: 279, fusion: 199, gold: 47011, silver: 2274320 }),
+  createArmletStep({ from: 9, shard: 342178, destructionStone: 5279, guardianStone: 16102, leapStone: 292, fusion: 206, gold: 48870, silver: 2624320 }),
+  createArmletStep({ from: 10, shard: 455019, destructionStone: 9381, guardianStone: 28657, leapStone: 526, fusion: 366, gold: 87516, silver: 3076720 }),
+  createArmletStep({ from: 11, shard: 485430, destructionStone: 9667, guardianStone: 29630, leapStone: 549, fusion: 378, gold: 90948, silver: 3276720 }),
+  createArmletStep({ from: 12, shard: 522183, destructionStone: 9953, guardianStone: 30659, leapStone: 572, fusion: 389, gold: 94494, silver: 3536720 }),
+  createArmletStep({ from: 13, shard: 555394, destructionStone: 10296, guardianStone: 31689, leapStone: 606, fusion: 412, gold: 98270, silver: 3756720 }),
+  createArmletStep({ from: 14, shard: 598063, destructionStone: 10639, guardianStone: 32776, leapStone: 641, fusion: 435, gold: 102159, silver: 4066720 }),
+  createArmletStep({ from: 15, shard: 792702, destructionStone: 16771, guardianStone: 51799, leapStone: 1031, fusion: 699, gold: 162122, silver: 4817360 }),
+  createArmletStep({ from: 16, shard: 844094, destructionStone: 17295, guardianStone: 53546, leapStone: 1083, fusion: 734, gold: 168586, silver: 5416880 }),
+  createArmletStep({ from: 17, shard: 892359, destructionStone: 17819, guardianStone: 55380, leapStone: 1136, fusion: 769, gold: 175224, silver: 5696880 }),
+  createArmletStep({ from: 18, shard: 945498, destructionStone: 18431, guardianStone: 57302, leapStone: 1188, fusion: 804, gold: 182212, silver: 6016880 }),
+  createArmletStep({ from: 19, shard: 994510, destructionStone: 19042, guardianStone: 59223, leapStone: 1258, fusion: 839, gold: 189375, silver: 6985680 }),
+  createArmletStep({ from: 20, shard: 1536554, destructionStone: 36405, guardianStone: 113422, leapStone: 2459, fusion: 1618, gold: 364697, silver: 9459840 }),
+  createArmletStep({ from: 21, shard: 1613887, destructionStone: 37538, guardianStone: 117305, leapStone: 2589, fusion: 1715, gold: 379259, silver: 11343120 }),
+  createArmletStep({ from: 22, shard: 1687838, destructionStone: 38832, guardianStone: 121350, leapStone: 2718, fusion: 1812, gold: 394145, silver: 11623120 }),
+  createArmletStep({ from: 23, shard: 1768731, destructionStone: 40126, guardianStone: 125557, leapStone: 2880, fusion: 1909, gold: 409678, silver: 13506400 }),
+  createArmletStep({ from: 24, shard: 1851889, destructionStone: 41421, guardianStone: 129925, leapStone: 3042, fusion: 2006, gold: 425858, silver: 13836400 }),
 ];
 
 // ─────────────────────────────────────────────
@@ -1315,7 +1331,7 @@ export const calcExpectedAttempts = (
   useBook: boolean,
   useBreath: boolean,
 ): number => {
-  if (step.expectedAttempts !== undefined) return step.expectedAttempts;
+  if (!useBook && !useBreath && step.expectedAttempts !== undefined) return step.expectedAttempts;
 
   const ceiling = getCeiling(step, useBook, useBreath);
   let expected = 0;
@@ -1344,6 +1360,7 @@ export const getAttemptMaterials = (
   ...step.baseMaterials,
   ...(useBook   && step.bookMaterial   ? [step.bookMaterial]   : []),
   ...(useBreath && step.breathMaterial ? [step.breathMaterial] : []),
+  ...(useBreath && step.breathMaterials ? step.breathMaterials : []),
 ];
 
 // ─────────────────────────────────────────────

--- a/src/data/enhancement.ts
+++ b/src/data/enhancement.ts
@@ -92,6 +92,8 @@ export interface EnhancementStep {
   gold: number;
   /** 실링 비용 */
   silver: number;
+  /** 단계별 총합 표에서 제공되는 기대 시도 횟수 */
+  expectedAttempts?: number;
 }
 
 // ─────────────────────────────────────────────
@@ -1187,6 +1189,80 @@ export const SERKA_WEAPON_STEPS: EnhancementStep[] = [
 ];
 
 // ─────────────────────────────────────────────
+// 완갑 일반 재련
+// 출처: https://www.inven.co.kr/board/lostark/4821/110554
+// 표가 단계별 기대 총합으로 제공되어 1회 재료는 expectedAttempts로 역산한다.
+// ─────────────────────────────────────────────
+
+const createArmletStep = ({
+  from,
+  expectedAttempts,
+  shard,
+  destructionStone,
+  guardianStone,
+  leapStone,
+  fusion,
+  gold,
+  silver,
+}: {
+  readonly from: number;
+  readonly expectedAttempts: number;
+  readonly shard: number;
+  readonly destructionStone: number;
+  readonly guardianStone: number;
+  readonly leapStone: number;
+  readonly fusion: number;
+  readonly gold: number;
+  readonly silver: number;
+}): EnhancementStep => ({
+  from,
+  baseSuccessRate: 1,
+  rateIncreasePerFailure: 0,
+  maxBaseSuccessRate: 1,
+  bookBonus: 0,
+  breathBonus: 0,
+  ceiling: { none: Math.ceil(expectedAttempts) },
+  expectedAttempts,
+  baseMaterials: [
+    { type: '운명의 파편', amount: shard / expectedAttempts },
+    { type: '운명의 파괴석 결정', amount: destructionStone / expectedAttempts },
+    { type: '운명의 수호석 결정', amount: guardianStone / expectedAttempts },
+    { type: '위대한 운명의 돌파석', amount: leapStone / expectedAttempts },
+    { type: '상급 아비도스 융화', amount: fusion / expectedAttempts },
+  ],
+  gold: gold / expectedAttempts,
+  silver: silver / expectedAttempts,
+});
+
+export const ARMLET_STEPS: EnhancementStep[] = [
+  createArmletStep({ from: 0, expectedAttempts: 4.85, shard: 215325, destructionStone: 2910, guardianStone: 8730, leapStone: 146, fusion: 107, gold: 25220, silver: 1838000 }),
+  createArmletStep({ from: 1, expectedAttempts: 4.85, shard: 217750, destructionStone: 3007, guardianStone: 9021, leapStone: 150, fusion: 112, gold: 26190, silver: 1838000 }),
+  createArmletStep({ from: 2, expectedAttempts: 4.85, shard: 220806, destructionStone: 3104, guardianStone: 9336, leapStone: 155, fusion: 116, gold: 27209, silver: 1838000 }),
+  createArmletStep({ from: 3, expectedAttempts: 4.85, shard: 223958, destructionStone: 3201, guardianStone: 9652, leapStone: 160, fusion: 121, gold: 28276, silver: 1838000 }),
+  createArmletStep({ from: 4, expectedAttempts: 4.85, shard: 227256, destructionStone: 3298, guardianStone: 9967, leapStone: 165, fusion: 126, gold: 29391, silver: 1838000 }),
+  createArmletStep({ from: 5, expectedAttempts: 6.64, shard: 265329, destructionStone: 4648, guardianStone: 14110, leapStone: 239, fusion: 179, gold: 41832, silver: 2011200 }),
+  createArmletStep({ from: 6, expectedAttempts: 6.64, shard: 288242, destructionStone: 4781, guardianStone: 14575, leapStone: 252, fusion: 186, gold: 43492, silver: 2244320 }),
+  createArmletStep({ from: 7, expectedAttempts: 6.64, shard: 293355, destructionStone: 4947, guardianStone: 15073, leapStone: 266, fusion: 193, gold: 45218, silver: 2244320 }),
+  createArmletStep({ from: 8, expectedAttempts: 6.64, shard: 301667, destructionStone: 5113, guardianStone: 15571, leapStone: 279, fusion: 199, gold: 47011, silver: 2274320 }),
+  createArmletStep({ from: 9, expectedAttempts: 6.64, shard: 342178, destructionStone: 5279, guardianStone: 16102, leapStone: 292, fusion: 206, gold: 48870, silver: 2624320 }),
+  createArmletStep({ from: 10, expectedAttempts: 11.44, shard: 455019, destructionStone: 9381, guardianStone: 28657, leapStone: 526, fusion: 366, gold: 87516, silver: 3076720 }),
+  createArmletStep({ from: 11, expectedAttempts: 11.44, shard: 485430, destructionStone: 9667, guardianStone: 29630, leapStone: 549, fusion: 378, gold: 90948, silver: 3276720 }),
+  createArmletStep({ from: 12, expectedAttempts: 11.44, shard: 522183, destructionStone: 9953, guardianStone: 30659, leapStone: 572, fusion: 389, gold: 94494, silver: 3536720 }),
+  createArmletStep({ from: 13, expectedAttempts: 11.44, shard: 555394, destructionStone: 10296, guardianStone: 31689, leapStone: 606, fusion: 412, gold: 98270, silver: 3756720 }),
+  createArmletStep({ from: 14, expectedAttempts: 11.44, shard: 598063, destructionStone: 10639, guardianStone: 32776, leapStone: 641, fusion: 435, gold: 102159, silver: 4066720 }),
+  createArmletStep({ from: 15, expectedAttempts: 17.47, shard: 792702, destructionStone: 16771, guardianStone: 51799, leapStone: 1031, fusion: 699, gold: 162122, silver: 4817360 }),
+  createArmletStep({ from: 16, expectedAttempts: 17.47, shard: 844094, destructionStone: 17295, guardianStone: 53546, leapStone: 1083, fusion: 734, gold: 168586, silver: 5416880 }),
+  createArmletStep({ from: 17, expectedAttempts: 17.47, shard: 892359, destructionStone: 17819, guardianStone: 55380, leapStone: 1136, fusion: 769, gold: 175224, silver: 5696880 }),
+  createArmletStep({ from: 18, expectedAttempts: 17.47, shard: 945498, destructionStone: 18431, guardianStone: 57302, leapStone: 1188, fusion: 804, gold: 182212, silver: 6016880 }),
+  createArmletStep({ from: 19, expectedAttempts: 17.47, shard: 994510, destructionStone: 19042, guardianStone: 59223, leapStone: 1258, fusion: 839, gold: 189375, silver: 6985680 }),
+  createArmletStep({ from: 20, expectedAttempts: 32.36, shard: 1536554, destructionStone: 36405, guardianStone: 113422, leapStone: 2459, fusion: 1618, gold: 364697, silver: 9459840 }),
+  createArmletStep({ from: 21, expectedAttempts: 32.36, shard: 1613887, destructionStone: 37538, guardianStone: 117305, leapStone: 2589, fusion: 1715, gold: 379259, silver: 11343120 }),
+  createArmletStep({ from: 22, expectedAttempts: 32.36, shard: 1687838, destructionStone: 38832, guardianStone: 121350, leapStone: 2718, fusion: 1812, gold: 394145, silver: 11623120 }),
+  createArmletStep({ from: 23, expectedAttempts: 32.36, shard: 1768731, destructionStone: 40126, guardianStone: 125557, leapStone: 2880, fusion: 1909, gold: 409678, silver: 13506400 }),
+  createArmletStep({ from: 24, expectedAttempts: 32.36, shard: 1851889, destructionStone: 41421, guardianStone: 129925, leapStone: 3042, fusion: 2006, gold: 425858, silver: 13836400 }),
+];
+
+// ─────────────────────────────────────────────
 // 유틸
 // ─────────────────────────────────────────────
 
@@ -1239,6 +1315,8 @@ export const calcExpectedAttempts = (
   useBook: boolean,
   useBreath: boolean,
 ): number => {
+  if (step.expectedAttempts !== undefined) return step.expectedAttempts;
+
   const ceiling = getCeiling(step, useBook, useBreath);
   let expected = 0;
   let probAllFailed = 1;

--- a/src/data/enhancement.ts
+++ b/src/data/enhancement.ts
@@ -1283,6 +1283,22 @@ export const ARMLET_STEPS: EnhancementStep[] = [
 // ─────────────────────────────────────────────
 
 /**
+ * 단계가 실제로 지원하는 부스터만 남긴다.
+ *
+ * 완갑처럼 bookMaterial이 없는 단계에 useBook: true가 들어오면
+ * 확률은 그대로인 채 partial 천장만 낮아져 재료 없이 비용이 줄어든다.
+ * 계산 진입부에서 한 번 정규화해 호출자가 같은 가드를 반복하지 않게 한다.
+ */
+const resolveBoosters = (
+  step: EnhancementStep,
+  useBook: boolean,
+  useBreath: boolean,
+): { book: boolean; breath: boolean } => ({
+  book: useBook && step.bookMaterial != null,
+  breath: useBreath && (step.breathMaterial != null || (step.breathMaterials?.length ?? 0) > 0),
+});
+
+/**
  * n번째 시도의 성공 확률 (실패 누적 반영)
  * @param step 강화 단계
  * @param attemptIndex 0-based 시도 인덱스 (0 = 1트)
@@ -1295,11 +1311,12 @@ export const calcAttemptRate = (
   useBook: boolean,
   useBreath: boolean,
 ): number => {
+  const booster = resolveBoosters(step, useBook, useBreath);
   const base = Math.min(
     step.maxBaseSuccessRate,
     step.baseSuccessRate + attemptIndex * step.rateIncreasePerFailure,
   );
-  const boosters = (useBook ? step.bookBonus : 0) + (useBreath ? step.breathBonus : 0);
+  const boosters = (booster.book ? step.bookBonus : 0) + (booster.breath ? step.breathBonus : 0);
   return Math.min(1, base + boosters);
 };
 
@@ -1314,8 +1331,9 @@ export const getCeiling = (
   useBook: boolean,
   useBreath: boolean,
 ): number => {
-  const useBoth = useBook && useBreath;
-  const useAny  = useBook || useBreath;
+  const booster = resolveBoosters(step, useBook, useBreath);
+  const useBoth = booster.book && booster.breath;
+  const useAny  = booster.book || booster.breath;
   if (useBoth   && step.ceiling.both    != null) return step.ceiling.both;
   if (useAny    && step.ceiling.partial != null) return step.ceiling.partial;
   return step.ceiling.none;
@@ -1331,14 +1349,15 @@ export const calcExpectedAttempts = (
   useBook: boolean,
   useBreath: boolean,
 ): number => {
-  if (!useBook && !useBreath && step.expectedAttempts !== undefined) return step.expectedAttempts;
+  const booster = resolveBoosters(step, useBook, useBreath);
+  if (!booster.book && !booster.breath && step.expectedAttempts !== undefined) return step.expectedAttempts;
 
-  const ceiling = getCeiling(step, useBook, useBreath);
+  const ceiling = getCeiling(step, booster.book, booster.breath);
   let expected = 0;
   let probAllFailed = 1;
 
   for (let i = 0; i < ceiling - 1; i++) {
-    const rate = calcAttemptRate(step, i, useBook, useBreath);
+    const rate = calcAttemptRate(step, i, booster.book, booster.breath);
     expected += (i + 1) * probAllFailed * rate;
     probAllFailed *= (1 - rate);
   }
@@ -1356,12 +1375,15 @@ export const getAttemptMaterials = (
   step: EnhancementStep,
   useBook: boolean,
   useBreath: boolean,
-): MaterialAmount[] => [
-  ...step.baseMaterials,
-  ...(useBook   && step.bookMaterial   ? [step.bookMaterial]   : []),
-  ...(useBreath && step.breathMaterial ? [step.breathMaterial] : []),
-  ...(useBreath && step.breathMaterials ? step.breathMaterials : []),
-];
+): MaterialAmount[] => {
+  const booster = resolveBoosters(step, useBook, useBreath);
+  return [
+    ...step.baseMaterials,
+    ...(booster.book   && step.bookMaterial    ? [step.bookMaterial]   : []),
+    ...(booster.breath && step.breathMaterial  ? [step.breathMaterial] : []),
+    ...(booster.breath && step.breathMaterials ? step.breathMaterials  : []),
+  ];
+};
 
 // ─────────────────────────────────────────────
 // 상급 재련 (에기르 전용)

--- a/src/data/specScore/lopecCoefficients.test.ts
+++ b/src/data/specScore/lopecCoefficients.test.ts
@@ -1,0 +1,53 @@
+import {
+  ARMLET_POWER_BY_LEVEL,
+  ARMLET_UNEQUIPPED_LEVEL,
+  resolveArmletLevel,
+} from './lopecCoefficients';
+
+describe('armlet combat power coefficients', () => {
+  it('separates unequipped armlet from equipped +0 armlet', () => {
+    expect(ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL]).toMatchObject({
+      weaponAttack: 0,
+      mainStat: 0,
+      baseAttack: 0,
+      baseAttackPercent: 0,
+      grade: '미착용',
+    });
+    expect(ARMLET_POWER_BY_LEVEL[0]).toMatchObject({
+      weaponAttack: 3500,
+      mainStat: 10500,
+      baseAttack: 0,
+      baseAttackPercent: 0,
+      grade: '영웅',
+    });
+  });
+
+  it('keeps exact known +0 through +10 armlet values', () => {
+    const expected = [
+      [0, 3500, 10500, 0],
+      [1, 5350, 10500, 0],
+      [2, 5350, 16500, 0],
+      [3, 7210, 16500, 0],
+      [4, 7210, 22530, 0],
+      [5, 7210, 22530, 850],
+      [6, 9077, 22530, 850],
+      [7, 9077, 28608, 850],
+      [8, 10969, 28608, 850],
+      [9, 10969, 34746, 850],
+      [10, 10969, 34746, 2030],
+    ] as const;
+
+    for (const [level, weaponAttack, mainStat, baseAttack] of expected) {
+      expect(ARMLET_POWER_BY_LEVEL[level]).toMatchObject({
+        weaponAttack,
+        mainStat,
+        baseAttack,
+        baseAttackPercent: 0,
+      });
+    }
+  });
+
+  it('does not guess unsupported armlet levels', () => {
+    expect(resolveArmletLevel(16)).toBeNull();
+  });
+});

--- a/src/data/specScore/lopecCoefficients.test.ts
+++ b/src/data/specScore/lopecCoefficients.test.ts
@@ -1,6 +1,7 @@
 import {
   ARMLET_POWER_BY_LEVEL,
   ARMLET_UNEQUIPPED_LEVEL,
+  resolveArmletCombatLevel,
   resolveArmletLevel,
 } from './lopecCoefficients';
 
@@ -47,7 +48,15 @@ describe('armlet combat power coefficients', () => {
     }
   });
 
-  it('does not guess unsupported armlet levels', () => {
+  it('keeps UI validation strict for unsupported armlet levels', () => {
+    // Given / When / Then
     expect(resolveArmletLevel(16)).toBeNull();
+  });
+
+  it('uses the nearest supported lower level for combat scoring', () => {
+    // Given / When / Then
+    expect(resolveArmletCombatLevel(13)).toBe(10);
+    expect(resolveArmletCombatLevel(18)).toBe(15);
+    expect(resolveArmletCombatLevel(23)).toBe(20);
   });
 });

--- a/src/data/specScore/lopecCoefficients.ts
+++ b/src/data/specScore/lopecCoefficients.ts
@@ -294,6 +294,18 @@ export const isArmletLevel = (level: number): level is ArmletLevel =>
 export const resolveArmletLevel = (level: number): ArmletLevel | null =>
   isArmletLevel(level) ? level : null;
 
+export const resolveArmletCombatLevel = (level: number): ArmletLevel | null => {
+  const exactLevel = resolveArmletLevel(level);
+  if (exactLevel !== null) return exactLevel;
+
+  for (let index = ARMLET_LEVELS.length - 1; index >= 0; index -= 1) {
+    const supportedLevel = ARMLET_LEVELS[index];
+    if (supportedLevel !== undefined && supportedLevel <= level) return supportedLevel;
+  }
+
+  return null;
+};
+
 /**
  * 상급 재련 단계별 누적 ratio (해당 슬롯의 X0 기준)
  * index 0..8 = X(i*5), 즉 X0, X5, X10, ..., X40

--- a/src/data/specScore/lopecCoefficients.ts
+++ b/src/data/specScore/lopecCoefficients.ts
@@ -252,11 +252,14 @@ export const LOPEC_T4_GEM_BASE_ATTACK_BY_LEVEL: Record<number, number> = {
 // ============================================================
 
 export type StandardEquipSlot = 'weapon' | 'helmet' | 'shoulder' | 'armor' | 'pants' | 'gloves';
-export type ArmletLevel = 0 | 10 | 15 | 20 | 25;
+export const ARMLET_UNEQUIPPED_LEVEL = -1;
+export type EquippedArmletLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 15 | 20 | 25;
+export type ArmletLevel = typeof ARMLET_UNEQUIPPED_LEVEL | EquippedArmletLevel;
 export type EquipSlot = StandardEquipSlot | 'armlet';
 
 export const STANDARD_EQUIP_SLOTS: StandardEquipSlot[] = ['weapon', 'helmet', 'shoulder', 'armor', 'pants', 'gloves'];
-export const ARMLET_LEVELS: ArmletLevel[] = [0, 10, 15, 20, 25];
+export const ARMLET_LEVELS: EquippedArmletLevel[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25];
+export const ARMLET_SELECT_LEVELS: ArmletLevel[] = [ARMLET_UNEQUIPPED_LEVEL, ...ARMLET_LEVELS];
 
 export interface ArmletPower {
   readonly weaponAttack: number;
@@ -268,7 +271,17 @@ export interface ArmletPower {
 }
 
 export const ARMLET_POWER_BY_LEVEL: Record<ArmletLevel, ArmletPower> = {
-  0: { weaponAttack: 0, mainStat: 0, baseAttack: 0, baseAttackPercent: 0, grade: '미착용', icon: '/images/arms1.webp' },
+  [-1]: { weaponAttack: 0, mainStat: 0, baseAttack: 0, baseAttackPercent: 0, grade: '미착용', icon: '/images/arms1.webp' },
+  0: { weaponAttack: 3500, mainStat: 10500, baseAttack: 0, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  1: { weaponAttack: 5350, mainStat: 10500, baseAttack: 0, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  2: { weaponAttack: 5350, mainStat: 16500, baseAttack: 0, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  3: { weaponAttack: 7210, mainStat: 16500, baseAttack: 0, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  4: { weaponAttack: 7210, mainStat: 22530, baseAttack: 0, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  5: { weaponAttack: 7210, mainStat: 22530, baseAttack: 850, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  6: { weaponAttack: 9077, mainStat: 22530, baseAttack: 850, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  7: { weaponAttack: 9077, mainStat: 28608, baseAttack: 850, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  8: { weaponAttack: 10969, mainStat: 28608, baseAttack: 850, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
+  9: { weaponAttack: 10969, mainStat: 34746, baseAttack: 850, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
   10: { weaponAttack: 10969, mainStat: 34746, baseAttack: 2030, baseAttackPercent: 0, grade: '영웅', icon: '/images/arms1.webp' },
   15: { weaponAttack: 14817, mainStat: 47268, baseAttack: 3690, baseAttackPercent: 1.0, grade: '전설', icon: '/images/arms2.webp' },
   20: { weaponAttack: 18794, mainStat: 60216, baseAttack: 5980, baseAttackPercent: 2.0, grade: '유물', icon: '/images/arms3.webp' },
@@ -276,10 +289,10 @@ export const ARMLET_POWER_BY_LEVEL: Record<ArmletLevel, ArmletPower> = {
 };
 
 export const isArmletLevel = (level: number): level is ArmletLevel =>
-  level === 0 || level === 10 || level === 15 || level === 20 || level === 25;
+  level === ARMLET_UNEQUIPPED_LEVEL || ARMLET_LEVELS.some((armletLevel) => armletLevel === level);
 
-export const resolveArmletLevel = (level: number): ArmletLevel =>
-  isArmletLevel(level) ? level : 0;
+export const resolveArmletLevel = (level: number): ArmletLevel | null =>
+  isArmletLevel(level) ? level : null;
 
 /**
  * 상급 재련 단계별 누적 ratio (해당 슬롯의 X0 기준)

--- a/src/pages/Character.test.tsx
+++ b/src/pages/Character.test.tsx
@@ -1,0 +1,23 @@
+import type { EquipmentItem } from '../types/lostark';
+import { getCombatEquipmentItems } from '../utils/characterEquipment';
+
+const equipment = (type: string, name: string): EquipmentItem => ({
+  Type: type,
+  Name: name,
+  Icon: '',
+  Grade: '고대',
+  Tooltip: '{}',
+});
+
+describe('getCombatEquipmentItems', () => {
+  it('places 완갑 directly below 무기 when present', () => {
+    const items = [
+      equipment('투구', '+19 운명의 전율 투구'),
+      equipment('완갑', '+9 운명의 전율 완갑'),
+      equipment('무기', '+21 운명의 전율 한손검'),
+      equipment('목걸이', '도래한 결전의 목걸이'),
+    ];
+
+    expect(getCombatEquipmentItems(items).map((item) => item.Type)).toEqual(['무기', '완갑', '투구']);
+  });
+});

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -18,6 +18,7 @@ import { fetchProfile, fetchEquipment, fetchGems, fetchEngravings, fetchArkGrid,
 import { type EffectSegment, stripHtml, htmlColorToGrade, parseBraceletLine } from '../utils/tooltipParser';
 import { gradeFrame, gradeStyles, EFFECT_GRADE_COLORS, qualityTextColor, qualityBgColor } from '../utils/equipmentColors';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { getCombatEquipmentItems, isCombatEquipment } from '../utils/characterEquipment';
 
 interface EquipmentEffect { grade: string | null; text: string; segments?: EffectSegment[] }
 
@@ -103,7 +104,6 @@ function parseEquipmentInfo(itemName: string, tooltip: string): ParsedEquipmentI
 }
 
 /* ── 장비 그룹 ── */
-const ARMOR_TYPES = ['무기', '투구', '어깨', '상의', '하의', '장갑'];
 const ACCESSORY_TYPES = ['목걸이', '귀걸이', '반지'];
 
 function shortCoreName(fullName: string | null): string {
@@ -520,13 +520,13 @@ const SectionLabel: React.FC<{ label: string }> = ({ label }) => (
 const EquipmentCard: React.FC<{ items: EquipmentItem[] }> = ({ items }) => {
   if (items.length === 0) return null;
 
-  const armor       = items.filter((it) => ARMOR_TYPES.some((t) => it.Type.includes(t)));
+  const armor       = getCombatEquipmentItems(items);
   const accessories = items.filter((it) => ACCESSORY_TYPES.some((t) => it.Type.includes(t)));
   const stone       = items.filter((it) => it.Type === '어빌리티 스톤');
   const bracelet    = items.filter((it) => it.Type === '팔찌');
   const extras      = items.filter(
     (it) =>
-      !ARMOR_TYPES.some((t) => it.Type.includes(t)) &&
+      !isCombatEquipment(it) &&
       !ACCESSORY_TYPES.some((t) => it.Type.includes(t)) &&
       it.Type !== '어빌리티 스톤' &&
       it.Type !== '팔찌'

--- a/src/pages/Compare.test.tsx
+++ b/src/pages/Compare.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Compare from './Compare';
-import type { CharacterProfile } from '../types/lostark';
+import type { CharacterProfile, EquipmentItem } from '../types/lostark';
 import {
   fetchArkGrid,
   fetchEngravings,
@@ -57,11 +57,19 @@ const validProfile: CharacterProfile = {
   CombatPower: null,
 };
 
+const equipment = (type: string, name: string): EquipmentItem => ({
+  Type: type,
+  Name: name,
+  Icon: 'https://example.com/icon.png',
+  Grade: '고대',
+  Tooltip: '{}',
+});
+
 describe('Compare', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedFetchProfile.mockImplementation(async (name) => {
-      if (name === '정상캐릭터') return validProfile;
+      if (name === '정상캐릭터' || name === '비교캐릭터') return { ...validProfile, CharacterName: name };
       return null as unknown as CharacterProfile;
     });
     mockedFetchEquipment.mockResolvedValue([]);
@@ -79,5 +87,22 @@ describe('Compare', () => {
 
     expect(await screen.findByText('"ㅎㅎㅎ" 캐릭터를 조회하지 못해 비교할 수 없습니다. 닉네임을 확인해주세요.')).toBeInTheDocument();
     await waitFor(() => expect(screen.queryByText('기본 정보')).not.toBeInTheDocument());
+  });
+
+  it('완갑 장비를 장비 비교 섹션에 표시한다', async () => {
+    mockedFetchEquipment.mockImplementation(async (name) => (
+      name === '정상캐릭터'
+        ? [equipment('완갑', '+9 운명의 전율 완갑')]
+        : []
+    ));
+
+    render(<Compare />);
+
+    fireEvent.change(screen.getByPlaceholderText('캐릭터 닉네임'), { target: { value: '정상캐릭터' } });
+    fireEvent.change(screen.getByPlaceholderText('비교할 캐릭터'), { target: { value: '비교캐릭터' } });
+    fireEvent.click(screen.getByRole('button', { name: '비교하기' }));
+
+    expect(await screen.findByText('+9 운명의 전율 완갑')).toBeInTheDocument();
+    expect(screen.getByText('완갑')).toBeInTheDocument();
   });
 });

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -23,6 +23,7 @@ import {
 } from '../utils/api';
 import { type EffectSegment, stripHtml, parseBraceletLine } from '../utils/tooltipParser';
 import { gradeFrame, gradeText, gradeStyles, qualityTextColor, qualityBgColor } from '../utils/equipmentColors';
+import { COMBAT_EQUIPMENT_TYPES } from '../utils/characterEquipment';
 
 /* ================================================================
    Types
@@ -62,7 +63,7 @@ function shortCoreName(fullName: string | null): string {
 interface DetailLine { text: string; segments?: EffectSegment[] }
 
 /** 장비 슬롯 순서 */
-const ARMOR_SLOTS = ['무기', '투구', '상의', '하의', '장갑', '어깨'];
+const ARMOR_SLOTS = COMBAT_EQUIPMENT_TYPES;
 const ACCESSORY_SLOTS = ['목걸이', '귀걸이', '귀걸이', '반지', '반지'];
 const EXTRA_SLOTS = ['어빌리티 스톤', '팔찌'];
 
@@ -120,7 +121,7 @@ function parseEquipDetails(tooltip: string, type: string): DetailLine[] {
   }
 }
 
-function findEquipBySlots(items: EquipmentItem[], slots: string[]): (EquipmentItem | null)[] {
+function findEquipBySlots(items: EquipmentItem[], slots: readonly string[]): (EquipmentItem | null)[] {
   const remaining = [...items];
   return slots.map((slot) => {
     const idx = remaining.findIndex((i) => i.Type === slot);

--- a/src/pages/Enhancement.test.tsx
+++ b/src/pages/Enhancement.test.tsx
@@ -86,7 +86,7 @@ describe('Enhancement armlet calculations', () => {
     expect(armletCard).not.toHaveTextContent('+0');
   });
 
-  it('applies breath and ceiling to a weapon without changing the armlet average', async () => {
+  it('applies breath and ceiling to the armlet calculation', async () => {
     mockedFetchEquipment.mockResolvedValue([
       equipment('무기', 10),
       equipment('완갑', 0),
@@ -119,7 +119,7 @@ describe('Enhancement armlet calculations', () => {
 
     const armletRow = within(slotSummary).getByText('완갑').closest('tr');
     const weaponRow = within(slotSummary).getByText('무기').closest('tr');
-    expect(armletRow).toHaveTextContent(`${calcExpectedAttempts(ARMLET_STEPS[0], false, false).toFixed(1)}트`);
+    expect(armletRow).toHaveTextContent(`${getCeiling(ARMLET_STEPS[0], false, true).toFixed(1)}트`);
     expect(weaponRow).toHaveTextContent(`${getCeiling(AEGIR_WEAPON_STEPS[0], false, true).toFixed(1)}트`);
   });
 });

--- a/src/pages/Enhancement.test.tsx
+++ b/src/pages/Enhancement.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import Enhancement from './Enhancement';
+import {
+  AEGIR_WEAPON_STEPS,
+  ARMLET_STEPS,
+  calcExpectedAttempts,
+  getCeiling,
+} from '../data/enhancement';
+import type { CharacterProfile, EquipmentItem } from '../types/lostark';
+import {
+  fetchEquipment,
+  fetchMarketItems,
+  fetchMarketOptions,
+  fetchProfile,
+} from '../utils/api';
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+jest.mock('../components/GlassCard', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
+
+jest.mock('../utils/api', () => ({
+  fetchEquipment: jest.fn(),
+  fetchMarketItems: jest.fn(),
+  fetchMarketOptions: jest.fn(),
+  fetchProfile: jest.fn(),
+}));
+
+const mockedFetchEquipment = jest.mocked(fetchEquipment);
+const mockedFetchMarketItems = jest.mocked(fetchMarketItems);
+const mockedFetchMarketOptions = jest.mocked(fetchMarketOptions);
+const mockedFetchProfile = jest.mocked(fetchProfile);
+
+const profile: CharacterProfile = {
+  CharacterImage: '',
+  CharacterName: '테스트캐릭터',
+  CharacterClassName: '바드',
+  CharacterLevel: 70,
+  ItemAvgLevel: '1,700.00',
+  ItemMaxLevel: '1,700.00',
+  ServerName: '루페온',
+  Title: null,
+  GuildName: null,
+  ExpeditionLevel: 300,
+  PvpGradeName: '',
+  TownLevel: null,
+  TownName: '',
+  UsingSkillPoint: 0,
+  TotalSkillPoint: 0,
+  Stats: [],
+  Tendencies: [],
+  CombatPower: null,
+};
+
+const equipment = (type: string, level: number): EquipmentItem => ({
+  Type: type,
+  Name: `+${level} 테스트 ${type}`,
+  Icon: '',
+  Grade: '고대',
+  Tooltip: '{}',
+});
+
+const chooseTarget = (slot: string, target: number): void => {
+  fireEvent.click(screen.getByRole('button', { name: `${slot} 일반 재련 목표 선택` }));
+  fireEvent.click(screen.getByRole('option', { name: `${target}강` }));
+};
+
+describe('Enhancement armlet calculations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchMarketOptions.mockResolvedValue({ Categories: [] });
+    mockedFetchMarketItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 0, Items: [] });
+    mockedFetchProfile.mockResolvedValue(profile);
+  });
+
+  it('keeps a missing armlet unequipped after character lookup', async () => {
+    mockedFetchEquipment.mockResolvedValue([equipment('무기', 10)]);
+
+    render(<Enhancement />);
+
+    fireEvent.change(screen.getByPlaceholderText('캐릭터명 입력'), { target: { value: '테스트캐릭터' } });
+    fireEvent.click(screen.getByRole('button', { name: '조회' }));
+
+    await screen.findByText('종합 아이템 레벨');
+    const armletCard = screen.getByText('완갑').closest('div');
+
+    expect(armletCard).toHaveTextContent('—');
+    expect(armletCard).not.toHaveTextContent('+0');
+  });
+
+  it('applies breath and ceiling to a weapon without changing the armlet average', async () => {
+    mockedFetchEquipment.mockResolvedValue([
+      equipment('무기', 10),
+      equipment('완갑', 0),
+    ]);
+
+    render(<Enhancement />);
+
+    fireEvent.change(screen.getByPlaceholderText('캐릭터명 입력'), { target: { value: '테스트캐릭터' } });
+    fireEvent.click(screen.getByRole('button', { name: '조회' }));
+    await screen.findByText('종합 아이템 레벨');
+
+    chooseTarget('완갑', 1);
+    chooseTarget('무기', 11);
+    await screen.findByText('일반 재련 설정');
+
+    const bookOn = screen.queryByRole('button', { name: '책 ON' });
+    if (bookOn) fireEvent.click(bookOn);
+    const breathOff = screen.queryByRole('button', { name: '숨결 OFF' });
+    if (breathOff) fireEvent.click(breathOff);
+
+    expect(screen.getByRole('button', { name: '숨결 ON' })).toBeInTheDocument();
+    const ceilingButton = screen.getByRole('button', { name: '장기백' });
+    expect(ceilingButton).toBeEnabled();
+    fireEvent.click(ceilingButton);
+
+    await waitFor(() => expect(ceilingButton).toHaveClass('bg-red-500/20'));
+    const slotSummary = screen.getByText('슬롯별 예상 비용').parentElement;
+    expect(slotSummary).not.toBeNull();
+    if (!slotSummary) return;
+
+    const armletRow = within(slotSummary).getByText('완갑').closest('tr');
+    const weaponRow = within(slotSummary).getByText('무기').closest('tr');
+    expect(armletRow).toHaveTextContent(`${calcExpectedAttempts(ARMLET_STEPS[0], false, false).toFixed(1)}트`);
+    expect(weaponRow).toHaveTextContent(`${getCeiling(AEGIR_WEAPON_STEPS[0], false, true).toFixed(1)}트`);
+  });
+});

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -426,8 +426,11 @@ const Enhancement: React.FC = () => {
     [targetMap, slotCurrentLevel],
   );
   const activeIncludesArmlet = activeSlots.includes('완갑');
-  const effectiveUseBreath = activeIncludesArmlet ? false : useBreath;
-  const effectiveCostMode = activeIncludesArmlet ? 'average' : costMode;
+  const armletIsOnlyActiveSlot = activeSlots.length === 1 && activeSlots[0] === '완갑';
+
+  useEffect(() => {
+    if (armletIsOnlyActiveSlot) setCostMode('average');
+  }, [armletIsOnlyActiveSlot]);
 
   // ── 슬롯별 필터된 steps 캐시 ─────────────────
   const slotFilteredSteps = useMemo(() => {
@@ -500,7 +503,6 @@ const Enhancement: React.FC = () => {
           if (advLevel > 0) advMap['무기'] = advLevel;
         }
       }
-      if (map['완갑'] === undefined) map['완갑'] = 0;
       setArmorMap(map);
       setSlotIconMap(iconMap);
       setSlotInheritedMap(inheritedMap);
@@ -541,8 +543,9 @@ const Enhancement: React.FC = () => {
   const perSlotStepData = useMemo(() => {
     const result = new Map<SlotName, ReturnType<typeof calcStepData>>();
     slotFilteredSteps.forEach((steps, slot) => {
-      const data = calcStepData(steps, useBook, effectiveUseBreath, prices);
-      if (effectiveCostMode === 'ceiling') {
+      const useSlotBreath = slot !== '완갑' && useBreath;
+      const data = calcStepData(steps, useBook, useSlotBreath, prices);
+      if (costMode === 'ceiling' && slot !== '완갑') {
         result.set(slot, data.map((d) => ({
           ...d,
           exp: d.ceiling,
@@ -556,7 +559,7 @@ const Enhancement: React.FC = () => {
       }
     });
     return result;
-  }, [slotFilteredSteps, useBook, effectiveUseBreath, prices, effectiveCostMode]);
+  }, [slotFilteredSteps, useBook, useBreath, prices, costMode]);
 
   // ── 슬롯별 소계 ──────────────────────────────
   const slotTotals = useMemo(() => {
@@ -1048,32 +1051,30 @@ const Enhancement: React.FC = () => {
                   label={`책 ${useBook ? 'ON' : 'OFF'}`}
                   active={useBook}
                   color="gold"
-                  badge={hasPrices && isCheapest(true, effectiveUseBreath) && !useBook ? '최적' : undefined}
+                  badge={hasPrices && isCheapest(true, useBreath) && !useBook ? '최적' : undefined}
                   onClick={() => setUseBook((b) => !b)}
                 />
               )}
               <Toggle
-                label={`숨결 ${effectiveUseBreath ? 'ON' : 'OFF'}`}
-                active={effectiveUseBreath}
+                label={`숨결 ${useBreath ? 'ON' : 'OFF'}`}
+                active={useBreath}
                 color="blue"
-                badge={hasPrices && !activeIncludesArmlet && isCheapest(useBook, true) && !useBreath ? '최적' : undefined}
-                onClick={() => {
-                  if (!activeIncludesArmlet) setUseBreath((b) => !b);
-                }}
+                badge={hasPrices && isCheapest(useBook, true) && !useBreath ? '최적' : undefined}
+                onClick={() => setUseBreath((b) => !b)}
               />
               {hasPrices && (
                 <button
-                  onClick={() => { setUseBook(cheapest.useBook); setUseBreath(activeIncludesArmlet ? false : cheapest.useBreath); }}
+                  onClick={() => { setUseBook(cheapest.useBook); setUseBreath(cheapest.useBreath); }}
                   className="text-xs text-green-600 dark:text-green-400 underline underline-offset-2 hover:opacity-70"
                 >
-                  최적 세팅 (책 {cheapest.useBook ? 'ON' : 'OFF'} / 숨결 {activeIncludesArmlet ? 'OFF' : (cheapest.useBreath ? 'ON' : 'OFF')})
+                  최적 세팅 (책 {cheapest.useBook ? 'ON' : 'OFF'} / 숨결 {cheapest.useBreath ? 'ON' : 'OFF'})
                 </button>
               )}
               <div className="ml-auto inline-flex rounded-full border border-gray-200 dark:border-white/10 overflow-hidden text-xs font-medium">
                 <button
                   onClick={() => setCostMode('average')}
                   className={`px-3 py-1.5 transition-colors ${
-                    effectiveCostMode === 'average'
+                    costMode === 'average'
                       ? 'bg-la-gold/20 text-la-gold-dark dark:text-la-gold'
                       : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5'
                   }`}
@@ -1082,12 +1083,12 @@ const Enhancement: React.FC = () => {
                 </button>
                 <button
                   onClick={() => {
-                    if (!activeIncludesArmlet) setCostMode('ceiling');
+                    if (!armletIsOnlyActiveSlot) setCostMode('ceiling');
                   }}
-                  disabled={activeIncludesArmlet}
-                  title={activeIncludesArmlet ? '완갑은 평균 기대 비용만 지원합니다' : undefined}
+                  disabled={armletIsOnlyActiveSlot}
+                  title={armletIsOnlyActiveSlot ? '완갑은 평균 기대 비용만 지원합니다' : undefined}
                   className={`px-3 py-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
-                    effectiveCostMode === 'ceiling'
+                    costMode === 'ceiling'
                       ? 'bg-red-500/20 text-red-600 dark:text-red-400'
                       : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5'
                   }`}
@@ -1097,7 +1098,7 @@ const Enhancement: React.FC = () => {
               </div>
               {activeIncludesArmlet && (
                 <p className="mt-2 text-[11px] text-gray-400 dark:text-gray-500">
-                  완갑은 출처 표의 평균 기대 총합만 확인되어 숨결과 장기백 계산을 제외합니다.
+                  완갑은 출처 표의 평균 기대 총합을 사용하며, 숨결과 장기백 설정은 함께 선택한 다른 장비에만 적용됩니다.
                 </p>
               )}
             </div>

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -182,9 +182,8 @@ const findCheapest = (
   let bestGold = Infinity;
   for (const combo of combos) {
     const gold = steps.reduce((sum, step) => {
-      const effBook = combo.useBook && !!step.bookMaterial;
-      const exp = calcExpectedAttempts(step, effBook, combo.useBreath);
-      const mats = getAttemptMaterials(step, effBook, combo.useBreath);
+      const exp = calcExpectedAttempts(step, combo.useBook, combo.useBreath);
+      const mats = getAttemptMaterials(step, combo.useBook, combo.useBreath);
       const matGold = mats.reduce((s, m) => s + m.amount * (prices[m.type] ?? 0), 0) * exp;
       return sum + step.gold * exp + matGold;
     }, 0);
@@ -261,10 +260,9 @@ const calcStepData = (
   breath: boolean,
   priceMap: PriceMap,
 ) => steps.map((step) => {
-  const effBook = book && !!step.bookMaterial;
-  const exp = calcExpectedAttempts(step, effBook, breath);
-  const ceiling = getCeiling(step, effBook, breath);
-  const mats = getAttemptMaterials(step, effBook, breath);
+  const exp = calcExpectedAttempts(step, book, breath);
+  const ceiling = getCeiling(step, book, breath);
+  const mats = getAttemptMaterials(step, book, breath);
   const matGoldPerAttempt = mats.reduce((s, m) => s + m.amount * (priceMap[m.type] ?? 0), 0);
   const matGold = matGoldPerAttempt * exp;
   const directGold = step.gold * exp;
@@ -621,9 +619,8 @@ const Enhancement: React.FC = () => {
     const map = new Map<MaterialType, number>();
     slotFilteredSteps.forEach((steps) => {
       steps.forEach((step) => {
-        const effBook = !!step.bookMaterial;
-        const exp = calcExpectedAttempts(step, effBook, true);
-        const mats = getAttemptMaterials(step, effBook, true);
+        const exp = calcExpectedAttempts(step, true, true);
+        const mats = getAttemptMaterials(step, true, true);
         mats.forEach((m) => {
           map.set(m.type, (map.get(m.type) ?? 0) + m.amount * exp);
         });

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -425,12 +425,6 @@ const Enhancement: React.FC = () => {
     () => ALL_SLOTS.filter((s) => targetMap[s] != null && targetMap[s]! > slotCurrentLevel[s]),
     [targetMap, slotCurrentLevel],
   );
-  const activeIncludesArmlet = activeSlots.includes('완갑');
-  const armletIsOnlyActiveSlot = activeSlots.length === 1 && activeSlots[0] === '완갑';
-
-  useEffect(() => {
-    if (armletIsOnlyActiveSlot) setCostMode('average');
-  }, [armletIsOnlyActiveSlot]);
 
   // ── 슬롯별 필터된 steps 캐시 ─────────────────
   const slotFilteredSteps = useMemo(() => {
@@ -543,9 +537,8 @@ const Enhancement: React.FC = () => {
   const perSlotStepData = useMemo(() => {
     const result = new Map<SlotName, ReturnType<typeof calcStepData>>();
     slotFilteredSteps.forEach((steps, slot) => {
-      const useSlotBreath = slot !== '완갑' && useBreath;
-      const data = calcStepData(steps, useBook, useSlotBreath, prices);
-      if (costMode === 'ceiling' && slot !== '완갑') {
+      const data = calcStepData(steps, useBook, useBreath, prices);
+      if (costMode === 'ceiling') {
         result.set(slot, data.map((d) => ({
           ...d,
           exp: d.ceiling,
@@ -1082,12 +1075,8 @@ const Enhancement: React.FC = () => {
                   평균
                 </button>
                 <button
-                  onClick={() => {
-                    if (!armletIsOnlyActiveSlot) setCostMode('ceiling');
-                  }}
-                  disabled={armletIsOnlyActiveSlot}
-                  title={armletIsOnlyActiveSlot ? '완갑은 평균 기대 비용만 지원합니다' : undefined}
-                  className={`px-3 py-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                  onClick={() => setCostMode('ceiling')}
+                  className={`px-3 py-1.5 transition-colors ${
                     costMode === 'ceiling'
                       ? 'bg-red-500/20 text-red-600 dark:text-red-400'
                       : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5'
@@ -1096,11 +1085,6 @@ const Enhancement: React.FC = () => {
                   장기백
                 </button>
               </div>
-              {activeIncludesArmlet && (
-                <p className="mt-2 text-[11px] text-gray-400 dark:text-gray-500">
-                  완갑은 출처 표의 평균 기대 총합을 사용하며, 숨결과 장기백 설정은 함께 선택한 다른 장비에만 적용됩니다.
-                </p>
-              )}
             </div>
           </GlassCard>
         )}

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -14,6 +14,7 @@ import {
   AEGIR_WEAPON_STEPS,
   SERKA_ARMOR_STEPS,
   SERKA_WEAPON_STEPS,
+  ARMLET_STEPS,
   ADV_ARMOR_STAGES,
   ADV_WEAPON_STAGES,
   ADV_STAGE_XP,
@@ -33,9 +34,10 @@ import {
 
 const ARMOR_SLOTS = ['투구', '어깨', '상의', '하의', '장갑'] as const;
 type ArmorSlot = (typeof ARMOR_SLOTS)[number];
-type SlotName = '무기' | ArmorSlot;
+type SlotName = '무기' | ArmorSlot | '완갑';
 
-const ALL_SLOTS: SlotName[] = ['무기', '투구', '어깨', '상의', '하의', '장갑'];
+const ALL_SLOTS: SlotName[] = ['무기', '완갑', '투구', '어깨', '상의', '하의', '장갑'];
+const ITEM_LEVEL_SLOTS = ['무기', ...ARMOR_SLOTS] as const;
 
 const ITEM_LEVEL_PER_STEP = 5; // 일반 재련 1단계당 아이템 레벨 증가량
 
@@ -246,9 +248,12 @@ const findCheapestAdv = (
 };
 
 const getStepsForSlot = (slot: SlotName, isInherited: boolean) => {
+  if (slot === '완갑') return ARMLET_STEPS;
   if (slot === '무기') return isInherited ? SERKA_WEAPON_STEPS : AEGIR_WEAPON_STEPS;
   return isInherited ? SERKA_ARMOR_STEPS : AEGIR_ARMOR_STEPS;
 };
+
+const supportsAdvancedHoning = (slot: SlotName): boolean => slot !== '완갑';
 
 const calcStepData = (
   steps: typeof AEGIR_ARMOR_STEPS,
@@ -316,7 +321,7 @@ const Toggle: React.FC<{
 const Enhancement: React.FC = () => {
   // ── 캐릭터 검색 ─────────────────────────────
   const [charInput, setCharInput] = useState('');
-  const [armorMap, setArmorMap] = useState<Partial<Record<ArmorSlot, number>>>({});
+  const [armorMap, setArmorMap] = useState<Partial<Record<ArmorSlot | '완갑', number>>>({});
   const [weaponLevel, setWeaponLevel] = useState<number | undefined>(undefined);
   const [slotIconMap, setSlotIconMap] = useState<Partial<Record<SlotName, string>>>({});
   const [slotInheritedMap, setSlotInheritedMap] = useState<Partial<Record<SlotName, boolean>>>({});
@@ -397,6 +402,7 @@ const Enhancement: React.FC = () => {
   // ── 슬롯별 현재 레벨 ─────────────────────────
   const slotCurrentLevel = useMemo<Record<SlotName, number>>(() => ({
     '무기': weaponLevel ?? 10,
+    '완갑': armorMap['완갑'] ?? 0,
     '투구': armorMap['투구'] ?? 10,
     '어깨': armorMap['어깨'] ?? 10,
     '상의': armorMap['상의'] ?? 10,
@@ -406,6 +412,7 @@ const Enhancement: React.FC = () => {
 
   const slotHasData = useMemo<Record<SlotName, boolean>>(() => ({
     '무기': weaponLevel !== undefined,
+    '완갑': armorMap['완갑'] !== undefined,
     '투구': armorMap['투구'] !== undefined,
     '어깨': armorMap['어깨'] !== undefined,
     '상의': armorMap['상의'] !== undefined,
@@ -418,6 +425,9 @@ const Enhancement: React.FC = () => {
     () => ALL_SLOTS.filter((s) => targetMap[s] != null && targetMap[s]! > slotCurrentLevel[s]),
     [targetMap, slotCurrentLevel],
   );
+  const activeIncludesArmlet = activeSlots.includes('완갑');
+  const effectiveUseBreath = activeIncludesArmlet ? false : useBreath;
+  const effectiveCostMode = activeIncludesArmlet ? 'average' : costMode;
 
   // ── 슬롯별 필터된 steps 캐시 ─────────────────
   const slotFilteredSteps = useMemo(() => {
@@ -466,7 +476,7 @@ const Enhancement: React.FC = () => {
     setTargetMap({});
     try {
       const equipment = await fetchEquipment(name.trim());
-      const map: Partial<Record<ArmorSlot, number>> = {};
+      const map: Partial<Record<ArmorSlot | '완갑', number>> = {};
       const iconMap: Partial<Record<SlotName, string>> = {};
       const inheritedMap: Partial<Record<SlotName, boolean>> = {};
       const advMap: Partial<Record<SlotName, number>> = {};
@@ -478,6 +488,10 @@ const Enhancement: React.FC = () => {
           if (isInherited) inheritedMap[item.Type as ArmorSlot] = true;
           if (advLevel > 0) advMap[item.Type as ArmorSlot] = advLevel;
         }
+        if (item.Type === '완갑') {
+          map['완갑'] = parseEnhLevel(item.Name);
+          if (item.Icon) iconMap['완갑'] = item.Icon;
+        }
         if (item.Type === '무기') {
           setWeaponLevel(parseEnhLevel(item.Name));
           if (item.Icon) iconMap['무기'] = item.Icon;
@@ -486,6 +500,7 @@ const Enhancement: React.FC = () => {
           if (advLevel > 0) advMap['무기'] = advLevel;
         }
       }
+      if (map['완갑'] === undefined) map['완갑'] = 0;
       setArmorMap(map);
       setSlotIconMap(iconMap);
       setSlotInheritedMap(inheritedMap);
@@ -526,8 +541,8 @@ const Enhancement: React.FC = () => {
   const perSlotStepData = useMemo(() => {
     const result = new Map<SlotName, ReturnType<typeof calcStepData>>();
     slotFilteredSteps.forEach((steps, slot) => {
-      const data = calcStepData(steps, useBook, useBreath, prices);
-      if (costMode === 'ceiling') {
+      const data = calcStepData(steps, useBook, effectiveUseBreath, prices);
+      if (effectiveCostMode === 'ceiling') {
         result.set(slot, data.map((d) => ({
           ...d,
           exp: d.ceiling,
@@ -541,7 +556,7 @@ const Enhancement: React.FC = () => {
       }
     });
     return result;
-  }, [slotFilteredSteps, useBook, useBreath, prices, costMode]);
+  }, [slotFilteredSteps, useBook, effectiveUseBreath, prices, effectiveCostMode]);
 
   // ── 슬롯별 소계 ──────────────────────────────
   const slotTotals = useMemo(() => {
@@ -624,6 +639,7 @@ const Enhancement: React.FC = () => {
   // ── 상급 재련 활성 슬롯 ───────────────────────
   const activeAdvSlots = useMemo(
     () => ALL_SLOTS.filter((s) => {
+      if (!supportsAdvancedHoning(s)) return false;
       const target = advTargetMap[s];
       return target != null && target > (advLevelMap[s] ?? 0);
     }),
@@ -651,6 +667,7 @@ const Enhancement: React.FC = () => {
 
     // 일반 재련: 1강당 +5 아이템 레벨
     const normalIncrease = activeSlots.reduce((sum, slot) => {
+      if (!(ITEM_LEVEL_SLOTS as readonly string[]).includes(slot)) return sum;
       const steps = (targetMap[slot] ?? slotCurrentLevel[slot]) - slotCurrentLevel[slot];
       return sum + steps * ITEM_LEVEL_PER_STEP;
     }, 0);
@@ -806,7 +823,7 @@ const Enhancement: React.FC = () => {
   const hasOwnedInput = Object.values(ownedMaterials).some((v) => (v ?? 0) > 0);
   // 상급 재련 가능한 슬롯이 1개 이상 존재 (에기르이고 40단계 미만)
   const hasAnyAdvSlotAvailable = ALL_SLOTS.some(
-    (s) => slotHasData[s] && !slotInheritedMap[s] && (advLevelMap[s] ?? 0) < 40,
+    (s) => supportsAdvancedHoning(s) && slotHasData[s] && !slotInheritedMap[s] && (advLevelMap[s] ?? 0) < 40,
   );
 
   // ─────────────────────────────────────────────
@@ -855,7 +872,7 @@ const Enhancement: React.FC = () => {
           )}
 
           {/* 슬롯 카드 - 현재 강화 수치 표시 */}
-          <div className="grid grid-cols-2 sm:grid-cols-6 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-7 gap-2">
             {ALL_SLOTS.map((slot) => {
               const hasData = slotHasData[slot];
               const level = slotCurrentLevel[slot];
@@ -895,7 +912,7 @@ const Enhancement: React.FC = () => {
                   }`}>
                     {hasData ? `+${level}` : '—'}
                   </span>
-                  {!slotInheritedMap[slot] && hasData && (
+                  {supportsAdvancedHoning(slot) && !slotInheritedMap[slot] && hasData && (
                     <span className={`text-[10px] leading-none ${
                       advTargetMap[slot] != null
                         ? 'text-purple-500 dark:text-purple-400'
@@ -926,7 +943,7 @@ const Enhancement: React.FC = () => {
               }}
             />
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-6 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-7 gap-2">
             {ALL_SLOTS.map((slot) => {
               const currentLvl = slotCurrentLevel[slot];
               const targetOptions = Array.from({ length: 25 - currentLvl }, (_, i) => {
@@ -964,16 +981,16 @@ const Enhancement: React.FC = () => {
                     if (val === undefined) return;
                     const targetLevel = Number(val);
                     ALL_SLOTS.forEach((slot) => {
-                      if (!slotInheritedMap[slot] && (advLevelMap[slot] ?? 0) < targetLevel) {
+                      if (supportsAdvancedHoning(slot) && !slotInheritedMap[slot] && (advLevelMap[slot] ?? 0) < targetLevel) {
                         handleAdvTargetChange(slot, targetLevel);
                       }
                     });
                   }}
                 />
               </div>
-              <div className="grid grid-cols-2 sm:grid-cols-6 gap-2">
+              <div className="grid grid-cols-2 sm:grid-cols-7 gap-2">
                 {ALL_SLOTS.map((slot) => {
-                  if (slotInheritedMap[slot]) {
+                  if (!supportsAdvancedHoning(slot) || slotInheritedMap[slot]) {
                     return <div key={slot} />;
                   }
                   const currentAdv = advLevelMap[slot] ?? 0;
@@ -1031,30 +1048,32 @@ const Enhancement: React.FC = () => {
                   label={`책 ${useBook ? 'ON' : 'OFF'}`}
                   active={useBook}
                   color="gold"
-                  badge={hasPrices && isCheapest(true, useBreath) && !useBook ? '최적' : undefined}
+                  badge={hasPrices && isCheapest(true, effectiveUseBreath) && !useBook ? '최적' : undefined}
                   onClick={() => setUseBook((b) => !b)}
                 />
               )}
               <Toggle
-                label={`숨결 ${useBreath ? 'ON' : 'OFF'}`}
-                active={useBreath}
+                label={`숨결 ${effectiveUseBreath ? 'ON' : 'OFF'}`}
+                active={effectiveUseBreath}
                 color="blue"
-                badge={hasPrices && isCheapest(useBook, true) && !useBreath ? '최적' : undefined}
-                onClick={() => setUseBreath((b) => !b)}
+                badge={hasPrices && !activeIncludesArmlet && isCheapest(useBook, true) && !useBreath ? '최적' : undefined}
+                onClick={() => {
+                  if (!activeIncludesArmlet) setUseBreath((b) => !b);
+                }}
               />
               {hasPrices && (
                 <button
-                  onClick={() => { setUseBook(cheapest.useBook); setUseBreath(cheapest.useBreath); }}
+                  onClick={() => { setUseBook(cheapest.useBook); setUseBreath(activeIncludesArmlet ? false : cheapest.useBreath); }}
                   className="text-xs text-green-600 dark:text-green-400 underline underline-offset-2 hover:opacity-70"
                 >
-                  최적 세팅 (책 {cheapest.useBook ? 'ON' : 'OFF'} / 숨결 {cheapest.useBreath ? 'ON' : 'OFF'})
+                  최적 세팅 (책 {cheapest.useBook ? 'ON' : 'OFF'} / 숨결 {activeIncludesArmlet ? 'OFF' : (cheapest.useBreath ? 'ON' : 'OFF')})
                 </button>
               )}
               <div className="ml-auto inline-flex rounded-full border border-gray-200 dark:border-white/10 overflow-hidden text-xs font-medium">
                 <button
                   onClick={() => setCostMode('average')}
                   className={`px-3 py-1.5 transition-colors ${
-                    costMode === 'average'
+                    effectiveCostMode === 'average'
                       ? 'bg-la-gold/20 text-la-gold-dark dark:text-la-gold'
                       : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5'
                   }`}
@@ -1062,9 +1081,13 @@ const Enhancement: React.FC = () => {
                   평균
                 </button>
                 <button
-                  onClick={() => setCostMode('ceiling')}
-                  className={`px-3 py-1.5 transition-colors ${
-                    costMode === 'ceiling'
+                  onClick={() => {
+                    if (!activeIncludesArmlet) setCostMode('ceiling');
+                  }}
+                  disabled={activeIncludesArmlet}
+                  title={activeIncludesArmlet ? '완갑은 평균 기대 비용만 지원합니다' : undefined}
+                  className={`px-3 py-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                    effectiveCostMode === 'ceiling'
                       ? 'bg-red-500/20 text-red-600 dark:text-red-400'
                       : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5'
                   }`}
@@ -1072,6 +1095,11 @@ const Enhancement: React.FC = () => {
                   장기백
                 </button>
               </div>
+              {activeIncludesArmlet && (
+                <p className="mt-2 text-[11px] text-gray-400 dark:text-gray-500">
+                  완갑은 출처 표의 평균 기대 총합만 확인되어 숨결과 장기백 계산을 제외합니다.
+                </p>
+              )}
             </div>
           </GlassCard>
         )}

--- a/src/utils/characterEquipment.ts
+++ b/src/utils/characterEquipment.ts
@@ -1,0 +1,13 @@
+import type { EquipmentItem } from '../types/lostark';
+
+export const COMBAT_EQUIPMENT_TYPES: readonly string[] = ['무기', '완갑', '투구', '어깨', '상의', '하의', '장갑'];
+
+const findCombatEquipmentOrder = (item: EquipmentItem): number =>
+  COMBAT_EQUIPMENT_TYPES.findIndex((type) => item.Type.includes(type));
+
+export const isCombatEquipment = (item: EquipmentItem): boolean => findCombatEquipmentOrder(item) !== -1;
+
+export const getCombatEquipmentItems = (items: readonly EquipmentItem[]): EquipmentItem[] =>
+  items
+    .filter(isCombatEquipment)
+    .sort((left, right) => findCombatEquipmentOrder(left) - findCombatEquipmentOrder(right));

--- a/src/utils/equipmentState.test.ts
+++ b/src/utils/equipmentState.test.ts
@@ -46,21 +46,42 @@ describe('parseEquipmentState normal honing power tables', () => {
 
     expect(result.armlet).toMatchObject({
       slot: 'armlet',
-      normalLevel: 0,
+      normalLevel: -1,
       advancedLevel: 0,
       tier: '미착용',
     });
   });
 
-  it('parses armlet only at supported public simulation levels', () => {
+  it('parses equipped +0 armlet separately from unequipped', () => {
+    const state = parseEquipmentState(equipment('{}', {
+      Type: '완갑',
+      Name: '운명의 전율 완갑',
+      Icon: 'https://example.com/armlet0.png',
+      Grade: '영웅',
+    }));
+
+    expect(state?.normalLevel).toBe(0);
+    expect(state?.tier).toBe('영웅');
+    expect(state?.normalHoningDelta).toEqual({
+      kind: 'armlet',
+      weaponAttack: 3500,
+      mainStat: 10500,
+      baseAttack: 0,
+      baseAttackPercent: 0,
+    });
+  });
+
+  it('keeps the armlet API level and icon for display', () => {
     const supported = parseEquipmentState(equipment('{}', {
       Type: '완갑',
       Name: '+15 운명의 전용 완갑',
+      Icon: 'https://example.com/armlet15.png',
       Grade: '전설',
     }));
-    const unsupported = parseEquipmentState(equipment('{}', {
+    const intermediate = parseEquipmentState(equipment('{}', {
       Type: '완갑',
-      Name: '+13 운명의 전용 완갑',
+      Name: '+9 운명의 전율 완갑',
+      Icon: 'https://cdn-lostark.game.onstove.com/efui_iconatlas/bracer/bracer_2.png',
       Grade: '영웅',
     }));
 
@@ -74,8 +95,17 @@ describe('parseEquipmentState normal honing power tables', () => {
       baseAttack: 3690,
       baseAttackPercent: 1.0,
     });
-    expect(unsupported?.normalLevel).toBe(0);
-    expect(unsupported?.tier).toBe('미착용');
+    expect(supported?.raw.Icon).toBe('https://example.com/armlet15.png');
+    expect(intermediate?.normalLevel).toBe(9);
+    expect(intermediate?.tier).toBe('영웅');
+    expect(intermediate?.raw.Icon).toBe('https://cdn-lostark.game.onstove.com/efui_iconatlas/bracer/bracer_2.png');
+    expect(intermediate?.normalHoningDelta).toEqual({
+      kind: 'armlet',
+      weaponAttack: 10969,
+      mainStat: 34746,
+      baseAttack: 850,
+      baseAttackPercent: 0,
+    });
   });
 
   it('attaches Egir armor tooltip stat delta for the current normal level', () => {

--- a/src/utils/equipmentState.test.ts
+++ b/src/utils/equipmentState.test.ts
@@ -108,6 +108,25 @@ describe('parseEquipmentState normal honing power tables', () => {
     });
   });
 
+  it('attaches the lower combat baseline to unsupported armlet API levels', () => {
+    // Given
+    const state = parseEquipmentState(equipment('{}', {
+      Type: '완갑',
+      Name: '+13 운명의 전율 완갑',
+      Grade: '영웅',
+    }));
+
+    // When / Then
+    expect(state?.normalLevel).toBe(13);
+    expect(state?.normalHoningDelta).toEqual({
+      kind: 'armlet',
+      weaponAttack: 10969,
+      mainStat: 34746,
+      baseAttack: 2030,
+      baseAttackPercent: 0,
+    });
+  });
+
   it('attaches Egir armor tooltip stat delta for the current normal level', () => {
     const tooltip = JSON.stringify({
       Element_001: { value: { slotData: { petBorder: 3 } } },

--- a/src/utils/equipmentState.ts
+++ b/src/utils/equipmentState.ts
@@ -11,7 +11,7 @@ import {
   ARMLET_UNEQUIPPED_LEVEL,
   EQUIP_TYPE_TO_SLOT,
   extractEquipTier,
-  resolveArmletLevel,
+  resolveArmletCombatLevel,
   type EquipSlot,
 } from '../data/specScore/lopecCoefficients';
 
@@ -106,7 +106,7 @@ export const resolveNormalHoningDelta = (
   normalLevel: number,
 ): EquipmentNormalHoningDelta | undefined => {
   if (slot === 'armlet') {
-    const armletLevel = resolveArmletLevel(normalLevel);
+    const armletLevel = resolveArmletCombatLevel(normalLevel);
     if (armletLevel === null) return undefined;
     const power = ARMLET_POWER_BY_LEVEL[armletLevel];
     return {

--- a/src/utils/equipmentState.ts
+++ b/src/utils/equipmentState.ts
@@ -8,6 +8,7 @@ import {
 } from '../data/specScore/equipmentPowerTables';
 import {
   ARMLET_POWER_BY_LEVEL,
+  ARMLET_UNEQUIPPED_LEVEL,
   EQUIP_TYPE_TO_SLOT,
   extractEquipTier,
   resolveArmletLevel,
@@ -105,7 +106,9 @@ export const resolveNormalHoningDelta = (
   normalLevel: number,
 ): EquipmentNormalHoningDelta | undefined => {
   if (slot === 'armlet') {
-    const power = ARMLET_POWER_BY_LEVEL[resolveArmletLevel(normalLevel)];
+    const armletLevel = resolveArmletLevel(normalLevel);
+    if (armletLevel === null) return undefined;
+    const power = ARMLET_POWER_BY_LEVEL[armletLevel];
     return {
       kind: 'armlet',
       weaponAttack: power.weaponAttack,
@@ -143,13 +146,13 @@ export const parseEquipmentState = (item: EquipmentItem): EquipmentState | null 
   const isInherited = equipmentFamily === 'serka' && parseIsInherited(item.Tooltip);
 
   if (slot === 'armlet') {
-    const normalLevel = resolveArmletLevel(parsedNormalLevel);
+    const normalLevel = parsedNormalLevel;
     const normalHoningDelta = resolveNormalHoningDelta(slot, equipmentFamily, normalLevel);
     return {
       slot,
       normalLevel,
       advancedLevel: 0,
-      tier: ARMLET_POWER_BY_LEVEL[normalLevel].grade,
+      tier: normalLevel === ARMLET_UNEQUIPPED_LEVEL ? ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].grade : item.Grade,
       equipmentFamily,
       normalHoningDelta,
       isInherited,
@@ -172,19 +175,19 @@ export const parseEquipmentState = (item: EquipmentItem): EquipmentState | null 
   };
 };
 
-const createEmptyArmletState = (): EquipmentState => ({
+export const createEmptyArmletState = (): EquipmentState => ({
   slot: 'armlet',
-  normalLevel: 0,
+  normalLevel: ARMLET_UNEQUIPPED_LEVEL,
   advancedLevel: 0,
-  tier: ARMLET_POWER_BY_LEVEL[0].grade,
+  tier: ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].grade,
   equipmentFamily: 'egir',
-  normalHoningDelta: resolveNormalHoningDelta('armlet', 'egir', 0),
+  normalHoningDelta: resolveNormalHoningDelta('armlet', 'egir', ARMLET_UNEQUIPPED_LEVEL),
   isInherited: false,
   raw: {
     Type: '완갑',
-    Name: '+0 완갑 미착용',
-    Icon: ARMLET_POWER_BY_LEVEL[0].icon,
-    Grade: ARMLET_POWER_BY_LEVEL[0].grade,
+    Name: '완갑 미착용',
+    Icon: ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].icon,
+    Grade: ARMLET_POWER_BY_LEVEL[ARMLET_UNEQUIPPED_LEVEL].grade,
     Tooltip: '{}',
   },
 });

--- a/src/utils/lopecCombatPower.test.ts
+++ b/src/utils/lopecCombatPower.test.ts
@@ -1,6 +1,7 @@
 import { ARMLET_POWER_BY_LEVEL } from '../data/specScore/lopecCoefficients';
 import { findBraceletOption } from '../data/specScore/polishOptions';
 import { calcCombatPowerBreakdown, COMBAT_POWER_CONSTANT } from './lopecCombatPower';
+import { sumNormalHoningRawDeltas } from './lopecEquipmentDelta';
 import { calcLopecDelta } from './lopecSimulator';
 import { emptyGems, engravings, equipment } from './lopecSimulator.testUtils';
 import type { CharStats } from './lopecSimulator';
@@ -101,10 +102,10 @@ describe('calcCombatPowerBreakdown current snapshot', () => {
 
 
 describe('calcCombatPowerBreakdown armlet weapon attack', () => {
-  it('keeps unchanged armlet weapon attack in the simulated snapshot', () => {
+  it('keeps unsupported armlet levels on their combat baseline in the simulated snapshot', () => {
     // Given
-    const armletLevel = 25;
-    const armletPower = ARMLET_POWER_BY_LEVEL[armletLevel];
+    const armletLevel = 13;
+    const armletPower = ARMLET_POWER_BY_LEVEL[10];
     const weaponAttack = 230_000;
     const mainStat = 700_000;
     const displayedBaseAttack = (Math.sqrt((mainStat * (weaponAttack + armletPower.weaponAttack)) / 6) + armletPower.baseAttack) *
@@ -134,6 +135,27 @@ describe('calcCombatPowerBreakdown armlet weapon attack', () => {
     if (breakdown === null) throw new TypeError('Expected a combat-power breakdown');
     expect(breakdown.simulated.effectiveWeaponAttack).toBeCloseTo(breakdown.current.effectiveWeaponAttack, 6);
     expect(breakdown.simulatedCombatPower).toBeCloseTo(currentCombatPower, 6);
+  });
+
+  it('scores an unsupported-to-supported armlet step from the lower combat baseline', () => {
+    // Given
+    const currentEquip = { armlet: equipment('armlet', { normalLevel: 13 }) };
+    const modifiedEquip = { armlet: equipment('armlet', { normalLevel: 15 }) };
+
+    // When
+    const delta = sumNormalHoningRawDeltas({
+      slots: ['armlet'],
+      currentEquip,
+      modifiedEquip,
+    });
+
+    // Then
+    expect(delta).toEqual({
+      weaponAttack: ARMLET_POWER_BY_LEVEL[15].weaponAttack - ARMLET_POWER_BY_LEVEL[10].weaponAttack,
+      mainStat: ARMLET_POWER_BY_LEVEL[15].mainStat - ARMLET_POWER_BY_LEVEL[10].mainStat,
+      baseAttack: ARMLET_POWER_BY_LEVEL[15].baseAttack - ARMLET_POWER_BY_LEVEL[10].baseAttack,
+      baseAttackPercent: ARMLET_POWER_BY_LEVEL[15].baseAttackPercent - ARMLET_POWER_BY_LEVEL[10].baseAttackPercent,
+    });
   });
 });
 

--- a/src/utils/lopecCombatPower.ts
+++ b/src/utils/lopecCombatPower.ts
@@ -1,5 +1,5 @@
 import type { ArkGridData, EngravingData, GemData } from '../types/lostark';
-import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletCombatLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
 import type { AccessorySlot } from '../data/specScore/polishOptions';
 import type { EquipmentState } from './equipmentState';
 import type { AccessoryState, BraceletState } from './polishState';
@@ -42,14 +42,14 @@ const EQUIP_SLOTS: EquipSlot[] = ['weapon', 'helmet', 'shoulder', 'armor', 'pant
 const sumArmletBaseAttackPercent = (
   equipment: Partial<Record<EquipSlot, EquipmentState>> | undefined,
 ): number => {
-  const level = resolveArmletLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  const level = resolveArmletCombatLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
   return level === null ? 0 : ARMLET_POWER_BY_LEVEL[level].baseAttackPercent;
 };
 
 const sumArmletWeaponAttack = (
   equipment: Partial<Record<EquipSlot, EquipmentState>> | undefined,
 ): number => {
-  const level = resolveArmletLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  const level = resolveArmletCombatLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
   return level === null ? 0 : ARMLET_POWER_BY_LEVEL[level].weaponAttack;
 };
 

--- a/src/utils/lopecCombatPower.ts
+++ b/src/utils/lopecCombatPower.ts
@@ -1,5 +1,5 @@
 import type { ArkGridData, EngravingData, GemData } from '../types/lostark';
-import { ARMLET_POWER_BY_LEVEL, resolveArmletLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, ARMLET_UNEQUIPPED_LEVEL, resolveArmletLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
 import type { AccessorySlot } from '../data/specScore/polishOptions';
 import type { EquipmentState } from './equipmentState';
 import type { AccessoryState, BraceletState } from './polishState';
@@ -41,11 +41,17 @@ const EQUIP_SLOTS: EquipSlot[] = ['weapon', 'helmet', 'shoulder', 'armor', 'pant
 
 const sumArmletBaseAttackPercent = (
   equipment: Partial<Record<EquipSlot, EquipmentState>> | undefined,
-): number => ARMLET_POWER_BY_LEVEL[resolveArmletLevel(equipment?.armlet?.normalLevel ?? 0)].baseAttackPercent;
+): number => {
+  const level = resolveArmletLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  return level === null ? 0 : ARMLET_POWER_BY_LEVEL[level].baseAttackPercent;
+};
 
 const sumArmletWeaponAttack = (
   equipment: Partial<Record<EquipSlot, EquipmentState>> | undefined,
-): number => ARMLET_POWER_BY_LEVEL[resolveArmletLevel(equipment?.armlet?.normalLevel ?? 0)].weaponAttack;
+): number => {
+  const level = resolveArmletLevel(equipment?.armlet?.normalLevel ?? ARMLET_UNEQUIPPED_LEVEL);
+  return level === null ? 0 : ARMLET_POWER_BY_LEVEL[level].weaponAttack;
+};
 
 export interface BaseAttackSnapshot {
   readonly effectiveWeaponAttack: number;

--- a/src/utils/lopecEquipmentDelta.ts
+++ b/src/utils/lopecEquipmentDelta.ts
@@ -10,7 +10,10 @@ interface NormalHoningBaseStatDeltaInput {
   readonly charStats: CharStats | undefined;
 }
 
-const getArmletPower = (level: number) => ARMLET_POWER_BY_LEVEL[resolveArmletLevel(level)];
+const getArmletPower = (level: number) => {
+  const armletLevel = resolveArmletLevel(level);
+  return armletLevel === null ? null : ARMLET_POWER_BY_LEVEL[armletLevel];
+};
 
 /**
  * 주스탯 산출 우선순위 (docs/lostark-combat-power-research.md > Serka Equipment Status)
@@ -51,6 +54,9 @@ const sumNormalHoningStepDelta = (
   if (slot === 'armlet') {
     const from = getArmletPower(fromLevel);
     const to = getArmletPower(toLevel);
+    if (from === null || to === null) {
+      return { weaponAttack: 0, mainStat: 0, baseAttack: 0, secondaryStat: 0 };
+    }
     return {
       weaponAttack: to.weaponAttack - from.weaponAttack,
       mainStat: to.mainStat - from.mainStat,
@@ -111,7 +117,11 @@ export const sumNormalHoningRawDeltas = ({
     mainStat += delta.mainStat;
     baseAttack += delta.baseAttack;
     if (slot === 'armlet') {
-      baseAttackPercent += getArmletPower(mod.normalLevel).baseAttackPercent - getArmletPower(cur.normalLevel).baseAttackPercent;
+      const currentPower = getArmletPower(cur.normalLevel);
+      const modifiedPower = getArmletPower(mod.normalLevel);
+      if (currentPower !== null && modifiedPower !== null) {
+        baseAttackPercent += modifiedPower.baseAttackPercent - currentPower.baseAttackPercent;
+      }
     }
   }
   return { weaponAttack, mainStat, baseAttack, baseAttackPercent };

--- a/src/utils/lopecEquipmentDelta.ts
+++ b/src/utils/lopecEquipmentDelta.ts
@@ -1,4 +1,4 @@
-import { ARMLET_POWER_BY_LEVEL, resolveArmletLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
+import { ARMLET_POWER_BY_LEVEL, resolveArmletCombatLevel, type EquipSlot } from '../data/specScore/lopecCoefficients';
 import { resolveNormalHoningDelta, type EquipmentState } from './equipmentState';
 import { invertMainStat } from './lopecBaseAttack';
 import type { CharStats } from './lopecSimulator';
@@ -11,7 +11,7 @@ interface NormalHoningBaseStatDeltaInput {
 }
 
 const getArmletPower = (level: number) => {
-  const armletLevel = resolveArmletLevel(level);
+  const armletLevel = resolveArmletCombatLevel(level);
   return armletLevel === null ? null : ARMLET_POWER_BY_LEVEL[armletLevel];
 };
 

--- a/src/utils/lopecSimulator.equipment.test.ts
+++ b/src/utils/lopecSimulator.equipment.test.ts
@@ -90,7 +90,7 @@ describe('calcLopecDelta equipment API/table formula changes', () => {
     const currentScore = 100_000;
     const weaponAttack = 200_000;
     const mainStat = 900_000;
-    const current = equipment('armlet', { normalLevel: 0, tier: '미착용' });
+    const current = equipment('armlet', { normalLevel: -1, tier: '미착용' });
     const modified = { ...current, normalLevel: 10, tier: '영웅' };
 
     const result = calcLopecDelta(
@@ -107,6 +107,56 @@ describe('calcLopecDelta equipment API/table formula changes', () => {
     );
     const currentBaseAttack = Math.sqrt((weaponAttack * mainStat) / 6);
     const modifiedBaseAttack = Math.sqrt(((weaponAttack + 10969) * (mainStat + 34746)) / 6) + 2030;
+
+    expect(result).toBeCloseTo(currentScore * (modifiedBaseAttack / currentBaseAttack), 6);
+  });
+
+  it('applies equipped +0 armlet separately from unequipped armlet', () => {
+    const currentScore = 100_000;
+    const weaponAttack = 200_000;
+    const mainStat = 900_000;
+    const current = equipment('armlet', { normalLevel: -1, tier: '미착용' });
+    const modified = { ...current, normalLevel: 0, tier: '영웅' };
+
+    const result = calcLopecDelta(
+      currentScore,
+      engravings([]),
+      engravings([]),
+      emptyGems,
+      emptyGems,
+      { armlet: current },
+      { armlet: modified },
+      undefined,
+      undefined,
+      charStatsFor(weaponAttack, mainStat),
+    );
+    const currentBaseAttack = Math.sqrt((weaponAttack * mainStat) / 6);
+    const modifiedBaseAttack = Math.sqrt(((weaponAttack + 3500) * (mainStat + 10500)) / 6);
+
+    expect(result).toBeCloseTo(currentScore * (modifiedBaseAttack / currentBaseAttack), 6);
+  });
+
+  it('applies only the known flat base attack delta from +9 to +10 armlet', () => {
+    const currentScore = 100_000;
+    const weaponAttack = 200_000;
+    const mainStat = 900_000;
+    const current = equipment('armlet', { normalLevel: 9, tier: '영웅' });
+    const modified = { ...current, normalLevel: 10 };
+
+    const result = calcLopecDelta(
+      currentScore,
+      engravings([]),
+      engravings([]),
+      emptyGems,
+      emptyGems,
+      { armlet: current },
+      { armlet: modified },
+      undefined,
+      undefined,
+      charStatsFor(weaponAttack, mainStat),
+    );
+    const currentBaseAttack = Math.sqrt((weaponAttack * mainStat) / 6);
+    const modifiedBaseAttack = currentBaseAttack + 1180;
 
     expect(result).toBeCloseTo(currentScore * (modifiedBaseAttack / currentBaseAttack), 6);
   });


### PR DESCRIPTION
## intent
완갑 장비를 캐릭터 조회, 비교, 강화 계산, 스펙 시뮬레이터 표시/전투력 계산 흐름에 반영합니다.

## changes
- character/compare: 공통 전투 장비 순서에 완갑을 추가하고, 무기 다음 슬롯으로 표시되도록 정렬했습니다.
- enhancement: 완갑 일반 재련 기대 비용 테이블을 추가하고, 완갑은 상급 재련 및 평균 아이템 레벨 상승 계산에서 제외했습니다.
- spec-score: 미착용과 +0 착용을 분리하고, 확보된 완갑 +0~+10 계수로 전투력 계산을 보정했습니다.
- spec-simulator: API 완갑 강화 수치와 아이콘을 보존하고, 미착용/0 선택 상태를 UI와 접근성 라벨에서 구분했습니다.

## risk
surface: 완갑 강화/스펙 시뮬레이터 계산, 장비 표시 순서 | severity: medium | mitigation: 단계별 계수/파싱/delta regression tests 추가, 관련 화면 테스트 보강, build 통과

## verification
- [x] test: `yarn test --watchAll=false lopecCoefficients.test.ts equipmentState.test.ts lopecSimulator.equipment.test.ts lopecCombatPower.test.ts enhancement.test.ts Compare.test.tsx Character.test.tsx`
- [x] build: `yarn build`
- [x] lint-ish: `git diff --check`
- [x] review: local self-review lanes completed; blocking findings fixed before commit

## references
- Refs https://www.inven.co.kr/board/lostark/4821/110554
- Refs Lost Ark Open API equipment response shape for `Type: "완갑"`

## context
Lost Ark 신규 장비 타입인 완갑이 API에서 팔찌와 별도 장비로 내려오지만, 기존 UI/계산 흐름은 무기와 방어구 6슬롯 중심으로 구성되어 있었습니다.
특히 스펙 시뮬레이터에서는 완갑 중간 강화 단계가 sparse milestone table에 없는 값이면 미착용처럼 계산되는 문제가 있었습니다.
이번 PR은 화면 표시와 계산 입력을 분리해, 실제 장착 상태와 검증된 계수 범위를 명시적으로 다룹니다.

## alternatives
- 완갑을 기존 팔찌 처리에 합치는 방식: API 타입과 게임 내 의미가 달라 폐기했습니다.
- 미확보 강화 단계 값을 보간하는 방식: 전투력 계산 정확도를 해칠 수 있어 폐기했습니다.
- 미착용을 0강으로 유지하는 방식: 실제 +0 착용 완갑에 무기 공격력/주스탯이 있어 폐기했습니다.

## breaking-changes
none — rationale: 외부 API, route, persisted schema 변경 없이 내부 장비 파싱/계산/표시만 확장합니다.

## migration
none — rationale: 배포 후 기존 사용자 데이터나 환경변수 변경 없이 새 코드 경로가 API 응답을 재파싱합니다.

## rollback
procedure: 이 PR의 6개 커밋을 revert하면 기존 완갑 미지원 상태로 돌아갑니다.
data-loss: none — 코드/정적 데이터 변경만 포함합니다.
caveat: rollback 시 완갑 장착 캐릭터는 다시 기존 슬롯/계산 흐름에서 누락됩니다.

## monitoring
- 스펙 시뮬레이터에서 완갑 +0~+10 캐릭터의 전투력 delta가 예상보다 크게 튀는지 확인합니다.
- 강화 페이지에서 완갑 포함 시 숨결/장기백이 평균 비용 안내로 제한되는지 확인합니다.
- 배포 후 Vercel build/test status와 브라우저 console error를 확인합니다.

## scope
- `src/pages/Character.tsx`, `src/pages/Compare.tsx`, `src/pages/Enhancement.tsx`
- `src/components/simulation/*`
- `src/data/specScore/lopecCoefficients.ts`, `src/data/enhancement.ts`
- `src/utils/equipmentState.ts`, `src/utils/lopec*`

## followups
- 완갑 +16~+19, +22~+24 정확 계수가 확보되면 계수 테이블과 선택지를 확장합니다.
- 완갑 장기백/숨결 공식이 확인되면 강화 페이지의 해당 모드를 다시 활성화합니다.
