### PR TITLE
모바일 UI 상태와 피드백 개선

### DIFF
--- a/src/components/FallbackImage.test.tsx
+++ b/src/components/FallbackImage.test.tsx
@@ -30,7 +30,24 @@ describe('FallbackImage', () => {
 
     expect(screen.queryByRole('img', { name: '테스트 레이드' })).not.toBeInTheDocument();
     expect(screen.getByRole('img', { name: '테스트 레이드 이미지 없음' })).toBeInTheDocument();
-    expect(screen.getByText('이미지를 불러올 수 없습니다')).toBeInTheDocument();
+    expect(screen.getByText('테스트 레이드 이미지 없음')).toBeInTheDocument();
+  });
+
+  it('uses the custom fallback label as the fallback accessible name', () => {
+    render(
+      <FallbackImage
+        src="/images/missing.webp"
+        alt="테스트 레이드"
+        fallbackLabel="비아키스 레이드 이미지 없음"
+        width={480}
+        height={224}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: '테스트 레이드' }));
+
+    expect(screen.getByRole('img', { name: '비아키스 레이드 이미지 없음' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: '테스트 레이드 이미지 없음' })).not.toBeInTheDocument();
   });
 
   it('does not force fallback dimensions from image width and height props', () => {

--- a/src/components/FallbackImage.test.tsx
+++ b/src/components/FallbackImage.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import FallbackImage from './FallbackImage';
+
+describe('FallbackImage', () => {
+  it('keeps the accessible image when loading succeeds', () => {
+    render(
+      <FallbackImage
+        src="/images/character.webp"
+        alt="테스트 캐릭터"
+        width={128}
+        height={128}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: '테스트 캐릭터' }))
+      .toHaveAttribute('src', '/images/character.webp');
+  });
+
+  it('replaces a failed image with an intentional fallback', () => {
+    render(
+      <FallbackImage
+        src="/images/missing.webp"
+        alt="테스트 레이드"
+        width={480}
+        height={224}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: '테스트 레이드' }));
+
+    expect(screen.queryByRole('img', { name: '테스트 레이드' })).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '테스트 레이드 이미지 없음' })).toBeInTheDocument();
+    expect(screen.getByText('이미지를 불러올 수 없습니다')).toBeInTheDocument();
+  });
+
+  it('does not force fallback dimensions from image width and height props', () => {
+    render(
+      <FallbackImage
+        src="/images/missing.webp"
+        alt="좁은 카드"
+        width={480}
+        height={224}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: '좁은 카드' }));
+
+    const fallback = screen.getByRole('img', { name: '좁은 카드 이미지 없음' });
+    expect(fallback).not.toHaveStyle({ width: '480px', height: '224px' });
+  });
+});

--- a/src/components/FallbackImage.tsx
+++ b/src/components/FallbackImage.tsx
@@ -14,7 +14,7 @@ export const FallbackImage: React.FC<FallbackImageProps> = ({
   src,
   alt,
   className,
-  fallbackLabel = '이미지를 불러올 수 없습니다',
+  fallbackLabel,
   fallbackClassName,
   height,
   onError,
@@ -24,12 +24,13 @@ export const FallbackImage: React.FC<FallbackImageProps> = ({
 }) => {
   const [failedSource, setFailedSource] = useState<string | null>(null);
   const showsFallback = !src || failedSource === src;
+  const resolvedFallbackLabel = fallbackLabel ?? `${alt} 이미지 없음`;
 
   if (showsFallback) {
     return (
       <div
         role="img"
-        aria-label={`${alt} 이미지 없음`}
+        aria-label={resolvedFallbackLabel}
         className={joinClassNames(
           'flex h-full w-full items-center justify-center bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-gray-500',
           className,
@@ -51,7 +52,7 @@ export const FallbackImage: React.FC<FallbackImageProps> = ({
             d="M3 16.5V6.75A2.25 2.25 0 015.25 4.5h13.5A2.25 2.25 0 0121 6.75v10.5a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 17.25v-.75zm0 0l4.72-4.72a2.25 2.25 0 013.18 0l2.1 2.1m0 0l1.47-1.47a2.25 2.25 0 013.18 0L21 15.75M14.25 8.25h.008v.008h-.008V8.25z"
           />
         </svg>
-        <span className="sr-only">{fallbackLabel}</span>
+        <span className="sr-only">{resolvedFallbackLabel}</span>
       </div>
     );
   }

--- a/src/components/FallbackImage.tsx
+++ b/src/components/FallbackImage.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+
+interface FallbackImageProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'alt' | 'src'> {
+  readonly src?: string | null;
+  readonly alt: string;
+  readonly fallbackLabel?: string;
+  readonly fallbackClassName?: string;
+}
+
+const joinClassNames = (...classes: Array<string | undefined>): string =>
+  classes.filter(Boolean).join(' ');
+
+export const FallbackImage: React.FC<FallbackImageProps> = ({
+  src,
+  alt,
+  className,
+  fallbackLabel = '이미지를 불러올 수 없습니다',
+  fallbackClassName,
+  height,
+  onError,
+  style,
+  width,
+  ...imageProps
+}) => {
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  const showsFallback = !src || failedSource === src;
+
+  if (showsFallback) {
+    return (
+      <div
+        role="img"
+        aria-label={`${alt} 이미지 없음`}
+        className={joinClassNames(
+          'flex h-full w-full items-center justify-center bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-gray-500',
+          className,
+          fallbackClassName,
+        )}
+        style={style}
+      >
+        <svg
+          aria-hidden="true"
+          className="h-1/3 w-1/3 min-h-5 min-w-5 max-h-10 max-w-10"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5V6.75A2.25 2.25 0 015.25 4.5h13.5A2.25 2.25 0 0121 6.75v10.5a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 17.25v-.75zm0 0l4.72-4.72a2.25 2.25 0 013.18 0l2.1 2.1m0 0l1.47-1.47a2.25 2.25 0 013.18 0L21 15.75M14.25 8.25h.008v.008h-.008V8.25z"
+          />
+        </svg>
+        <span className="sr-only">{fallbackLabel}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      {...imageProps}
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+      style={style}
+      onError={(event) => {
+        onError?.(event);
+        setFailedSource(src);
+      }}
+    />
+  );
+};
+
+export default FallbackImage;

--- a/src/components/NavBar.test.tsx
+++ b/src/components/NavBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 jest.mock(
@@ -30,6 +30,11 @@ const renderNavBar = () =>
 beforeEach(() => {
   // NavBar가 ChangelogBell을 통해 읽음 상태를 읽으므로 테스트 간 저장소를 격리한다.
   window.localStorage.clear();
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 390,
+  });
 });
 
 test('renders the changelog bell in the header', () => {
@@ -42,12 +47,26 @@ test('theme toggle button switches label and root class on click', async () => {
   renderNavBar();
 
   const toggleButton = screen.getByRole('button', { name: '라이트 모드로 전환' });
+  expect(toggleButton).toHaveAttribute('title', '라이트 모드로 전환');
   expect(document.documentElement).toHaveClass('dark');
 
   await userEvent.click(toggleButton);
 
   expect(document.documentElement).not.toHaveClass('dark');
   expect(screen.getByRole('button', { name: '다크 모드로 전환' })).toBeInTheDocument();
+});
+
+test('mobile menu groups links and describes the current theme without adding a focus stop', async () => {
+  renderNavBar();
+
+  await userEvent.click(screen.getByRole('button', { name: '메뉴 열기' }));
+
+  const panel = screen.getByRole('dialog', { name: '모바일 메뉴' });
+  expect(panel).toHaveTextContent('주요 메뉴');
+  expect(panel).toHaveTextContent('기타 메뉴');
+  expect(screen.getByRole('status', { name: '현재 화면 테마' })).toHaveTextContent('다크 모드');
+  expect(panel.querySelectorAll('button')).toHaveLength(1);
+  expect(panel.querySelector('button')).toHaveAccessibleName('모바일 메뉴 닫기');
 });
 
 test('mobile menu opens as an overlay with a scrim and closes on scrim click', async () => {
@@ -75,7 +94,7 @@ test('mobile menu closes on Escape key', async () => {
   expect(document.getElementById('navbar-mobile-menu')).not.toBeInTheDocument();
 });
 
-test('mobile menu hides background content from assistive tech and restores focus on close', async () => {
+test('mobile menu has an in-dialog close control and restores focus on close', async () => {
   const root = document.createElement('div');
   root.id = 'root';
   document.body.appendChild(root);
@@ -91,7 +110,9 @@ test('mobile menu hides background content from assistive tech and restores focu
   expect(panel).toHaveAttribute('aria-modal', 'true');
   expect(document.activeElement).toBe(panel?.querySelector('a'));
 
-  await userEvent.keyboard('{Escape}');
+  const closeButton = screen.getByRole('button', { name: '모바일 메뉴 닫기' });
+  expect(panel).toContainElement(closeButton);
+  await userEvent.click(closeButton);
 
   expect(root).not.toHaveAttribute('aria-hidden');
   expect(document.activeElement).toBe(screen.getByRole('button', { name: '메뉴 열기' }));
@@ -105,9 +126,9 @@ test('Tab wraps focus inside the open mobile menu', async () => {
   await userEvent.click(screen.getByRole('button', { name: '메뉴 열기' }));
 
   const panel = document.getElementById('navbar-mobile-menu') as HTMLElement;
-  const links = panel.querySelectorAll('a');
-  const first = links[0];
-  const last = links[links.length - 1];
+  const focusables = panel.querySelectorAll('a, button');
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
 
   expect(document.activeElement).toBe(first);
 
@@ -116,4 +137,40 @@ test('Tab wraps focus inside the open mobile menu', async () => {
 
   await userEvent.tab();
   expect(document.activeElement).toBe(first);
+});
+
+test('mobile menu closes and restores page state after resizing to desktop', async () => {
+  const root = document.createElement('div');
+  root.id = 'root';
+  document.body.appendChild(root);
+
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 390,
+  });
+
+  renderNavBar();
+  const visibleThemeButton = screen.getByRole('button', { name: /모드로 전환/ });
+  await userEvent.click(screen.getByRole('button', { name: '메뉴 열기' }));
+
+  expect(document.getElementById('navbar-mobile-menu')).toBeInTheDocument();
+  expect(root).toHaveAttribute('aria-hidden', 'true');
+  expect(document.body.style.overflow).toBe('hidden');
+
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 1024,
+  });
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  expect(document.getElementById('navbar-mobile-menu')).not.toBeInTheDocument();
+  expect(root).not.toHaveAttribute('aria-hidden');
+  expect(document.body.style.overflow).toBe('');
+  expect(document.activeElement).toBe(visibleThemeButton);
+
+  document.body.removeChild(root);
 });

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
 import ChangelogBell from './ChangelogBell';
+import { getNavItemClass, MORE_NAV_LINKS, NavLinks, PRIMARY_NAV_LINKS } from './nav/NavLinks';
 
 const NavBar: React.FC = () => {
   const { pathname } = useLocation();
@@ -12,13 +13,32 @@ const NavBar: React.FC = () => {
   const [moreMenuPosition, setMoreMenuPosition] = useState<{ top: number; right: number } | null>(null);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const moreMenuRef = useRef<HTMLDivElement>(null);
+  const themeButtonRef = useRef<HTMLButtonElement>(null);
   const mobileMenuButtonRef = useRef<HTMLButtonElement>(null);
   const mobileMenuPanelRef = useRef<HTMLDivElement>(null);
+  const restoreMobileMenuFocusRef = useRef<'trigger' | 'desktop'>('trigger');
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
     setIsMoreMenuOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    if (!isMobileMenuOpen) return;
+
+    const closeOnDesktopResize = () => {
+      if (window.innerWidth < 768) return;
+      restoreMobileMenuFocusRef.current = 'desktop';
+      setIsMobileMenuOpen(false);
+    };
+
+    closeOnDesktopResize();
+    window.addEventListener('resize', closeOnDesktopResize);
+
+    return () => {
+      window.removeEventListener('resize', closeOnDesktopResize);
+    };
+  }, [isMobileMenuOpen]);
 
   useEffect(() => {
     if (!isMobileMenuOpen) return;
@@ -65,6 +85,7 @@ const NavBar: React.FC = () => {
     document.addEventListener('keydown', handleKeyDown);
 
     const toggleButton = mobileMenuButtonRef.current;
+    const themeButton = themeButtonRef.current;
 
     return () => {
       document.body.style.position = previousBodyPosition;
@@ -74,7 +95,12 @@ const NavBar: React.FC = () => {
       root?.removeAttribute('aria-hidden');
       document.removeEventListener('keydown', handleKeyDown);
       window.scrollTo(0, scrollY);
-      toggleButton?.focus();
+      if (restoreMobileMenuFocusRef.current === 'desktop') {
+        themeButton?.focus();
+        restoreMobileMenuFocusRef.current = 'trigger';
+      } else {
+        toggleButton?.focus();
+      }
     };
   }, [isMobileMenuOpen]);
 
@@ -123,57 +149,10 @@ const NavBar: React.FC = () => {
     };
   }, [isMoreMenuOpen]);
 
-  const linkClass = (path: string) =>
-    `px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 inline-flex items-center gap-1.5 ${
-      pathname === path
-        ? 'bg-la-gold/20 text-la-gold-dark dark:text-la-gold'
-        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/5'
-    }`;
+  const isMoreActive = MORE_NAV_LINKS.some((link) => link.path === pathname);
+  const moreButtonClass = getNavItemClass(isMoreActive);
 
-  const morePaths = ['/expedition', '/spending'];
-  const isMoreActive = morePaths.includes(pathname);
-  const moreButtonClass = `px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 inline-flex items-center gap-1.5 ${
-    isMoreActive
-      ? 'bg-la-gold/20 text-la-gold-dark dark:text-la-gold'
-      : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/5'
-  }`;
-
-  const primaryLinks = (
-    <>
-      <Link to="/" className={linkClass('/')}>
-        홈
-      </Link>
-      <Link to="/simulation" className={linkClass('/simulation')}>
-        주간골드
-      </Link>
-      <Link to="/enhancement" className={linkClass('/enhancement')}>
-        재련견적
-      </Link>
-      <Link to="/market" className={linkClass('/market')}>
-        시세
-      </Link>
-      <Link to="/compare" className={linkClass('/compare')}>
-        비교
-      </Link>
-      <Link to="/character" className={linkClass('/character')}>
-        캐릭터
-      </Link>
-      <Link to="/spec-simulator" className={linkClass('/spec-simulator')}>
-        전투력 시뮬
-      </Link>
-    </>
-  );
-
-  const moreLinks = (
-    <>
-      <Link to="/expedition" className={linkClass('/expedition')}>
-        원정대
-      </Link>
-      <Link to="/spending" className={linkClass('/spending')}>
-        결제 내역
-      </Link>
-    </>
-  );
+  const themeToggleLabel = isDarkMode ? '라이트 모드로 전환' : '다크 모드로 전환';
 
   const mobileMenu = isMobileMenuOpen && typeof document !== 'undefined'
     ? createPortal(
@@ -192,12 +171,39 @@ const NavBar: React.FC = () => {
             aria-label="모바일 메뉴"
             className="fixed inset-x-0 top-14 z-50 max-h-[calc(100dvh-3.5rem)] overflow-y-auto border-t border-gray-200/50 bg-white px-4 pb-4 shadow-lg shadow-black/10 dark:border-white/5 dark:bg-la-dark dark:shadow-black/30"
           >
-            <div className="flex flex-col gap-2 pt-3">
-              {primaryLinks}
-              <div className={`px-3 pt-2 text-xs font-bold uppercase tracking-wide ${isMoreActive ? 'text-la-gold-dark dark:text-la-gold' : 'text-gray-400 dark:text-gray-500'}`}>
-                더보기
+            <div className="flex flex-col gap-3 pt-3">
+              <section aria-labelledby="mobile-primary-links-title" className="rounded-xl bg-gray-50/80 p-2 dark:bg-white/5">
+                <h2 id="mobile-primary-links-title" className="px-3 pb-1 text-xs font-bold tracking-wide text-gray-400 dark:text-gray-500">
+                  주요 메뉴
+                </h2>
+                <div className="flex flex-col gap-1">
+                  <NavLinks links={PRIMARY_NAV_LINKS} pathname={pathname} />
+                </div>
+              </section>
+              <section aria-labelledby="mobile-more-links-title" className="rounded-xl bg-gray-50/80 p-2 dark:bg-white/5">
+                <h2 id="mobile-more-links-title" className={`px-3 pb-1 text-xs font-bold tracking-wide ${isMoreActive ? 'text-la-gold-dark dark:text-la-gold' : 'text-gray-400 dark:text-gray-500'}`}>
+                  기타 메뉴
+                </h2>
+                <div className="flex flex-col gap-1">
+                  <NavLinks links={MORE_NAV_LINKS} pathname={pathname} />
+                </div>
+              </section>
+              <div
+                role="status"
+                aria-label="현재 화면 테마"
+                className="flex items-center justify-between rounded-xl border border-gray-200/60 px-4 py-3 text-xs dark:border-white/10"
+              >
+                <span className="font-medium text-gray-500 dark:text-gray-400">현재 테마</span>
+                <span className="font-bold text-gray-900 dark:text-white">{isDarkMode ? '다크 모드' : '라이트 모드'}</span>
               </div>
-              {moreLinks}
+              <button
+                type="button"
+                aria-label="모바일 메뉴 닫기"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="inline-flex h-10 items-center justify-center rounded-lg text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                닫기
+              </button>
             </div>
           </div>
         </div>,
@@ -217,7 +223,7 @@ const NavBar: React.FC = () => {
           }}
         >
           <div className="flex flex-col gap-1">
-            {moreLinks}
+            <NavLinks links={MORE_NAV_LINKS} pathname={pathname} />
           </div>
         </div>,
         document.body
@@ -232,7 +238,7 @@ const NavBar: React.FC = () => {
           Lokki
         </Link>
         <div className="hidden md:flex items-center gap-2">
-          {primaryLinks}
+          <NavLinks links={PRIMARY_NAV_LINKS} pathname={pathname} />
           <div className="relative">
             <button
               ref={moreButtonRef}
@@ -252,10 +258,12 @@ const NavBar: React.FC = () => {
         <div className="flex items-center gap-1">
           <ChangelogBell />
           <button
+            ref={themeButtonRef}
             type="button"
             onClick={toggleDarkMode}
             className="inline-flex items-center justify-center w-10 h-10 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-300 dark:hover:text-white dark:hover:bg-white/10 transition-colors"
-            aria-label={isDarkMode ? '라이트 모드로 전환' : '다크 모드로 전환'}
+            aria-label={themeToggleLabel}
+            title={themeToggleLabel}
           >
             {isDarkMode ? (
               <svg className="w-5 h-5 text-la-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import ChangelogBell from './ChangelogBell';
 import { getNavItemClass, MORE_NAV_LINKS, NavLinks, PRIMARY_NAV_LINKS } from './nav/NavLinks';
 
@@ -17,6 +18,8 @@ const NavBar: React.FC = () => {
   const mobileMenuButtonRef = useRef<HTMLButtonElement>(null);
   const mobileMenuPanelRef = useRef<HTMLDivElement>(null);
   const restoreMobileMenuFocusRef = useRef<'trigger' | 'desktop'>('trigger');
+
+  useBodyScrollLock(isMobileMenuOpen);
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
@@ -42,20 +45,6 @@ const NavBar: React.FC = () => {
 
   useEffect(() => {
     if (!isMobileMenuOpen) return;
-
-    const scrollY = window.scrollY;
-    const root = document.getElementById('root');
-    const previousBodyPosition = document.body.style.position;
-    const previousBodyTop = document.body.style.top;
-    const previousBodyWidth = document.body.style.width;
-    const previousBodyOverflow = document.body.style.overflow;
-
-    // iOS Safari는 overflow: hidden만으로는 배경 터치 스크롤(러버밴드)을 막지 못해 position: fixed로 고정한다.
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${scrollY}px`;
-    document.body.style.width = '100%';
-    document.body.style.overflow = 'hidden';
-    root?.setAttribute('aria-hidden', 'true');
 
     const focusableSelector = 'a[href], button:not([disabled])';
     const panel = mobileMenuPanelRef.current;
@@ -88,13 +77,7 @@ const NavBar: React.FC = () => {
     const themeButton = themeButtonRef.current;
 
     return () => {
-      document.body.style.position = previousBodyPosition;
-      document.body.style.top = previousBodyTop;
-      document.body.style.width = previousBodyWidth;
-      document.body.style.overflow = previousBodyOverflow;
-      root?.removeAttribute('aria-hidden');
       document.removeEventListener('keydown', handleKeyDown);
-      window.scrollTo(0, scrollY);
       if (restoreMobileMenuFocusRef.current === 'desktop') {
         themeButton?.focus();
         restoreMobileMenuFocusRef.current = 'trigger';

--- a/src/components/SelectMenu.test.tsx
+++ b/src/components/SelectMenu.test.tsx
@@ -1,0 +1,218 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SelectMenu from './SelectMenu';
+
+const options = [
+  { value: 1, label: '첫 번째' },
+  { value: 2, label: '두 번째' },
+  { value: 3, label: '선택 불가', disabled: true },
+];
+
+const setViewportWidth = (width: number): void => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+};
+
+beforeEach(() => {
+  setViewportWidth(1024);
+  document.body.style.overflow = '';
+});
+
+afterEach(() => {
+  document.body.style.overflow = '';
+});
+
+describe('SelectMenu', () => {
+  it('opens and selects an enabled desktop option', async () => {
+    const onChange = jest.fn((_value: string | number | undefined): void => undefined);
+
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={onChange}
+        ariaLabel="강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+    expect(screen.getByRole('listbox', { name: '강화 단계' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('option', { name: '두 번째' }));
+
+    expect(onChange).toHaveBeenCalledWith(2);
+    expect(screen.queryByRole('listbox', { name: '강화 단계' })).not.toBeInTheDocument();
+  });
+
+
+  it('uses the current viewport presentation after resizing while closed', async () => {
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={jest.fn()}
+        ariaLabel="강화 단계"
+        panelTitle="목표 강화 단계"
+      />,
+    );
+
+    setViewportWidth(390);
+    fireEvent(window, new Event('resize'));
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    expect(screen.getByRole('dialog', { name: '목표 강화 단계' })).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    setViewportWidth(1024);
+    fireEvent(window, new Event('resize'));
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    expect(screen.queryByRole('dialog', { name: '목표 강화 단계' })).not.toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '강화 단계' })).toBeInTheDocument();
+  });
+
+  it('closes an open menu with Escape without changing the value', async () => {
+    const onChange = jest.fn((_value: string | number | undefined): void => undefined);
+
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={onChange}
+        ariaLabel="강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox', { name: '강화 단계' })).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the menu open when a disabled option is pressed', async () => {
+    const onChange = jest.fn((_value: string | number | undefined): void => undefined);
+
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={onChange}
+        ariaLabel="강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+    await userEvent.click(screen.getByRole('option', { name: '선택 불가' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('listbox', { name: '강화 단계' })).toBeInTheDocument();
+  });
+
+  it('focuses the selected enabled mobile option and restores body scroll after selection', async () => {
+    setViewportWidth(390);
+    const onChange = jest.fn((_value: string | number | undefined): void => undefined);
+
+    render(
+      <SelectMenu
+        value={2}
+        options={options}
+        onChange={onChange}
+        ariaLabel="강화 단계"
+        panelTitle="목표 강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    expect(screen.getByRole('dialog', { name: '목표 강화 단계' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '목표 강화 단계 닫기' })).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.activeElement).toBe(screen.getByRole('option', { name: '두 번째' }));
+
+    await userEvent.click(screen.getByRole('option', { name: '첫 번째' }));
+
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(screen.queryByRole('dialog', { name: '목표 강화 단계' })).not.toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('');
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '강화 단계' }));
+  });
+
+  it('focuses the mobile close action when no option is enabled', async () => {
+    setViewportWidth(390);
+
+    render(
+      <SelectMenu
+        value={3}
+        options={[{ value: 3, label: '선택 불가', disabled: true }]}
+        onChange={jest.fn()}
+        ariaLabel="강화 단계"
+        panelTitle="목표 강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '목표 강화 단계 닫기' }));
+  });
+
+  it('traps Tab inside the mobile sheet and isolates the background', async () => {
+    setViewportWidth(390);
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={jest.fn()}
+        ariaLabel="강화 단계"
+        panelTitle="목표 강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    const firstOption = screen.getByRole('option', { name: '첫 번째' });
+    const closeButton = screen.getByRole('button', { name: '목표 강화 단계 닫기' });
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(document.activeElement).toBe(firstOption);
+
+    await userEvent.tab({ shift: true });
+    expect(document.activeElement).toBe(closeButton);
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(firstOption);
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog', { name: '목표 강화 단계' })).not.toBeInTheDocument();
+    expect(root).not.toHaveAttribute('aria-hidden');
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '강화 단계' }));
+
+    document.body.removeChild(root);
+  });
+
+  it('closes the mobile sheet from its explicit close action', async () => {
+    setViewportWidth(390);
+
+    render(
+      <SelectMenu
+        options={options}
+        onChange={jest.fn()}
+        ariaLabel="강화 단계"
+        panelTitle="목표 강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+    expect(document.activeElement).toBe(screen.getByRole('option', { name: '첫 번째' }));
+    await userEvent.click(screen.getByRole('button', { name: '목표 강화 단계 닫기' }));
+
+    expect(screen.queryByRole('dialog', { name: '목표 강화 단계' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SelectMenu.test.tsx
+++ b/src/components/SelectMenu.test.tsx
@@ -74,6 +74,40 @@ describe('SelectMenu', () => {
     expect(screen.getByRole('listbox', { name: '강화 단계' })).toBeInTheDocument();
   });
 
+  it('moves focus through enabled options with listbox navigation keys', async () => {
+    render(
+      <SelectMenu
+        value={1}
+        options={options}
+        onChange={jest.fn()}
+        ariaLabel="강화 단계"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '강화 단계' }));
+
+    const firstOption = screen.getByRole('option', { name: '첫 번째' });
+    const secondOption = screen.getByRole('option', { name: '두 번째' });
+    const disabledOption = screen.getByRole('option', { name: '선택 불가' });
+
+    firstOption.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(secondOption);
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(firstOption);
+    expect(document.activeElement).not.toBe(disabledOption);
+
+    await userEvent.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(secondOption);
+
+    await userEvent.keyboard('{Home}');
+    expect(document.activeElement).toBe(firstOption);
+
+    await userEvent.keyboard('{End}');
+    expect(document.activeElement).toBe(secondOption);
+  });
+
   it('closes an open menu with Escape without changing the value', async () => {
     const onChange = jest.fn((_value: string | number | undefined): void => undefined);
 

--- a/src/components/SelectMenu.tsx
+++ b/src/components/SelectMenu.tsx
@@ -1,28 +1,30 @@
 import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { SelectMenuMobilePanel } from './SelectMenuMobilePanel';
 
 type SelectMenuVariant = 'gray' | 'purple';
 type SelectMenuValue = string | number;
 
 export interface SelectMenuOption {
-  value: SelectMenuValue;
-  label: string;
-  disabled?: boolean;
+  readonly value: SelectMenuValue;
+  readonly label: string;
+  readonly disabled?: boolean;
 }
 
 interface SelectMenuProps {
-  value?: SelectMenuValue;
-  options: SelectMenuOption[];
-  onChange: (value: SelectMenuValue | undefined) => void;
-  ariaLabel: string;
-  placeholder?: string;
-  variant?: SelectMenuVariant;
-  fullWidth?: boolean;
-  compact?: boolean;
-  clearable?: boolean;
-  align?: 'left' | 'center';
-  textAlign?: 'left' | 'center';
-  className?: string;
+  readonly value?: SelectMenuValue;
+  readonly options: readonly SelectMenuOption[];
+  readonly onChange: (value: SelectMenuValue | undefined) => void;
+  readonly ariaLabel: string;
+  readonly panelTitle?: string;
+  readonly placeholder?: string;
+  readonly variant?: SelectMenuVariant;
+  readonly fullWidth?: boolean;
+  readonly compact?: boolean;
+  readonly clearable?: boolean;
+  readonly align?: 'left' | 'center';
+  readonly textAlign?: 'left' | 'center';
+  readonly className?: string;
 }
 
 const joinClassNames = (...classes: Array<string | false | undefined>): string =>
@@ -38,11 +40,14 @@ const activeOptionClass: Record<SelectMenuVariant, string> = {
   purple: 'bg-purple-500/20 text-purple-700 dark:text-purple-300',
 };
 
+const MOBILE_BREAKPOINT = 640;
+
 const SelectMenu: React.FC<SelectMenuProps> = ({
   value,
   options,
   onChange,
   ariaLabel,
+  panelTitle,
   placeholder = '선택',
   variant = 'gray',
   fullWidth = false,
@@ -54,15 +59,30 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
+  const [mobileViewport, setMobileViewport] = useState(
+    () => typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT,
+  );
   const rootRef = useRef<HTMLDivElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const listboxRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const listboxId = useId();
+  const panelTitleId = useId();
   const selected = options.find((option) => option.value === value);
   const displayLabel = selected?.label ?? placeholder;
   const resolvedTextAlign = align ?? textAlign;
+  const resolvedPanelTitle = panelTitle ?? ariaLabel;
+
+  const closeMenu = useCallback((): void => {
+    setOpen(false);
+    buttonRef.current?.focus();
+  }, []);
 
   const updateMenuPosition = useCallback((): void => {
+    if (window.innerWidth < MOBILE_BREAKPOINT) {
+      setMenuStyle({});
+      return;
+    }
+
     const button = buttonRef.current;
     if (!button) return;
 
@@ -81,86 +101,162 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
   }, []);
 
   useLayoutEffect(() => {
-    if (open) updateMenuPosition();
-  }, [open, updateMenuPosition]);
+    if (!open) return;
+
+    updateMenuPosition();
+    if (mobileViewport) {
+      const panel = panelRef.current;
+      const focusTarget = panel?.querySelector<HTMLButtonElement>(
+        '[role="option"][aria-selected="true"]:not(:disabled)',
+      ) ?? panel?.querySelector<HTMLButtonElement>('[role="option"]:not(:disabled)')
+        ?? panel?.querySelector<HTMLButtonElement>('button:not(:disabled)');
+      focusTarget?.focus();
+    }
+  }, [mobileViewport, open, updateMenuPosition]);
 
   useEffect(() => {
     if (!open) return;
 
     const handlePointerDown = (event: PointerEvent): void => {
-      const target = event.target as Node | null;
-      if (!target || rootRef.current?.contains(target) || listboxRef.current?.contains(target)) return;
-      setOpen(false);
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (rootRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      closeMenu();
     };
 
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') setOpen(false);
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeMenu();
+      }
+    };
+
+    const handleResize = (): void => {
+      setMobileViewport(window.innerWidth < MOBILE_BREAKPOINT);
+      updateMenuPosition();
     };
 
     window.addEventListener('pointerdown', handlePointerDown);
     window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('resize', handleResize);
     window.addEventListener('scroll', updateMenuPosition, true);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('resize', handleResize);
       window.removeEventListener('scroll', updateMenuPosition, true);
     };
-  }, [open, updateMenuPosition]);
+  }, [closeMenu, open, updateMenuPosition]);
+
+  useEffect(() => {
+    if (!open || !mobileViewport || typeof document === 'undefined') return;
+
+    const root = document.getElementById('root');
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    root?.setAttribute('aria-hidden', 'true');
+
+    const focusableSelector = 'button:not([disabled]), [role="option"]:not(:disabled)';
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab') return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      root?.removeAttribute('aria-hidden');
+    };
+  }, [mobileViewport, open]);
 
   const handleSelect = (nextValue: SelectMenuValue | undefined): void => {
     onChange(nextValue);
-    setOpen(false);
+    closeMenu();
   };
+
+  const optionButtons = (
+    <>
+      {clearable && (
+        <button
+          type="button"
+          role="option"
+          aria-selected={value == null}
+          onClick={() => handleSelect(undefined)}
+          className={joinClassNames(
+            'block w-full rounded-lg text-left text-gray-400 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-500 dark:hover:bg-white/10',
+            mobileViewport ? 'min-h-10 px-3 py-2' : 'px-2 py-1.5',
+            resolvedTextAlign === 'center' && 'text-center',
+          )}
+        >
+          {placeholder}
+        </button>
+      )}
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={String(option.value)}
+            type="button"
+            role="option"
+            aria-selected={active}
+            disabled={option.disabled}
+            onClick={() => handleSelect(option.value)}
+            className={joinClassNames(
+              'block w-full rounded-lg text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 disabled:cursor-not-allowed disabled:opacity-40',
+              mobileViewport ? 'min-h-10 px-3 py-2' : 'px-2 py-1.5',
+              active
+                ? activeOptionClass[variant]
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/10',
+              resolvedTextAlign === 'center' && 'text-center',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </>
+  );
 
   const menu = open && typeof document !== 'undefined'
     ? createPortal(
-        <div
-          ref={listboxRef}
-          id={listboxId}
-          role="listbox"
-          aria-label={ariaLabel}
-          style={menuStyle}
-          className="max-h-60 overflow-y-auto rounded-xl border border-gray-200 bg-white p-1 text-xs shadow-xl dark:border-white/10 dark:bg-[#151a21]"
-        >
-          {clearable && (
-            <button
-              type="button"
-              role="option"
-              aria-selected={value == null}
-              onClick={() => handleSelect(undefined)}
-              className={joinClassNames(
-                'block w-full rounded-lg px-2 py-1.5 text-left text-gray-400 transition-colors hover:bg-gray-100 dark:text-gray-500 dark:hover:bg-white/10',
-                resolvedTextAlign === 'center' && 'text-center',
-              )}
-            >
-              {placeholder}
-            </button>
-          )}
-          {options.map((option) => {
-            const active = option.value === value;
-            return (
-              <button
-                key={String(option.value)}
-                type="button"
-                role="option"
-                aria-selected={active}
-                disabled={option.disabled}
-                onClick={() => handleSelect(option.value)}
-                className={joinClassNames(
-                  'block w-full rounded-lg px-2 py-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-40',
-                  active
-                    ? activeOptionClass[variant]
-                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-white/10',
-                  resolvedTextAlign === 'center' && 'text-center',
-                )}
-              >
-                {option.label}
-              </button>
-            );
-          })}
-        </div>,
+        mobileViewport ? (
+          <SelectMenuMobilePanel
+            ariaLabel={ariaLabel}
+            listboxId={listboxId}
+            onClose={closeMenu}
+            panelRef={panelRef}
+            title={resolvedPanelTitle}
+            titleId={panelTitleId}
+          >
+            {optionButtons}
+          </SelectMenuMobilePanel>
+        ) : (
+          <div
+            ref={panelRef}
+            id={listboxId}
+            role="listbox"
+            aria-label={ariaLabel}
+            style={menuStyle}
+            className="max-h-60 overflow-y-auto rounded-xl border border-gray-200 bg-white p-1 text-xs shadow-xl dark:border-white/10 dark:bg-la-dark-card"
+          >
+            {optionButtons}
+          </div>
+        ),
         document.body,
       )
     : null;
@@ -174,7 +270,10 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={() => {
+          setMobileViewport(window.innerWidth < MOBILE_BREAKPOINT);
+          setOpen((prev) => !prev);
+        }}
         className={joinClassNames(
           'inline-flex items-center justify-between gap-1 rounded-lg text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-la-gold/30',
           compact ? 'px-2 py-1' : 'px-2 py-1.5',

--- a/src/components/SelectMenu.tsx
+++ b/src/components/SelectMenu.tsx
@@ -37,7 +37,7 @@ const variantClass: Record<SelectMenuVariant, string> = {
 };
 
 const activeOptionClass: Record<SelectMenuVariant, string> = {
-  gray: 'bg-la-gold/15 text-la-gold-dark dark:text-la-gold',
+  gray: 'bg-la-gold/15 text-la-gold-deep dark:text-la-gold',
   purple: 'bg-purple-500/20 text-purple-700 dark:text-purple-300',
 };
 

--- a/src/components/SelectMenu.tsx
+++ b/src/components/SelectMenu.tsx
@@ -103,6 +103,30 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
     });
   }, []);
 
+  const focusEnabledOption = useCallback((direction: 'first' | 'last' | 'next' | 'previous'): void => {
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const enabledOptions = Array.from(panel.querySelectorAll<HTMLButtonElement>('[role="option"]:not(:disabled)'));
+    if (enabledOptions.length === 0) return;
+
+    const currentIndex = enabledOptions.findIndex((option) => option === document.activeElement);
+    if (direction === 'first') {
+      enabledOptions[0]?.focus();
+      return;
+    }
+    if (direction === 'last') {
+      enabledOptions[enabledOptions.length - 1]?.focus();
+      return;
+    }
+    if (direction === 'next') {
+      enabledOptions[currentIndex === -1 ? 0 : (currentIndex + 1) % enabledOptions.length]?.focus();
+      return;
+    }
+
+    enabledOptions[currentIndex <= 0 ? enabledOptions.length - 1 : currentIndex - 1]?.focus();
+  }, []);
+
   useLayoutEffect(() => {
     if (!open) return;
 
@@ -131,6 +155,27 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
       if (event.key === 'Escape') {
         event.preventDefault();
         closeMenu();
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusEnabledOption('next');
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusEnabledOption('previous');
+        return;
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        focusEnabledOption('first');
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        focusEnabledOption('last');
       }
     };
 
@@ -149,7 +194,7 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('scroll', updateMenuPosition, true);
     };
-  }, [closeMenu, open, updateMenuPosition]);
+  }, [closeMenu, focusEnabledOption, open, updateMenuPosition]);
 
   useEffect(() => {
     if (!open || !mobileViewport) return;

--- a/src/components/SelectMenu.tsx
+++ b/src/components/SelectMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import { SelectMenuMobilePanel } from './SelectMenuMobilePanel';
 
 type SelectMenuVariant = 'gray' | 'purple';
@@ -71,6 +72,8 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
   const displayLabel = selected?.label ?? placeholder;
   const resolvedTextAlign = align ?? textAlign;
   const resolvedPanelTitle = panelTitle ?? ariaLabel;
+
+  useBodyScrollLock(open && mobileViewport);
 
   const closeMenu = useCallback((): void => {
     setOpen(false);
@@ -149,12 +152,7 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
   }, [closeMenu, open, updateMenuPosition]);
 
   useEffect(() => {
-    if (!open || !mobileViewport || typeof document === 'undefined') return;
-
-    const root = document.getElementById('root');
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    root?.setAttribute('aria-hidden', 'true');
+    if (!open || !mobileViewport) return;
 
     const focusableSelector = 'button:not([disabled]), [role="option"]:not(:disabled)';
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -179,8 +177,6 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-      root?.removeAttribute('aria-hidden');
     };
   }, [mobileViewport, open]);
 

--- a/src/components/SelectMenuMobilePanel.tsx
+++ b/src/components/SelectMenuMobilePanel.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+interface SelectMenuMobilePanelProps {
+  readonly ariaLabel: string;
+  readonly children: React.ReactNode;
+  readonly listboxId: string;
+  readonly onClose: () => void;
+  readonly panelRef: React.RefObject<HTMLDivElement | null>;
+  readonly title: string;
+  readonly titleId: string;
+}
+
+export const SelectMenuMobilePanel: React.FC<SelectMenuMobilePanelProps> = ({
+  ariaLabel,
+  children,
+  listboxId,
+  onClose,
+  panelRef,
+  title,
+  titleId,
+}) => (
+  <div className="fixed inset-0 z-[9999] flex items-end bg-black/40">
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="flex max-h-[85dvh] w-full flex-col overflow-hidden rounded-t-xl border border-b-0 border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-la-dark-card"
+    >
+      <div className="flex flex-none items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-white/10">
+        <h2 id={titleId} className="min-w-0 break-words text-sm font-bold text-gray-900 dark:text-white">
+          {title}
+        </h2>
+        <button
+          type="button"
+          aria-label={`${title} 닫기`}
+          onClick={onClose}
+          className="flex h-10 w-10 flex-none items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-400 dark:hover:bg-white/10"
+        >
+          <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label={ariaLabel}
+        className="min-h-0 overflow-y-auto overscroll-contain p-2 pb-4 text-sm"
+      >
+        {children}
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/StateFeedback.test.tsx
+++ b/src/components/StateFeedback.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StateFeedback from './StateFeedback';
+
+describe('StateFeedback', () => {
+  it('announces loading state without marking the status node busy', () => {
+    render(
+      <StateFeedback
+        tone="loading"
+        title="시세를 불러오는 중"
+        description="잠시만 기다려 주세요."
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: '시세를 불러오는 중' }))
+      .not.toHaveAttribute('aria-busy');
+  });
+
+  it('renders an empty state action', async () => {
+    const onAction = jest.fn();
+
+    render(
+      <StateFeedback
+        tone="empty"
+        title="표시할 결과가 없습니다"
+        action={{ label: '다시 검색', onClick: onAction }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '다시 검색' }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses alert semantics and wrapping-friendly text for errors', () => {
+    render(
+      <StateFeedback
+        tone="error"
+        title="조회에 실패했습니다"
+        description="캐릭터 정보를 불러오지 못했습니다. 잠시 후 닉네임을 확인하고 다시 시도해 주세요."
+      />,
+    );
+
+    const feedback = screen.getByRole('alert', { name: '조회에 실패했습니다' });
+    expect(feedback).toHaveAttribute('data-tone', 'error');
+    expect(screen.getByText(/캐릭터 정보를 불러오지 못했습니다/)).toHaveClass('break-words');
+  });
+
+  it('uses compact spacing when requested', () => {
+    render(
+      <StateFeedback
+        tone="empty"
+        title="결과 없음"
+        compact
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: '결과 없음' })).toHaveClass('p-4');
+  });
+});

--- a/src/components/StateFeedback.tsx
+++ b/src/components/StateFeedback.tsx
@@ -1,0 +1,106 @@
+import React, { useId } from 'react';
+import GlassCard from './GlassCard';
+import { SkeletonBlock } from './Loading';
+
+export type StateFeedbackTone = 'loading' | 'empty' | 'error';
+
+interface StateFeedbackAction {
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+interface StateFeedbackProps {
+  readonly tone: StateFeedbackTone;
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: StateFeedbackAction;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+const toneStyles: Record<StateFeedbackTone, string> = {
+  loading: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  empty: 'bg-gray-500/10 text-gray-500 dark:text-gray-400',
+  error: 'bg-red-500/10 text-red-600 dark:text-red-400',
+};
+
+const toneRoles: Record<StateFeedbackTone, 'alert' | 'status'> = {
+  loading: 'status',
+  empty: 'status',
+  error: 'alert',
+};
+
+const toneIconPaths: Record<StateFeedbackTone, string> = {
+  loading: 'M12 6v6l4 2m5-2a9 9 0 11-18 0 9 9 0 0118 0z',
+  empty: 'M3.75 9.75h16.5m-16.5 0A2.25 2.25 0 016 7.5h12a2.25 2.25 0 012.25 2.25m-16.5 0v7.5A2.25 2.25 0 006 19.5h12a2.25 2.25 0 002.25-2.25v-7.5M9 13.5h6',
+  error: 'M12 9v3.75m9.303 3.376c.866 1.5-.217 3.374-1.948 3.374H4.645c-1.73 0-2.813-1.874-1.948-3.374L10.052 3.38c.866-1.5 3.03-1.5 3.896 0l7.355 12.746zM12 15.75h.008v.008H12v-.008z',
+};
+
+const joinClassNames = (...classes: Array<string | false | undefined>): string =>
+  classes.filter(Boolean).join(' ');
+
+export const StateFeedback: React.FC<StateFeedbackProps> = ({
+  tone,
+  title,
+  description,
+  action,
+  compact = false,
+  className,
+}) => {
+  const titleId = useId();
+
+  return (
+    <GlassCard className={joinClassNames('overflow-hidden', className)}>
+      <section
+        role={toneRoles[tone]}
+        aria-labelledby={titleId}
+        data-tone={tone}
+        className={joinClassNames(
+          'flex flex-col items-center text-center',
+          compact ? 'gap-2 p-4' : 'gap-3 p-6',
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={joinClassNames(
+            'flex h-10 w-10 items-center justify-center rounded-full',
+            toneStyles[tone],
+          )}
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+            <path strokeLinecap="round" strokeLinejoin="round" d={toneIconPaths[tone]} />
+          </svg>
+        </span>
+
+        <div className="min-w-0 max-w-xl">
+          <h2 id={titleId} className="break-words text-sm font-bold text-gray-900 dark:text-white">
+            {title}
+          </h2>
+          {description && (
+            <p className="mt-1 break-words text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+              {description}
+            </p>
+          )}
+        </div>
+
+        {tone === 'loading' && (
+          <div aria-hidden="true" className="w-20">
+            <SkeletonBlock className="h-1.5 w-full" />
+          </div>
+        )}
+
+        {action && (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="min-h-10 rounded-lg bg-la-gold/15 px-4 py-2 text-xs font-bold text-la-gold-deep transition-colors hover:bg-la-gold/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-la-gold"
+          >
+            {action.label}
+          </button>
+        )}
+      </section>
+    </GlassCard>
+  );
+};
+
+export default StateFeedback;

--- a/src/components/expedition/ExpeditionProfiles.tsx
+++ b/src/components/expedition/ExpeditionProfiles.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { CharacterProfile } from '../../types/lostark';
+import FallbackImage from '../FallbackImage';
+import GlassCard from '../GlassCard';
+
+type ExpeditionSummary = {
+  readonly highestLevel: number | null;
+  readonly averageLevel: number | null;
+};
+
+type ExpeditionProfilesProps = {
+  readonly nickname: string;
+  readonly profiles: readonly CharacterProfile[];
+  readonly summary: ExpeditionSummary;
+};
+
+const ExpeditionProfiles: React.FC<ExpeditionProfilesProps> = ({ nickname, profiles, summary }) => (
+  <div className="space-y-6 animate-fade-in">
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <GlassCard className="p-4 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">원정대 캐릭터</p>
+        <p className="text-2xl font-bold text-gray-900 dark:text-white">{profiles.length}</p>
+      </GlassCard>
+      <GlassCard className="p-4 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">최고 레벨</p>
+        <p className="text-2xl font-bold text-la-gold-dark dark:text-la-gold">
+          {summary.highestLevel?.toFixed(2) ?? '-'}
+        </p>
+      </GlassCard>
+      <GlassCard className="p-4 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">평균 레벨</p>
+        <p className="text-2xl font-bold text-gray-900 dark:text-white">
+          {summary.averageLevel?.toFixed(2) ?? '-'}
+        </p>
+      </GlassCard>
+      <GlassCard className="p-4 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">주간 골드</p>
+        <Link
+          to={`/simulation?nickname=${encodeURIComponent(nickname)}`}
+          className="inline-flex items-center justify-center px-3 py-2 rounded-lg text-sm font-medium bg-la-gold/20 text-la-gold-dark dark:text-la-gold hover:bg-la-gold/30 transition-colors"
+        >
+          계산하러 가기
+        </Link>
+      </GlassCard>
+    </div>
+
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
+      {profiles.map((profile) => (
+        <Link
+          key={profile.CharacterName}
+          to={`/character?nickname=${encodeURIComponent(profile.CharacterName)}`}
+          className="block self-start"
+        >
+          <GlassCard className="p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20">
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-2xl overflow-hidden bg-gray-100 dark:bg-white/5 flex-shrink-0">
+                <FallbackImage
+                  src={profile.CharacterImage}
+                  alt={profile.CharacterName}
+                  className="w-full h-full object-cover object-top"
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white truncate">{profile.CharacterName}</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{profile.CharacterClassName}</p>
+                <div className="mt-2 inline-flex items-center rounded-full bg-la-gold/15 px-2.5 py-1 text-xs font-medium text-la-gold-dark dark:text-la-gold">
+                  아이템 레벨 {profile.ItemAvgLevel}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-gray-500 dark:text-gray-400">캐릭터 레벨</p>
+                <p className="mt-1 font-semibold text-gray-900 dark:text-white">Lv.{profile.CharacterLevel}</p>
+              </div>
+              <div>
+                <p className="text-gray-500 dark:text-gray-400">원정대 레벨</p>
+                <p className="mt-1 font-semibold text-gray-900 dark:text-white">Lv.{profile.ExpeditionLevel}</p>
+              </div>
+              <div>
+                <p className="text-gray-500 dark:text-gray-400">서버</p>
+                <p className="mt-1 font-semibold text-gray-900 dark:text-white">{profile.ServerName}</p>
+              </div>
+              <div>
+                <p className="text-gray-500 dark:text-gray-400">길드</p>
+                <p className="mt-1 font-semibold text-gray-900 dark:text-white truncate">{profile.GuildName || '-'}</p>
+              </div>
+            </div>
+          </GlassCard>
+        </Link>
+      ))}
+    </div>
+  </div>
+);
+
+export default ExpeditionProfiles;

--- a/src/components/home/HomeDashboardIntro.test.tsx
+++ b/src/components/home/HomeDashboardIntro.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, within } from '@testing-library/react';
+import HomeDashboardIntro from './HomeDashboardIntro';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...rest}>{children}</a>
+    ),
+  }),
+  { virtual: true },
+);
+
+describe('HomeDashboardIntro', () => {
+  it('groups the mobile quick menu with visible action affordances', () => {
+    render(
+      <HomeDashboardIntro
+        activeEventCount={2}
+        calendarGroupCount={3}
+        loadingEvents={false}
+        loadingCalendar={false}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: '성장에 필요한 도구를 한곳에' })).toHaveClass('break-keep');
+    const quickMenu = screen.getByRole('navigation', { name: '빠른 메뉴' });
+    expect(within(quickMenu).getAllByRole('link')).toHaveLength(4);
+    const weeklyGoldLink = within(quickMenu).getByRole('link', { name: /주간 골드 계산/ });
+    expect(within(weeklyGoldLink).getByText('계산하기').parentElement).toHaveClass('opacity-100');
+    expect(within(quickMenu).getByRole('link', { name: /시세 랭킹/ })).toHaveAttribute('href', '/market');
+  });
+});

--- a/src/components/home/HomeDashboardIntro.tsx
+++ b/src/components/home/HomeDashboardIntro.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface HomeDashboardIntroProps {
+  readonly activeEventCount: number;
+  readonly calendarGroupCount: number;
+  readonly loadingEvents: boolean;
+  readonly loadingCalendar: boolean;
+}
+
+const QUICK_ACTIONS = [
+  {
+    to: '/simulation',
+    title: '주간 골드 계산',
+    description: '주간 골드와 숙제 현황',
+    action: '계산하기',
+    iconBg: 'bg-amber-500/15',
+    iconText: 'text-amber-700 dark:text-amber-400',
+    ctaText: 'text-amber-700 dark:text-amber-400',
+    path: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    featured: true,
+  },
+  {
+    to: '/enhancement',
+    title: '재련 계산',
+    description: '재료 시세 기반 강화 비용',
+    action: '계산하기',
+    iconBg: 'bg-emerald-500/15',
+    iconText: 'text-emerald-600 dark:text-emerald-400',
+    ctaText: 'text-emerald-600 dark:text-emerald-400',
+    path: 'M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396c.251.023.501.05.75.082M19 14.5l-2.14 3.21a2.25 2.25 0 01-1.873 1.002H9.013A2.25 2.25 0 017.14 17.71L5 14.5m14 0H5',
+    featured: false,
+  },
+  {
+    to: '/market',
+    title: '시세 랭킹',
+    description: '각인서·보석 최저가 순위',
+    action: '랭킹 보기',
+    iconBg: 'bg-la-gold/20',
+    iconText: 'text-la-gold-dark dark:text-la-gold',
+    ctaText: 'text-la-gold-dark dark:text-la-gold',
+    path: 'M3 10h18M7 15h1m4 0h1m4 0h1M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z',
+    featured: false,
+  },
+  {
+    to: '/compare',
+    title: '캐릭터 비교',
+    description: '두 캐릭터 스펙 비교',
+    action: '비교하기',
+    iconBg: 'bg-sky-500/15',
+    iconText: 'text-sky-600 dark:text-sky-400',
+    ctaText: 'text-sky-600 dark:text-sky-400',
+    path: 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3',
+    featured: false,
+  },
+] as const;
+
+const HomeDashboardIntro: React.FC<HomeDashboardIntroProps> = ({
+  activeEventCount,
+  calendarGroupCount,
+  loadingEvents,
+  loadingCalendar,
+}) => (
+  <>
+    <section className="glass-card relative overflow-hidden p-5 animate-fade-in sm:p-8" aria-labelledby="home-dashboard-title">
+      <div className="absolute -left-20 -top-20 h-56 w-56 rounded-full bg-la-gold/20 blur-3xl" aria-hidden />
+      <div className="absolute -right-20 bottom-0 h-48 w-48 rounded-full bg-amber-500/10 blur-3xl" aria-hidden />
+      <div className="relative grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
+        <div className="min-w-0">
+          <span className="inline-flex rounded-full border border-la-gold/20 bg-la-gold/10 px-3 py-1 text-xs font-bold text-la-gold-dark dark:text-la-gold">
+            로아 성장 관리 대시보드
+          </span>
+          <h1 id="home-dashboard-title" className="mt-4 break-keep text-3xl font-black tracking-tight text-gray-950 dark:text-white sm:text-4xl md:text-5xl">
+            성장에 필요한 도구를 한곳에
+          </h1>
+          <p className="mt-4 max-w-2xl break-keep text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-base">
+            시세, 골드, 캐릭터 비교, 재련 계산까지 필요한 순간 바로 확인하세요.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3" aria-label="오늘의 요약">
+          <div className="rounded-2xl border border-la-gold/20 bg-la-gold/10 p-4">
+            <p className="text-xs font-bold tracking-wider text-la-gold-dark dark:text-la-gold">이벤트</p>
+            <p className="mt-2 text-3xl font-black tabular-nums text-gray-950 dark:text-white">{loadingEvents ? '-' : activeEventCount}</p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">진행 중</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/60 p-4 dark:bg-white/5">
+            <p className="text-xs font-bold tracking-wider text-gray-500 dark:text-gray-400">일정</p>
+            <p className="mt-2 text-3xl font-black tabular-nums text-gray-950 dark:text-white">{loadingCalendar ? '-' : calendarGroupCount}</p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">오늘 일정</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="home-quick-menu-title" className="animate-fade-in">
+      <div className="mb-4">
+        <h2 id="home-quick-menu-title" className="text-xl font-bold text-gray-900 dark:text-white">빠른 메뉴</h2>
+        <p className="mt-1 break-keep text-sm text-gray-500 dark:text-gray-400">자주 쓰는 성장 도구로 바로 이동합니다.</p>
+      </div>
+      <nav aria-label="빠른 메뉴" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {QUICK_ACTIONS.map((action) => (
+          <Link
+            key={action.to}
+            to={action.to}
+            className={`glass-card group cursor-pointer p-5 text-left transition-all duration-300 hover:border-la-gold/30 hover:shadow-gold-glow dark:hover:border-la-gold/20 ${action.featured ? 'ring-1 ring-la-gold/20' : ''}`}
+          >
+            <div className="mb-3 flex items-center gap-3">
+              <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${action.iconBg}`}>
+                <svg className={`h-5 w-5 ${action.iconText}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d={action.path} />
+                </svg>
+              </div>
+              <h3 className="text-base font-bold text-gray-900 dark:text-white">{action.title}</h3>
+            </div>
+            <p className="break-keep text-sm leading-relaxed text-gray-500 dark:text-gray-400">{action.description}</p>
+            <div className={`mt-3 flex items-center gap-1 text-sm font-medium opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 ${action.ctaText}`}>
+              <span>{action.action}</span>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </Link>
+        ))}
+      </nav>
+    </section>
+  </>
+);
+
+export default HomeDashboardIntro;

--- a/src/components/market/MarketRankings.tsx
+++ b/src/components/market/MarketRankings.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import GlassCard from '../GlassCard';
+import StateFeedback from '../StateFeedback';
+
+export type RankStatus = 'loading' | 'success' | 'error';
+export type GemKind = '겁화' | '작열';
+
+export type EngravingRankItem = {
+  readonly rank: number;
+  readonly name: string;
+  readonly itemName: string;
+  readonly icon: string;
+  readonly price: number;
+  readonly yDayAvgPrice: number;
+};
+
+export type GemRankItem = {
+  readonly rank: number;
+  readonly level: number;
+  readonly kind: GemKind;
+  readonly name: string;
+  readonly icon: string;
+  readonly price: number;
+};
+
+export type RankState<T> = {
+  readonly status: RankStatus;
+  readonly items: readonly T[];
+  readonly fetchedAt: Date | null;
+  readonly failedCount: number;
+};
+
+type RankingProps<T> = {
+  readonly state: RankState<T>;
+  readonly onRetry: () => void;
+};
+
+const formatGold = (value?: number | null): string => {
+  if (value == null || value <= 0) return '-';
+  return `${value.toLocaleString()}G`;
+};
+
+type PriceDeltaDirection = 'up' | 'down' | 'flat';
+
+const getPriceDelta = (current?: number | null, previous?: number | null): { readonly label: string; readonly direction: PriceDeltaDirection } => {
+  if (current == null || previous == null || current <= 0 || previous <= 0 || current === previous) {
+    return { label: '-', direction: 'flat' };
+  }
+
+  const difference = Math.abs(current - previous);
+  return current > previous
+    ? { label: `▲ ${formatGold(difference)}`, direction: 'up' }
+    : { label: `▼ ${formatGold(difference)}`, direction: 'down' };
+};
+
+const formatTime = (date: Date | null): string =>
+  date ? date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }) : '-';
+
+const SectionHeader: React.FC<{
+  readonly title: string;
+  readonly count: number;
+  readonly fetchedAt: Date | null;
+  readonly failedCount: number;
+}> = ({ title, count, fetchedAt, failedCount }) => (
+  <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h2 className="text-xl font-black text-gray-950 dark:text-white">{title}</h2>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        {count}개 · 최저가 기준 · {formatTime(fetchedAt)}
+      </p>
+    </div>
+    {failedCount > 0 && (
+      <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-xs font-bold text-amber-700 dark:text-amber-300">
+        {failedCount}개 실패
+      </span>
+    )}
+  </div>
+);
+
+const RankBadge: React.FC<{ readonly rank: number }> = ({ rank }) => (
+  <span className="inline-flex h-8 min-w-8 items-center justify-center rounded-lg bg-la-gold/15 px-2 text-sm font-black text-la-gold-dark dark:text-la-gold">
+    #{rank}
+  </span>
+);
+
+const PriceDelta: React.FC<{ readonly current?: number | null; readonly previous?: number | null }> = ({ current, previous }) => {
+  const delta = getPriceDelta(current, previous);
+  const colorClass = delta.direction === 'up'
+    ? 'text-red-600 dark:text-red-400'
+    : delta.direction === 'down'
+      ? 'text-blue-600 dark:text-blue-400'
+      : 'text-gray-500 dark:text-gray-400';
+
+  return <span className={`tabular-nums ${colorClass}`}>{delta.label}</span>;
+};
+
+export const EngravingRanking: React.FC<RankingProps<EngravingRankItem>> = ({ state, onRetry }) => (
+  <section>
+    <SectionHeader title="유물 각인서" count={state.items.length} fetchedAt={state.fetchedAt} failedCount={state.failedCount} />
+    {state.status === 'loading' && (
+      <StateFeedback
+        tone="loading"
+        title="유물 각인서 시세를 불러오는 중입니다"
+        description="최저가와 전일 평균을 비교하고 있습니다."
+        compact
+      />
+    )}
+    {state.status === 'error' && (
+      <StateFeedback
+        tone="error"
+        title="유물 각인서 시세를 불러오지 못했습니다"
+        description="요청이 많거나 서버 응답이 지연되었습니다. 잠시 후 다시 시도해 주세요."
+        action={{ label: '다시 불러오기', onClick: onRetry }}
+        compact
+      />
+    )}
+    {state.status === 'success' && state.items.length === 0 && (
+      <StateFeedback
+        tone="empty"
+        title="표시할 유물 각인서 시세가 없습니다"
+        description="잠시 후 새로고침해 최신 시세를 다시 확인해 주세요."
+        action={{ label: '다시 불러오기', onClick: onRetry }}
+        compact
+      />
+    )}
+    {state.status === 'success' && state.items.length > 0 && (
+      <GlassCard className="overflow-hidden">
+        <div className="hidden md:block">
+          <div className="grid grid-cols-[72px_minmax(0,1fr)_150px_150px_150px] gap-4 border-b border-gray-200/50 px-5 py-3 text-xs font-bold uppercase tracking-wider text-gray-400 dark:border-white/10">
+            <span>순위</span>
+            <span>아이템</span>
+            <span>최저가</span>
+            <span>전일 평균</span>
+            <span>변동</span>
+          </div>
+          {state.items.map((item) => (
+            <div key={item.name} className="grid grid-cols-[72px_minmax(0,1fr)_150px_150px_150px] gap-4 border-b border-gray-200/40 px-5 py-4 last:border-b-0 dark:border-white/5">
+              <div className="flex items-center"><RankBadge rank={item.rank} /></div>
+              <div className="flex min-w-0 items-center gap-3">
+                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
+                <p className="truncate text-sm font-bold text-gray-900 dark:text-white">{item.itemName}</p>
+              </div>
+              <div className="flex items-center text-sm font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</div>
+              <div className="flex items-center text-sm tabular-nums text-gray-600 dark:text-gray-300">{formatGold(item.yDayAvgPrice)}</div>
+              <div className="flex items-center text-sm font-bold"><PriceDelta current={item.price} previous={item.yDayAvgPrice} /></div>
+            </div>
+          ))}
+        </div>
+
+        <div className="divide-y divide-gray-200/50 md:hidden dark:divide-white/10">
+          {state.items.map((item) => (
+            <div key={`${item.name}-mobile`} role="group" aria-label={`${item.itemName} 모바일 시세`} className="p-3">
+              <div className="flex items-start gap-2.5">
+                <RankBadge rank={item.rank} />
+                <img src={item.icon} alt="" className="h-10 w-10 flex-shrink-0 rounded-lg bg-gray-100 object-cover dark:bg-white/5" />
+                <div className="min-w-0 flex-1">
+                  <p className="line-clamp-2 text-sm font-bold leading-snug text-gray-900 dark:text-white">{item.itemName}</p>
+                  <div className="mt-2 grid grid-cols-[1fr_1fr_auto] gap-2 text-xs">
+                    <div className="min-w-0">
+                      <p className="text-gray-400 dark:text-gray-500">최저가</p>
+                      <p className="mt-0.5 whitespace-nowrap font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-gray-400 dark:text-gray-500">전일 평균</p>
+                      <p className="mt-0.5 whitespace-nowrap tabular-nums text-gray-600 dark:text-gray-300">{formatGold(item.yDayAvgPrice)}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-gray-400 dark:text-gray-500">변동</p>
+                      <p className="mt-0.5 whitespace-nowrap font-bold"><PriceDelta current={item.price} previous={item.yDayAvgPrice} /></p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </GlassCard>
+    )}
+  </section>
+);
+
+export const GemRanking: React.FC<RankingProps<GemRankItem>> = ({ state, onRetry }) => (
+  <section>
+    <SectionHeader title="보석" count={state.items.length} fetchedAt={state.fetchedAt} failedCount={state.failedCount} />
+    {state.status === 'loading' && (
+      <StateFeedback tone="loading" title="보석 시세를 불러오는 중입니다" description="레벨과 종류별 최저가를 비교하고 있습니다." compact />
+    )}
+    {state.status === 'error' && (
+      <StateFeedback
+        tone="error"
+        title="보석 시세를 불러오지 못했습니다"
+        description="요청이 많거나 서버 응답이 지연되었습니다. 잠시 후 다시 시도해 주세요."
+        action={{ label: '다시 불러오기', onClick: onRetry }}
+        compact
+      />
+    )}
+    {state.status === 'success' && state.items.length === 0 && (
+      <StateFeedback
+        tone="empty"
+        title="표시할 보석 시세가 없습니다"
+        description="잠시 후 새로고침해 최신 시세를 다시 확인해 주세요."
+        action={{ label: '다시 불러오기', onClick: onRetry }}
+        compact
+      />
+    )}
+    {state.status === 'success' && state.items.length > 0 && (
+      <GlassCard className="overflow-hidden">
+        <div className="hidden md:block">
+          <div className="grid grid-cols-[72px_minmax(0,1fr)_150px] gap-4 border-b border-gray-200/50 px-5 py-3 text-xs font-bold uppercase tracking-wider text-gray-400 dark:border-white/10">
+            <span>순위</span>
+            <span>아이템</span>
+            <span>최저가</span>
+          </div>
+          {state.items.map((item) => (
+            <div key={`${item.level}-${item.kind}`} className="grid grid-cols-[72px_minmax(0,1fr)_150px] gap-4 border-b border-gray-200/40 px-5 py-4 last:border-b-0 dark:border-white/5">
+              <div className="flex items-center"><RankBadge rank={item.rank} /></div>
+              <div className="flex min-w-0 items-center gap-3">
+                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-bold text-gray-900 dark:text-white">Lv.{item.level}</p>
+                    <span className="rounded-full border border-la-gold/20 bg-la-gold/10 px-2.5 py-1 text-xs font-bold text-la-gold-dark dark:text-la-gold">{item.kind}</span>
+                  </div>
+                  <p className="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">{item.name}</p>
+                </div>
+              </div>
+              <div className="flex items-center text-sm font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="divide-y divide-gray-200/50 md:hidden dark:divide-white/10">
+          {state.items.map((item) => (
+            <div key={`${item.level}-${item.kind}-mobile`} className="p-3">
+              <div className="flex items-start gap-2.5">
+                <RankBadge rank={item.rank} />
+                <img src={item.icon} alt="" className="h-10 w-10 flex-shrink-0 rounded-lg bg-gray-100 object-cover dark:bg-white/5" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-bold text-gray-900 dark:text-white">Lv.{item.level} {item.kind}</p>
+                  <p className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">{item.name}</p>
+                  <div className="mt-2 text-xs">
+                    <p className="text-gray-400 dark:text-gray-500">최저가</p>
+                    <p className="mt-0.5 font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </GlassCard>
+    )}
+  </section>
+);

--- a/src/components/market/MarketRankings.tsx
+++ b/src/components/market/MarketRankings.tsx
@@ -157,15 +157,15 @@ export const EngravingRanking: React.FC<RankingProps<EngravingRankItem>> = ({ st
                   <p className="line-clamp-2 text-sm font-bold leading-snug text-gray-900 dark:text-white">{item.itemName}</p>
                   <div className="mt-2 grid grid-cols-[1fr_1fr_auto] gap-2 text-xs">
                     <div className="min-w-0">
-                      <p className="text-gray-400 dark:text-gray-500">최저가</p>
-                      <p className="mt-0.5 whitespace-nowrap font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
+                      <p className="text-gray-500 dark:text-gray-500">최저가</p>
+                      <p className="mt-0.5 whitespace-nowrap font-black tabular-nums text-la-gold-deep dark:text-la-gold">{formatGold(item.price)}</p>
                     </div>
                     <div className="min-w-0">
-                      <p className="text-gray-400 dark:text-gray-500">전일 평균</p>
+                      <p className="text-gray-500 dark:text-gray-500">전일 평균</p>
                       <p className="mt-0.5 whitespace-nowrap tabular-nums text-gray-600 dark:text-gray-300">{formatGold(item.yDayAvgPrice)}</p>
                     </div>
                     <div className="text-right">
-                      <p className="text-gray-400 dark:text-gray-500">변동</p>
+                      <p className="text-gray-500 dark:text-gray-500">변동</p>
                       <p className="mt-0.5 whitespace-nowrap font-bold"><PriceDelta current={item.price} previous={item.yDayAvgPrice} /></p>
                     </div>
                   </div>
@@ -239,8 +239,8 @@ export const GemRanking: React.FC<RankingProps<GemRankItem>> = ({ state, onRetry
                   <p className="text-sm font-bold text-gray-900 dark:text-white">Lv.{item.level} {item.kind}</p>
                   <p className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">{item.name}</p>
                   <div className="mt-2 text-xs">
-                    <p className="text-gray-400 dark:text-gray-500">최저가</p>
-                    <p className="mt-0.5 font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
+                    <p className="text-gray-500 dark:text-gray-500">최저가</p>
+                    <p className="mt-0.5 font-black tabular-nums text-la-gold-deep dark:text-la-gold">{formatGold(item.price)}</p>
                   </div>
                 </div>
               </div>

--- a/src/components/nav/NavLinks.tsx
+++ b/src/components/nav/NavLinks.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type NavLinkItem = {
+  readonly path: string;
+  readonly label: string;
+};
+
+type NavLinksProps = {
+  readonly links: readonly NavLinkItem[];
+  readonly pathname: string;
+};
+
+export const PRIMARY_NAV_LINKS = [
+  { path: '/', label: '홈' },
+  { path: '/simulation', label: '주간골드' },
+  { path: '/enhancement', label: '재련견적' },
+  { path: '/market', label: '시세' },
+  { path: '/compare', label: '비교' },
+  { path: '/character', label: '캐릭터' },
+  { path: '/spec-simulator', label: '전투력 시뮬' },
+] as const;
+
+export const MORE_NAV_LINKS = [
+  { path: '/expedition', label: '원정대' },
+  { path: '/spending', label: '결제 내역' },
+] as const;
+
+export const getNavItemClass = (isActive: boolean): string =>
+  `px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 inline-flex items-center gap-1.5 ${
+    isActive
+      ? 'bg-la-gold/20 text-la-gold-dark dark:text-la-gold'
+      : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/5'
+  }`;
+
+export const NavLinks: React.FC<NavLinksProps> = ({ links, pathname }) => (
+  <>
+    {links.map((link) => (
+      <Link key={link.path} to={link.path} className={getNavItemClass(pathname === link.path)}>
+        {link.label}
+      </Link>
+    ))}
+  </>
+);

--- a/src/components/simulation/CharacterRaidCard.test.tsx
+++ b/src/components/simulation/CharacterRaidCard.test.tsx
@@ -8,6 +8,9 @@ import { normalizeRaidSelection } from '../../utils/simulationKeys';
 type RenderCardOptions = {
   readonly hasCustomRaids?: boolean;
   readonly onResetRaidSelection?: () => void;
+  readonly itemLevel?: string;
+  /** 지정하면 기본 선택(참여 가능 상위 3개) 대신 이 키를 선택 상태로 넘긴다. */
+  readonly selectedRaidKeysOverride?: readonly string[];
 };
 
 const setViewportWidth = (width: number): void => {
@@ -30,9 +33,13 @@ afterEach(() => {
 const renderCard = ({
   hasCustomRaids = false,
   onResetRaidSelection = jest.fn(),
+  itemLevel = '1780.00',
+  selectedRaidKeysOverride,
 }: RenderCardOptions = {}) => {
-  const result = calculateCharacterGold('1780', '버서커', '1780.00', 'img');
-  const selectedRaidKeys = result.selectedRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`);
+  const result = calculateCharacterGold(itemLevel.split('.')[0], '버서커', itemLevel, 'img');
+  const selectedRaidKeys =
+    selectedRaidKeysOverride?.slice() ??
+    result.selectedRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`);
   const onRaidSelectionChange = jest.fn();
 
   render(
@@ -89,8 +96,13 @@ describe('CharacterRaidCard raid simulation flow', () => {
     expect(screen.getByRole('dialog', { name: '1780 레이드 변경' })).toBeInTheDocument();
     expect(document.body.style.overflow).toBe('hidden');
     expect(screen.getByText('현재 선택 레이드')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '참여 가능 레이드' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '참여 불가 레이드' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /참여 가능 레이드/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /참여 불가 레이드/ })).toBeInTheDocument();
+
+    // 최고 요구 레벨이 1780이므로 이 캐릭터는 전 레이드 참여 가능하고, 참여 불가 그룹은 접을 대상이 없다.
+    expect(screen.getByRole('button', { name: /참여 가능 레이드/ })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: '참여 불가 레이드 0개' })).toHaveAttribute('aria-expanded', 'true');
+
     expect(screen.getAllByText('벨가르딘 (그림자)').length).toBeGreaterThan(1);
     expect(screen.getAllByRole('img', { name: '벨가르딘 (그림자) 레이드' })).toHaveLength(4);
     expect(screen.getByText('62,000G')).toBeInTheDocument();
@@ -105,6 +117,53 @@ describe('CharacterRaidCard raid simulation flow', () => {
     await userEvent.click(screen.getByRole('button', { name: '1780 레이드 변경 닫기' }));
     expect(screen.queryByRole('dialog', { name: '1780 레이드 변경' })).not.toBeInTheDocument();
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('collapses the unavailable raid group by default and reopens it on demand', async () => {
+    renderCard({ itemLevel: '1680.00' });
+
+    await userEvent.click(screen.getByRole('button', { name: '레이드 변경' }));
+
+    const unavailableToggle = screen.getByRole('button', { name: /^참여 불가 레이드 [1-9]/ });
+    expect(screen.getByRole('button', { name: /참여 가능 레이드/ })).toHaveAttribute('aria-expanded', 'true');
+    expect(unavailableToggle).toHaveAttribute('aria-expanded', 'false');
+
+    const collapsedPanelId = unavailableToggle.getAttribute('aria-controls');
+    expect(collapsedPanelId).not.toBeNull();
+    expect(document.getElementById(collapsedPanelId as string)).toHaveAttribute('hidden');
+
+    await userEvent.click(unavailableToggle);
+
+    expect(unavailableToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(document.getElementById(collapsedPanelId as string)).not.toHaveAttribute('hidden');
+  });
+
+  it('keeps the unavailable raid group open when it already holds a checked raid', async () => {
+    const result = calculateCharacterGold('1680', '버서커', '1680.00', 'img');
+    const availableKeys = new Set(
+      result.availableRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`),
+    );
+    const unavailableRaid = RAID_COLUMNS.find(
+      (raid) => !availableKeys.has(`${raid.raidName}::${raid.difficulty}`),
+    );
+
+    if (!unavailableRaid) {
+      throw new TypeError('Expected at least one unavailable raid at item level 1680');
+    }
+
+    renderCard({
+      itemLevel: '1680.00',
+      selectedRaidKeysOverride: [`${unavailableRaid.raidName}::${unavailableRaid.difficulty}`],
+      hasCustomRaids: true,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: '레이드 변경' }));
+
+    // 접으면 사용자가 심어둔 체크 상태가 화면에서 사라지므로 펼친 상태로 시작해야 한다.
+    expect(screen.getByRole('button', { name: /^참여 불가 레이드 [1-9]/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
   });
 
   it('portals the raid picker dialog outside the character glass card', async () => {

--- a/src/components/simulation/CharacterRaidCard.test.tsx
+++ b/src/components/simulation/CharacterRaidCard.test.tsx
@@ -73,7 +73,7 @@ describe('CharacterRaidCard raid simulation flow', () => {
     expect(screen.getByText('코어 16')).toBeInTheDocument();
 
     fireEvent.error(screen.getByRole('img', { name: '1780' }));
-    expect(screen.getByRole('img', { name: '1780 이미지 없음' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '1780 캐릭터 이미지 없음' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('벨가르딘 (그림자)'));
 
@@ -121,6 +121,55 @@ describe('CharacterRaidCard raid simulation flow', () => {
     const dialog = screen.getByRole('dialog', { name: '1780 레이드 변경' });
     expect(document.body).toContainElement(dialog);
     expect(card).not.toContainElement(dialog);
+  });
+
+  it('closes the mobile raid picker with Escape, restores focus, and traps Tab at both edges', async () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    renderCard();
+    const openButton = screen.getByRole('button', { name: '레이드 변경' });
+
+    await userEvent.click(openButton);
+
+    const dialog = screen.getByRole('dialog', { name: '1780 레이드 변경' });
+    const closeButton = screen.getByRole('button', { name: '1780 레이드 변경 닫기' });
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(document.activeElement).toBe(closeButton);
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog', { name: '1780 레이드 변경' })).not.toBeInTheDocument();
+    expect(root).not.toHaveAttribute('aria-hidden');
+    expect(document.activeElement).toBe(openButton);
+
+    await userEvent.click(openButton);
+
+    const reopenedDialog = screen.getByRole('dialog', { name: '1780 레이드 변경' });
+    const focusableSelector = 'button:not([disabled]), input:not([disabled]), a[href]';
+    const focusables = Array.from(reopenedDialog.querySelectorAll<HTMLElement>(focusableSelector));
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (!first || !last) {
+      throw new TypeError('Expected the raid picker to expose focusable controls');
+    }
+
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(document.activeElement).toBe(first);
+
+    await userEvent.tab({ shift: true });
+    expect(document.activeElement).toBe(last);
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(first);
+
+    await userEvent.click(screen.getByRole('button', { name: '1780 레이드 변경 닫기' }));
+    expect(root).not.toHaveAttribute('aria-hidden');
+    expect(document.activeElement).toBe(openButton);
+
+    document.body.removeChild(root);
   });
 
   it('keeps the raid picker inline inside the character card on desktop', async () => {

--- a/src/components/simulation/CharacterRaidCard.test.tsx
+++ b/src/components/simulation/CharacterRaidCard.test.tsx
@@ -1,38 +1,69 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { calculateCharacterGold, RAID_COLUMNS } from '../../data/raidGold';
 import CharacterRaidCard from './CharacterRaidCard';
 import { normalizeRaidSelection } from '../../utils/simulationKeys';
 
-describe('CharacterRaidCard raid simulation flow', () => {
-  it('renders Belgardin from raid data in default selection and the raid picker', async () => {
-    const result = calculateCharacterGold('1780', '버서커', '1780.00', 'img');
-    const selectedRaidKeys = result.selectedRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`);
-    const onRaidSelectionChange = jest.fn();
+type RenderCardOptions = {
+  readonly hasCustomRaids?: boolean;
+  readonly onResetRaidSelection?: () => void;
+};
 
-    render(
-      <MemoryRouter>
-        <CharacterRaidCard
-          result={result}
-          index={0}
-          formatGold={(gold) => gold.toLocaleString()}
-          bonusSelections={new Set()}
-          onToggleBonus={jest.fn()}
-          onToggleAllCharBonus={jest.fn()}
-          isAllCharBonusSelected={false}
-          characterBonusCost={0}
-          coreData={{ base: 16, bonus: 0 }}
-          completedRaids={new Set()}
-          onToggleComplete={jest.fn()}
-          selectedRaidKeys={selectedRaidKeys}
-          onRaidSelectionChange={onRaidSelectionChange}
-          onResetRaidSelection={jest.fn()}
-          hasCustomRaids={false}
-          allRaids={RAID_COLUMNS}
-        />
-      </MemoryRouter>,
-    );
+const setViewportWidth = (width: number): void => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+};
+
+beforeEach(() => {
+  setViewportWidth(390);
+  document.body.style.overflow = '';
+});
+
+afterEach(() => {
+  document.body.style.overflow = '';
+});
+
+const renderCard = ({
+  hasCustomRaids = false,
+  onResetRaidSelection = jest.fn(),
+}: RenderCardOptions = {}) => {
+  const result = calculateCharacterGold('1780', '버서커', '1780.00', 'img');
+  const selectedRaidKeys = result.selectedRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`);
+  const onRaidSelectionChange = jest.fn();
+
+  render(
+    <MemoryRouter>
+      <CharacterRaidCard
+        result={result}
+        index={0}
+        formatGold={(gold) => gold.toLocaleString()}
+        bonusSelections={new Set()}
+        onToggleBonus={jest.fn()}
+        onToggleAllCharBonus={jest.fn()}
+        isAllCharBonusSelected={false}
+        characterBonusCost={0}
+        coreData={{ base: 16, bonus: 0 }}
+        completedRaids={new Set()}
+        onToggleComplete={jest.fn()}
+        selectedRaidKeys={selectedRaidKeys}
+        onRaidSelectionChange={onRaidSelectionChange}
+        onResetRaidSelection={onResetRaidSelection}
+        hasCustomRaids={hasCustomRaids}
+        allRaids={RAID_COLUMNS}
+      />
+    </MemoryRouter>,
+  );
+
+  return { onRaidSelectionChange, selectedRaidKeys };
+};
+
+describe('CharacterRaidCard raid simulation flow', () => {
+  it('keeps character context and Belgardin selection semantics in the raid panel', async () => {
+    const { onRaidSelectionChange, selectedRaidKeys } = renderCard();
 
     expect(screen.getByText('벨가르딘 (그림자)')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: '벨가르딘 (그림자) 레이드' }))
@@ -40,6 +71,9 @@ describe('CharacterRaidCard raid simulation flow', () => {
     expect(screen.getAllByText('나이트메어').length).toBeGreaterThan(1);
     expect(screen.getByText('75,000G')).toBeInTheDocument();
     expect(screen.getByText('코어 16')).toBeInTheDocument();
+
+    fireEvent.error(screen.getByRole('img', { name: '1780' }));
+    expect(screen.getByRole('img', { name: '1780 이미지 없음' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('벨가르딘 (그림자)'));
 
@@ -51,6 +85,12 @@ describe('CharacterRaidCard raid simulation flow', () => {
 
     await userEvent.click(screen.getByRole('button', { name: '레이드 변경' }));
 
+    expect(screen.getByRole('button', { name: '레이드 변경 패널 열림' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('dialog', { name: '1780 레이드 변경' })).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(screen.getByText('현재 선택 레이드')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '참여 가능 레이드' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '참여 불가 레이드' })).toBeInTheDocument();
     expect(screen.getAllByText('벨가르딘 (그림자)').length).toBeGreaterThan(1);
     expect(screen.getAllByRole('img', { name: '벨가르딘 (그림자) 레이드' })).toHaveLength(4);
     expect(screen.getByText('62,000G')).toBeInTheDocument();
@@ -61,6 +101,81 @@ describe('CharacterRaidCard raid simulation flow', () => {
     expect(onRaidSelectionChange).toHaveBeenCalledWith(
       selectedRaidKeys.filter((key) => key !== '벨가르딘 (그림자)::나이트메어'),
     );
+
+    await userEvent.click(screen.getByRole('button', { name: '1780 레이드 변경 닫기' }));
+    expect(screen.queryByRole('dialog', { name: '1780 레이드 변경' })).not.toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('portals the raid picker dialog outside the character glass card', async () => {
+    renderCard();
+    const openButton = screen.getByRole('button', { name: '레이드 변경' });
+    const card = openButton.closest('.glass-card');
+
+    if (!(card instanceof HTMLElement)) {
+      throw new TypeError('Expected the raid change button to be inside a character glass card');
+    }
+
+    await userEvent.click(openButton);
+
+    const dialog = screen.getByRole('dialog', { name: '1780 레이드 변경' });
+    expect(document.body).toContainElement(dialog);
+    expect(card).not.toContainElement(dialog);
+  });
+
+  it('keeps the raid picker inline inside the character card on desktop', async () => {
+    setViewportWidth(1024);
+    renderCard();
+    const openButton = screen.getByRole('button', { name: '레이드 변경' });
+    const card = openButton.closest('.glass-card');
+
+    if (!(card instanceof HTMLElement)) {
+      throw new TypeError('Expected the raid change button to be inside a character glass card');
+    }
+
+    await userEvent.click(openButton);
+
+    expect(card).toContainElement(screen.getByRole('dialog', { name: '1780 레이드 변경' }));
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('keeps an open desktop raid picker open during an ordinary desktop resize', async () => {
+    setViewportWidth(1024);
+    renderCard();
+    await userEvent.click(screen.getByRole('button', { name: '레이드 변경' }));
+
+    setViewportWidth(1280);
+    fireEvent(window, new Event('resize'));
+
+    expect(screen.getByRole('dialog', { name: '1780 레이드 변경' })).toBeInTheDocument();
+  });
+
+  it('closes multiple desktop raid pickers before a mobile breakpoint transition can stack modals', async () => {
+    setViewportWidth(1024);
+    renderCard();
+    renderCard();
+
+    const openButtons = screen.getAllByRole('button', { name: '레이드 변경' });
+    await userEvent.click(openButtons[0]);
+    await userEvent.click(openButtons[1]);
+    expect(screen.getAllByRole('dialog', { name: '1780 레이드 변경' })).toHaveLength(2);
+
+    setViewportWidth(390);
+    fireEvent(window, new Event('resize'));
+
+    expect(screen.queryAllByRole('dialog', { name: '1780 레이드 변경' })).toHaveLength(0);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('resets a custom selection without losing the open panel context', async () => {
+    const onResetRaidSelection = jest.fn();
+    renderCard({ hasCustomRaids: true, onResetRaidSelection });
+
+    await userEvent.click(screen.getByRole('button', { name: '레이드 변경' }));
+    await userEvent.click(screen.getByRole('button', { name: '기본 선택으로 초기화' }));
+
+    expect(onResetRaidSelection).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: '1780 레이드 변경' })).toBeInTheDocument();
   });
 
   it('keeps only one Belgardin difficulty selected when adding a second one', () => {

--- a/src/components/simulation/CharacterRaidCard.tsx
+++ b/src/components/simulation/CharacterRaidCard.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { CharacterGoldResult, RaidColumn } from '../../data/raidGold';
+import FallbackImage from '../FallbackImage';
 import RaidPicker from './RaidPicker';
 import SelectedRaidRow from './SelectedRaidRow';
 
@@ -44,6 +45,40 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
   allRaids,
 }) => {
   const [showRaidPicker, setShowRaidPicker] = useState(false);
+  const raidPickerButtonRef = useRef<HTMLButtonElement>(null);
+  const wasRaidPickerOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (showRaidPicker) {
+      wasRaidPickerOpenRef.current = true;
+      return;
+    }
+
+    if (!wasRaidPickerOpenRef.current) return;
+    wasRaidPickerOpenRef.current = false;
+    raidPickerButtonRef.current?.focus();
+  }, [showRaidPicker]);
+
+  useEffect(() => {
+    if (!showRaidPicker) return;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setShowRaidPicker(false);
+    };
+    let wasMobileViewport = window.innerWidth < 768;
+    const handleResize = (): void => {
+      const isMobileViewport = window.innerWidth < 768;
+      if (wasMobileViewport !== isMobileViewport) setShowRaidPicker(false);
+      wasMobileViewport = isMobileViewport;
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [showRaidPicker]);
 
   const characterBoundGold = result.selectedRaids.reduce((sum, r) => sum + r.boundGold, 0);
   const characterTradeableGold = result.totalGold - characterBoundGold;
@@ -60,11 +95,12 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
         <aside className="min-w-0 rounded-xl border border-gray-200/80 bg-gray-50/70 p-3 shadow-sm shadow-gray-900/5 dark:border-white/10 dark:bg-black/20 dark:shadow-black/20 lg:w-60 lg:flex-none">
           <div className="flex min-w-0 items-center gap-3">
             <div className="relative h-16 w-16 flex-none overflow-hidden rounded-xl border border-white/50 bg-gray-100 shadow-sm dark:border-white/10 dark:bg-white/5">
-              <img
+              <FallbackImage
                 src={result.characterImage}
                 alt={result.characterName}
                 width={128}
                 height={128}
+                fallbackLabel={`${result.characterName} 캐릭터 이미지 없음`}
                 className="h-full w-full object-cover object-top"
               />
               <div aria-hidden="true" className="absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-black/45 to-transparent" />
@@ -94,7 +130,7 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
             </div>
           </div>
 
-          {!dimmed && (result.selectedRaids.length > 0 || result.availableRaids.length > 0) && (
+          {!dimmed && (result.selectedRaids.length > 0 || allRaids.length > 0) && (
             <div className="mt-3 flex min-w-0 gap-1.5 border-t border-gray-200/70 pt-2.5 dark:border-white/10">
               {result.selectedRaids.length > 0 && (
                 <button
@@ -109,10 +145,12 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
                   {isAllCharBonusSelected ? '더보기 해제' : '일괄 더보기'}
                 </button>
               )}
-              {result.availableRaids.length > 0 && (
+              {allRaids.length > 0 && (
                 <button
+                  ref={raidPickerButtonRef}
                   type="button"
                   aria-expanded={showRaidPicker}
+                  aria-label={showRaidPicker ? '레이드 변경 패널 열림' : '레이드 변경'}
                   onClick={() => setShowRaidPicker((current) => !current)}
                   className={`min-h-9 min-w-0 flex-1 rounded-lg border px-2 py-1.5 text-[10px] font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 ${
                     showRaidPicker
@@ -120,7 +158,7 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
                       : 'border-gray-200 bg-white/70 text-gray-600 hover:border-la-gold/50 hover:text-la-gold-deep dark:border-white/10 dark:bg-white/5 dark:text-gray-400 dark:hover:text-la-gold'
                   }`}
                 >
-                  {showRaidPicker ? '레이드 선택 닫기' : '레이드 변경'}
+                  {showRaidPicker ? '레이드 선택 중' : '레이드 변경'}
                 </button>
               )}
             </div>
@@ -160,7 +198,10 @@ const CharacterRaidCard: React.FC<CharacterRaidCardProps> = ({
               availableRaids={result.availableRaids}
               selectedRaidKeys={selectedRaidKeys}
               hasCustomRaids={hasCustomRaids}
+              characterName={result.characterName}
+              currentRaidNames={result.selectedRaids.map((raid) => `${raid.raidName} ${raid.difficulty}`)}
               formatGold={formatGold}
+              onClose={() => setShowRaidPicker(false)}
               onRaidSelectionChange={onRaidSelectionChange}
               onResetRaidSelection={onResetRaidSelection}
             />

--- a/src/components/simulation/RaidPicker.tsx
+++ b/src/components/simulation/RaidPicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import type { RaidColumn, SelectedRaid } from '../../data/raidGold';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import FallbackImage from '../FallbackImage';
 import StateFeedback from '../StateFeedback';
 
@@ -33,6 +34,8 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
   const dialogRef = React.useRef<HTMLElement>(null);
   const [isMobile, setIsMobile] = React.useState(() => window.innerWidth < 768);
 
+  useBodyScrollLock(isMobile);
+
   React.useEffect(() => {
     const handleResize = (): void => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
@@ -41,11 +44,6 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
 
   React.useEffect(() => {
     if (!isMobile) return;
-
-    const root = document.getElementById('root');
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    root?.setAttribute('aria-hidden', 'true');
 
     const focusableSelector = 'button:not([disabled]), input:not([disabled]), a[href]';
     const focusFirst = (): void => {
@@ -75,8 +73,6 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-      root?.removeAttribute('aria-hidden');
     };
   }, [isMobile]);
   const availableKeys = new Set(

--- a/src/components/simulation/RaidPicker.tsx
+++ b/src/components/simulation/RaidPicker.tsx
@@ -122,9 +122,9 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
         </header>
 
         <div className="flex-none border-b border-gray-200 bg-gray-50/70 px-4 py-3 dark:border-white/10 dark:bg-black/20">
-          <p className="text-[10px] font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">현재 캐릭터</p>
+          <p className="text-[10px] font-bold uppercase tracking-wide text-gray-500 dark:text-gray-500">현재 캐릭터</p>
           <p className="mt-0.5 break-words text-sm font-bold text-gray-800 dark:text-gray-100">{characterName}</p>
-          <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">현재 선택 레이드</p>
+          <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-gray-500 dark:text-gray-500">현재 선택 레이드</p>
           <p className="mt-0.5 break-words text-xs leading-relaxed text-gray-600 dark:text-gray-300">
             {currentRaidNames.length > 0 ? currentRaidNames.join(' · ') : '선택된 레이드 없음'}
           </p>
@@ -267,7 +267,7 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
               </section>
             ))
           )}
-          <p className="text-[10px] text-gray-400 dark:text-gray-500">
+          <p className="text-[10px] text-gray-500 dark:text-gray-500">
             제한 없이 체크 가능 · 참여 레벨 미달 레이드는 선택 상태만 저장됩니다.
           </p>
         </div>

--- a/src/components/simulation/RaidPicker.tsx
+++ b/src/components/simulation/RaidPicker.tsx
@@ -5,6 +5,40 @@ import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import FallbackImage from '../FallbackImage';
 import StateFeedback from '../StateFeedback';
 
+type RaidGroupKey = 'available' | 'unavailable';
+
+interface RaidGroupCollapseInput {
+  /** 참여 가능 레이드 개수 */
+  readonly availableCount: number;
+  /** 참여 불가 레이드 개수 */
+  readonly unavailableCount: number;
+  /** 참여 불가 레이드 중 이미 체크되어 있는 개수 */
+  readonly unavailableSelectedCount: number;
+}
+
+/**
+ * 패널을 열었을 때의 그룹별 초기 접힘 상태를 결정한다.
+ * 마운트 시 1회만 평가되므로 이후 선택 변경에는 영향을 받지 않는다.
+ */
+const resolveInitialCollapsed = ({
+  availableCount,
+  unavailableCount,
+  unavailableSelectedCount,
+}: RaidGroupCollapseInput): Record<RaidGroupKey, boolean> => {
+  // 참여 가능 그룹은 항상 펼친다. 조작 대상이 여기 있고, 비어 있으면 빈 상태 안내를 보여줘야 한다.
+  // 참여 불가 그룹은 기본 접기로 첫 화면 길이를 줄이되, 접으면 맥락이 사라지는 두 경우는 예외로 펼친다.
+  const keepUnavailableOpen =
+    // 사용자가 참여 불가 레이드를 직접 체크해 둔 경우: 접으면 그 선택이 화면에서 사라진다.
+    unavailableSelectedCount > 0 ||
+    // 참여 가능 레이드가 없는 경우: 접으면 조작할 대상이 하나도 보이지 않는다.
+    availableCount === 0;
+
+  return {
+    available: false,
+    unavailable: unavailableCount > 0 && !keepUnavailableOpen,
+  };
+};
+
 interface RaidPickerProps {
   readonly allRaids: readonly RaidColumn[];
   readonly availableRaids: readonly SelectedRaid[];
@@ -55,7 +89,10 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
       if (event.key !== 'Tab') return;
       const dialog = dialogRef.current;
       if (!dialog) return;
-      const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector));
+      // 접힌 그룹([hidden]) 내부 요소는 focus 불가하므로 트랩 경계 계산에서 제외한다.
+      const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        (element) => element.closest('[hidden]') === null,
+      );
       if (focusables.length === 0) return;
       const first = focusables[0];
       const last = focusables[focusables.length - 1];
@@ -80,16 +117,34 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
   );
   const raidGroups = [
     {
+      key: 'available',
       label: '참여 가능 레이드',
       available: true,
       raids: allRaids.filter((raid) => availableKeys.has(`${raid.raidName}::${raid.difficulty}`)),
     },
     {
+      key: 'unavailable',
       label: '참여 불가 레이드',
       available: false,
       raids: allRaids.filter((raid) => !availableKeys.has(`${raid.raidName}::${raid.difficulty}`)),
     },
   ] as const;
+
+  // 선택 상태(selectedRaidKeys)와 독립적으로 유지되는 접힘 상태.
+  // lazy initializer라 마운트 시 1회만 평가되고, 이후 체크 변경에는 재계산되지 않는다.
+  const [collapsedGroups, setCollapsedGroups] = React.useState<Record<RaidGroupKey, boolean>>(() =>
+    resolveInitialCollapsed({
+      availableCount: raidGroups[0].raids.length,
+      unavailableCount: raidGroups[1].raids.length,
+      unavailableSelectedCount: raidGroups[1].raids.filter((raid) =>
+        selectedRaidKeys.includes(`${raid.raidName}::${raid.difficulty}`),
+      ).length,
+    }),
+  );
+
+  const toggleGroup = (key: RaidGroupKey): void => {
+    setCollapsedGroups((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
 
   const picker = (
     <div className="fixed inset-0 z-[9998] flex items-end bg-black/40 md:static md:block md:bg-transparent">
@@ -147,15 +202,39 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
               compact
             />
           ) : (
-            raidGroups.map((group) => (
+            raidGroups.map((group) => {
+              const collapsed = collapsedGroups[group.key];
+              const panelId = `${titleId}-${group.key}`;
+              return (
               <section key={group.label} aria-label={group.label}>
-                <div className="mb-2 flex items-center justify-between gap-3">
-                  <h3 className="text-xs font-bold text-gray-700 dark:text-gray-200">{group.label}</h3>
-                  <span className="rounded-md bg-gray-100 px-2 py-1 text-[10px] font-bold tabular-nums text-gray-500 dark:bg-white/10 dark:text-gray-400">
-                    {group.raids.length}개
-                  </span>
-                </div>
+                <h3 className="mb-2">
+                  <button
+                    type="button"
+                    aria-expanded={!collapsed}
+                    aria-controls={panelId}
+                    onClick={() => toggleGroup(group.key)}
+                    className="flex min-h-10 w-full items-center justify-between gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:hover:bg-white/5"
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <svg
+                        aria-hidden="true"
+                        className={`h-4 w-4 flex-none text-gray-400 transition-transform duration-200 ${collapsed ? '' : 'rotate-90'}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                      </svg>
+                      <span className="truncate text-xs font-bold text-gray-700 dark:text-gray-200">{group.label}</span>
+                    </span>
+                    <span className="flex-none rounded-md bg-gray-100 px-2 py-1 text-[10px] font-bold tabular-nums text-gray-500 dark:bg-white/10 dark:text-gray-400">
+                      {group.raids.length}개
+                    </span>
+                  </button>
+                </h3>
 
+                <div id={panelId} hidden={collapsed}>
                 {group.raids.length === 0 ? (
                   group.available ? (
                     <StateFeedback
@@ -264,8 +343,10 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
                     })}
                   </div>
                 )}
+                </div>
               </section>
-            ))
+              );
+            })
           )}
           <p className="text-[10px] text-gray-500 dark:text-gray-500">
             제한 없이 체크 가능 · 참여 레벨 미달 레이드는 선택 상태만 저장됩니다.

--- a/src/components/simulation/RaidPicker.tsx
+++ b/src/components/simulation/RaidPicker.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import type { RaidColumn, SelectedRaid } from '../../data/raidGold';
+import FallbackImage from '../FallbackImage';
+import StateFeedback from '../StateFeedback';
 
 interface RaidPickerProps {
-  readonly allRaids: RaidColumn[];
-  readonly availableRaids: SelectedRaid[];
-  readonly selectedRaidKeys: string[];
+  readonly allRaids: readonly RaidColumn[];
+  readonly availableRaids: readonly SelectedRaid[];
+  readonly selectedRaidKeys: readonly string[];
   readonly hasCustomRaids: boolean;
+  readonly characterName: string;
+  readonly currentRaidNames: readonly string[];
   readonly formatGold: (gold: number) => string;
+  readonly onClose: () => void;
   readonly onRaidSelectionChange: (keys: string[]) => void;
   readonly onResetRaidSelection: () => void;
 }
@@ -16,132 +22,266 @@ const RaidPicker: React.FC<RaidPickerProps> = ({
   availableRaids,
   selectedRaidKeys,
   hasCustomRaids,
+  characterName,
+  currentRaidNames,
   formatGold,
+  onClose,
   onRaidSelectionChange,
   onResetRaidSelection,
-}) => (
-  <section className="mt-4 min-w-0 border-t border-gray-200 pt-4 dark:border-white/10" aria-label="레이드 선택">
-    <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-      <div>
-        <p className="text-sm font-bold text-gray-800 dark:text-gray-100">참여 레이드 선택</p>
-        <p className="mt-0.5 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">
-          체크한 레이드 중 참여 가능한 골드 상위 3개가 적용됩니다.
-        </p>
-      </div>
-      {hasCustomRaids && (
-        <button
-          type="button"
-          onClick={onResetRaidSelection}
-          className="w-fit rounded-lg border border-gray-200 bg-white/70 px-2.5 py-1.5 text-[11px] font-semibold text-gray-600 transition-colors hover:border-la-gold/50 hover:text-la-gold-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:border-white/10 dark:bg-white/5 dark:text-gray-400 dark:hover:text-la-gold"
-        >
-          기본값(골드 높은 순 3개)으로 되돌리기
-        </button>
-      )}
-    </div>
+}) => {
+  const titleId = React.useId();
+  const dialogRef = React.useRef<HTMLElement>(null);
+  const [isMobile, setIsMobile] = React.useState(() => window.innerWidth < 768);
 
-    <div className="grid max-h-96 min-w-0 grid-cols-1 gap-2 overflow-y-auto pr-1 md:grid-cols-2">
-      {allRaids.map((raid) => {
-        const key = `${raid.raidName}::${raid.difficulty}`;
-        const available = availableRaids.some(
-          (candidate) => candidate.raidName === raid.raidName && candidate.difficulty === raid.difficulty,
-        );
-        const checked = selectedRaidKeys.includes(key);
-        return (
-          <label
-            key={key}
-            className={`group relative min-h-28 min-w-0 cursor-pointer overflow-hidden rounded-xl border bg-la-dark text-white shadow-sm transition-[border-color,box-shadow,opacity] duration-200 focus-within:ring-2 focus-within:ring-la-gold/60 active:opacity-90 ${
-              available
-                ? checked
-                  ? 'border-la-gold shadow-gold-glow ring-1 ring-inset ring-la-gold/70'
-                  : 'border-gray-700 hover:border-la-gold/60 dark:border-white/10'
-                : checked
-                  ? 'border-gray-400/70 ring-1 ring-inset ring-gray-300/40 dark:border-white/20'
-                  : 'border-gray-700/70 hover:border-gray-500 dark:border-white/10'
-            }`}
+  React.useEffect(() => {
+    const handleResize = (): void => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isMobile) return;
+
+    const root = document.getElementById('root');
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    root?.setAttribute('aria-hidden', 'true');
+
+    const focusableSelector = 'button:not([disabled]), input:not([disabled]), a[href]';
+    const focusFirst = (): void => {
+      dialogRef.current?.querySelector<HTMLElement>(focusableSelector)?.focus();
+    };
+    focusFirst();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab') return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector));
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      root?.removeAttribute('aria-hidden');
+    };
+  }, [isMobile]);
+  const availableKeys = new Set(
+    availableRaids.map((raid) => `${raid.raidName}::${raid.difficulty}`),
+  );
+  const raidGroups = [
+    {
+      label: '참여 가능 레이드',
+      available: true,
+      raids: allRaids.filter((raid) => availableKeys.has(`${raid.raidName}::${raid.difficulty}`)),
+    },
+    {
+      label: '참여 불가 레이드',
+      available: false,
+      raids: allRaids.filter((raid) => !availableKeys.has(`${raid.raidName}::${raid.difficulty}`)),
+    },
+  ] as const;
+
+  const picker = (
+    <div className="fixed inset-0 z-[9998] flex items-end bg-black/40 md:static md:block md:bg-transparent">
+      <section
+        ref={dialogRef}
+        role="dialog"
+        aria-modal={isMobile ? 'true' : undefined}
+        aria-labelledby={titleId}
+        className="flex max-h-[90dvh] w-full min-w-0 flex-col overflow-hidden rounded-t-xl border border-b-0 border-gray-200 bg-white shadow-xl dark:border-white/10 dark:bg-la-dark-card md:mt-4 md:max-h-none md:rounded-xl md:border-b md:shadow-sm"
+      >
+        <header className="flex flex-none items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-white/10">
+          <div className="min-w-0">
+            <h2 id={titleId} className="break-words text-sm font-bold text-gray-900 dark:text-white">
+              {characterName} 레이드 변경
+            </h2>
+            <p className="mt-1 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">
+              체크한 레이드 중 참여 가능한 골드 상위 3개가 적용됩니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label={`${characterName} 레이드 변경 닫기`}
+            onClick={onClose}
+            className="flex h-10 w-10 flex-none items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-400 dark:hover:bg-white/10"
           >
-            <img
-              src={raid.imagePath}
-              alt={`${raid.raidName} 레이드`}
-              width={480}
-              height={224}
-              loading="lazy"
-              className={`absolute inset-0 h-full w-full object-cover transition-[filter,opacity,transform] duration-300 group-hover:scale-105 ${
-                available ? (checked ? 'opacity-95' : 'opacity-80') : 'opacity-30 grayscale'
-              }`}
-            />
-            <span
-              aria-hidden="true"
-              className={`absolute inset-0 bg-gradient-to-r ${
-                available
-                  ? 'from-black/90 via-black/55 to-black/10'
-                  : 'from-black via-black/80 to-black/55'
-              }`}
-            />
-            <span aria-hidden="true" className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/80 to-transparent" />
+            <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
 
-            <span className="relative z-10 flex min-h-28 min-w-0 flex-col justify-between p-3">
-              <span className="flex items-start justify-between gap-2">
-                <span
-                  className={`rounded-md border px-2 py-1 text-[10px] font-bold backdrop-blur-sm ${
-                    available
-                      ? 'border-white/20 bg-black/45 text-white'
-                      : 'border-gray-400/30 bg-black/60 text-gray-300'
-                  }`}
-                >
-                  {available ? raid.difficulty : `참여 불가 · Lv.${raid.requiredLevel}`}
-                </span>
-                <input
-                  type="checkbox"
-                  aria-label={`${raid.raidName} ${raid.difficulty} 선택`}
-                  checked={checked}
-                  onChange={() => {
-                    const next = checked
-                      ? selectedRaidKeys.filter((selectedKey) => selectedKey !== key)
-                      : [...selectedRaidKeys, key];
-                    onRaidSelectionChange(next);
-                  }}
-                  className="sr-only"
-                />
-                <span
-                  aria-hidden="true"
-                  className={`flex h-8 w-8 flex-none items-center justify-center rounded-full border-2 shadow-sm backdrop-blur-md transition-colors ${
-                    checked
-                      ? available
-                        ? 'border-la-gold bg-la-gold text-la-dark'
-                        : 'border-gray-300 bg-gray-200 text-gray-700'
-                      : 'border-white/60 bg-black/35 text-transparent group-hover:border-white'
-                  }`}
-                >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                </span>
-              </span>
+        <div className="flex-none border-b border-gray-200 bg-gray-50/70 px-4 py-3 dark:border-white/10 dark:bg-black/20">
+          <p className="text-[10px] font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">현재 캐릭터</p>
+          <p className="mt-0.5 break-words text-sm font-bold text-gray-800 dark:text-gray-100">{characterName}</p>
+          <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">현재 선택 레이드</p>
+          <p className="mt-0.5 break-words text-xs leading-relaxed text-gray-600 dark:text-gray-300">
+            {currentRaidNames.length > 0 ? currentRaidNames.join(' · ') : '선택된 레이드 없음'}
+          </p>
+          <button
+            type="button"
+            disabled={!hasCustomRaids}
+            onClick={onResetRaidSelection}
+            className="mt-3 min-h-10 rounded-lg border border-gray-200 bg-white px-3 py-2 text-[11px] font-semibold text-gray-600 transition-colors hover:border-la-gold/50 hover:text-la-gold-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 disabled:cursor-default disabled:opacity-50 dark:border-white/10 dark:bg-white/5 dark:text-gray-400 dark:hover:text-la-gold"
+          >
+            {hasCustomRaids ? '기본 선택으로 초기화' : '기본 선택 사용 중'}
+          </button>
+        </div>
 
-              <span className="min-w-0">
-                <span className="block truncate text-sm font-black tracking-tight text-white sm:text-base">
-                  {raid.raidName}
-                </span>
-                <span className="mt-1 flex items-center gap-2 text-[11px]">
-                  <span className={`font-bold tabular-nums ${available ? 'text-la-gold-light' : 'text-gray-400'}`}>
-                    {formatGold(raid.totalGold)}G
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto overscroll-contain p-3 md:max-h-96">
+          {allRaids.length === 0 ? (
+            <StateFeedback
+              tone="empty"
+              title="선택할 레이드가 없습니다"
+              description="레이드 정보가 준비되면 이곳에서 참여 레이드를 변경할 수 있습니다."
+              compact
+            />
+          ) : (
+            raidGroups.map((group) => (
+              <section key={group.label} aria-label={group.label}>
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <h3 className="text-xs font-bold text-gray-700 dark:text-gray-200">{group.label}</h3>
+                  <span className="rounded-md bg-gray-100 px-2 py-1 text-[10px] font-bold tabular-nums text-gray-500 dark:bg-white/10 dark:text-gray-400">
+                    {group.raids.length}개
                   </span>
-                  {checked && (
-                    <span className={`font-semibold ${available ? 'text-la-gold-light' : 'text-gray-300'}`}>
-                      선택됨
-                    </span>
-                  )}
-                </span>
-              </span>
-            </span>
-          </label>
-        );
-      })}
+                </div>
+
+                {group.raids.length === 0 ? (
+                  group.available ? (
+                    <StateFeedback
+                      tone="empty"
+                      title="참여 가능한 레이드가 없습니다"
+                      description="현재 아이템 레벨에서 참여할 수 있는 레이드가 없습니다. 참여 불가 목록의 선택 상태는 저장할 수 있습니다."
+                      compact
+                    />
+                  ) : null
+                ) : (
+                  <div className="grid min-w-0 grid-cols-1 gap-2 md:grid-cols-2">
+                    {group.raids.map((raid) => {
+                      const key = `${raid.raidName}::${raid.difficulty}`;
+                      const checked = selectedRaidKeys.includes(key);
+                      return (
+                        <label
+                          key={key}
+                          className={`group relative min-h-28 min-w-0 cursor-pointer overflow-hidden rounded-xl border bg-la-dark text-white shadow-sm transition-[border-color,box-shadow,opacity] duration-200 focus-within:ring-2 focus-within:ring-la-gold/60 active:opacity-90 ${
+                            group.available
+                              ? checked
+                                ? 'border-la-gold shadow-gold-glow ring-1 ring-inset ring-la-gold/70'
+                                : 'border-gray-700 hover:border-la-gold/60 dark:border-white/10'
+                              : checked
+                                ? 'border-gray-400/70 ring-1 ring-inset ring-gray-300/40 dark:border-white/20'
+                                : 'border-gray-700/70 hover:border-gray-500 dark:border-white/10'
+                          }`}
+                        >
+                          <FallbackImage
+                            src={raid.imagePath}
+                            alt={`${raid.raidName} 레이드`}
+                            width={480}
+                            height={224}
+                            loading="lazy"
+                            fallbackClassName="bg-la-dark text-gray-500"
+                            className={`absolute inset-0 h-full w-full object-cover transition-[filter,opacity,transform] duration-300 group-hover:scale-105 ${
+                              group.available ? (checked ? 'opacity-95' : 'opacity-80') : 'opacity-30 grayscale'
+                            }`}
+                          />
+                          <span
+                            aria-hidden="true"
+                            className={`absolute inset-0 bg-gradient-to-r ${
+                              group.available
+                                ? 'from-black/90 via-black/55 to-black/10'
+                                : 'from-black via-black/80 to-black/55'
+                            }`}
+                          />
+                          <span aria-hidden="true" className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/80 to-transparent" />
+
+                          <span className="relative z-10 flex min-h-28 min-w-0 flex-col justify-between p-3">
+                            <span className="flex items-start justify-between gap-2">
+                              <span
+                                className={`rounded-md border px-2 py-1 text-[10px] font-bold backdrop-blur-sm ${
+                                  group.available
+                                    ? 'border-white/20 bg-black/45 text-white'
+                                    : 'border-gray-400/30 bg-black/60 text-gray-300'
+                                }`}
+                              >
+                                {group.available ? raid.difficulty : `참여 불가 · Lv.${raid.requiredLevel}`}
+                              </span>
+                              <input
+                                type="checkbox"
+                                aria-label={`${raid.raidName} ${raid.difficulty} 선택`}
+                                checked={checked}
+                                onChange={() => {
+                                  const next = checked
+                                    ? selectedRaidKeys.filter((selectedKey) => selectedKey !== key)
+                                    : [...selectedRaidKeys, key];
+                                  onRaidSelectionChange(next);
+                                }}
+                                className="sr-only"
+                              />
+                              <span
+                                aria-hidden="true"
+                                className={`flex h-8 w-8 flex-none items-center justify-center rounded-full border-2 shadow-sm backdrop-blur-md transition-colors ${
+                                  checked
+                                    ? group.available
+                                      ? 'border-la-gold bg-la-gold text-la-dark'
+                                      : 'border-gray-300 bg-gray-200 text-gray-700'
+                                    : 'border-white/60 bg-black/35 text-transparent group-hover:border-white'
+                                }`}
+                              >
+                                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                                </svg>
+                              </span>
+                            </span>
+
+                            <span className="min-w-0">
+                              <span className="block truncate text-sm font-black tracking-tight text-white sm:text-base">
+                                {raid.raidName}
+                              </span>
+                              <span className="mt-1 flex items-center gap-2 text-[11px]">
+                                <span className={`font-bold tabular-nums ${group.available ? 'text-la-gold-light' : 'text-gray-400'}`}>
+                                  {formatGold(raid.totalGold)}G
+                                </span>
+                                {checked && (
+                                  <span className={`font-semibold ${group.available ? 'text-la-gold-light' : 'text-gray-300'}`}>
+                                    선택됨
+                                  </span>
+                                )}
+                              </span>
+                            </span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            ))
+          )}
+          <p className="text-[10px] text-gray-400 dark:text-gray-500">
+            제한 없이 체크 가능 · 참여 레벨 미달 레이드는 선택 상태만 저장됩니다.
+          </p>
+        </div>
+      </section>
     </div>
-    <p className="mt-2 text-[10px] text-gray-400 dark:text-gray-500">
-      제한 없이 체크 가능 · 참여 레벨 미달 레이드는 선택 상태만 저장됩니다.
-    </p>
-  </section>
-);
+  );
+
+  return isMobile
+    ? createPortal(picker, document.body)
+    : picker;
+};
 
 export default RaidPicker;

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+export const useBodyScrollLock = (locked: boolean): void => {
+  useEffect(() => {
+    if (!locked || typeof document === 'undefined') return;
+
+    const scrollY = window.scrollY;
+    const root = document.getElementById('root');
+    const previousBodyPosition = document.body.style.position;
+    const previousBodyTop = document.body.style.top;
+    const previousBodyWidth = document.body.style.width;
+    const previousBodyOverflow = document.body.style.overflow;
+
+    // iOS Safari blocks background rubber-band scrolling only when the body is fixed.
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+    document.body.style.overflow = 'hidden';
+    root?.setAttribute('aria-hidden', 'true');
+
+    return () => {
+      document.body.style.position = previousBodyPosition;
+      document.body.style.top = previousBodyTop;
+      document.body.style.width = previousBodyWidth;
+      document.body.style.overflow = previousBodyOverflow;
+      root?.removeAttribute('aria-hidden');
+      window.scrollTo(0, scrollY);
+    };
+  }, [locked]);
+};

--- a/src/pages/Character.test.tsx
+++ b/src/pages/Character.test.tsx
@@ -1,5 +1,67 @@
-import type { EquipmentItem } from '../types/lostark';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Character from './Character';
+import type { CharacterProfile, EquipmentItem } from '../types/lostark';
 import { getCombatEquipmentItems } from '../utils/characterEquipment';
+import {
+  fetchArkGrid,
+  fetchEngravings,
+  fetchEquipment,
+  fetchGems,
+  fetchProfile,
+} from '../utils/api';
+
+const mockSetSearchParams = jest.fn();
+let mockCurrentSearchParams = new URLSearchParams('nickname=테스트캐릭터');
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useLocation: () => ({ pathname: '/character' }),
+    useSearchParams: () => [mockCurrentSearchParams, mockSetSearchParams],
+  }),
+  { virtual: true },
+);
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+jest.mock('../components/PullToRefresh', () => ({ children }: { children: React.ReactNode }) => <>{children}</>);
+
+jest.mock('../utils/api', () => ({
+  fetchProfile: jest.fn(),
+  fetchEquipment: jest.fn(),
+  fetchGems: jest.fn(),
+  fetchEngravings: jest.fn(),
+  fetchArkGrid: jest.fn(),
+  LS_NICKNAME: 'lostark_nickname',
+}));
+
+const mockedFetchProfile = fetchProfile as jest.MockedFunction<typeof fetchProfile>;
+const mockedFetchEquipment = fetchEquipment as jest.MockedFunction<typeof fetchEquipment>;
+const mockedFetchGems = fetchGems as jest.MockedFunction<typeof fetchGems>;
+const mockedFetchEngravings = fetchEngravings as jest.MockedFunction<typeof fetchEngravings>;
+const mockedFetchArkGrid = fetchArkGrid as jest.MockedFunction<typeof fetchArkGrid>;
+
+const profile: CharacterProfile = {
+  CharacterImage: 'https://example.com/character.png',
+  CharacterName: '테스트캐릭터',
+  CharacterClassName: '바드',
+  CharacterLevel: 70,
+  ItemAvgLevel: '1,700.00',
+  ItemMaxLevel: '1,700.00',
+  ServerName: '루페온',
+  Title: null,
+  GuildName: null,
+  ExpeditionLevel: 300,
+  PvpGradeName: '',
+  TownLevel: null,
+  TownName: '',
+  UsingSkillPoint: 0,
+  TotalSkillPoint: 0,
+  Stats: [],
+  Tendencies: [],
+  CombatPower: null,
+};
 
 const equipment = (type: string, name: string): EquipmentItem => ({
   Type: type,
@@ -19,5 +81,60 @@ describe('getCombatEquipmentItems', () => {
     ];
 
     expect(getCombatEquipmentItems(items).map((item) => item.Type)).toEqual(['무기', '완갑', '투구']);
+  });
+});
+
+describe('Character route state affordances', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentSearchParams = new URLSearchParams('nickname=테스트캐릭터');
+    mockSetSearchParams.mockImplementation((nextInit) => {
+      mockCurrentSearchParams = new URLSearchParams(nextInit);
+    });
+    mockedFetchEquipment.mockResolvedValue(null);
+    mockedFetchGems.mockResolvedValue(null);
+    mockedFetchEngravings.mockResolvedValue(null);
+    mockedFetchArkGrid.mockResolvedValue(null);
+  });
+
+  it('shows an intentional fallback when the profile image fails', async () => {
+    mockedFetchProfile.mockResolvedValue(profile);
+
+    render(<Character />);
+
+    const image = await screen.findByRole('img', { name: '테스트캐릭터' });
+    fireEvent.error(image);
+
+    expect(screen.getByRole('img', { name: '테스트캐릭터 이미지 없음' })).toBeInTheDocument();
+  });
+
+  it('explains a failed search and offers a next action', async () => {
+    mockedFetchProfile.mockRejectedValue(new Error('rate limited'));
+
+    render(<Character />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('요청이 많거나 서버 응답이 지연될 수 있습니다');
+    expect(screen.getByRole('button', { name: '닉네임 다시 입력' })).toBeInTheDocument();
+  });
+
+  it('returns to nickname input and clears query params after reset action', async () => {
+    mockedFetchProfile.mockRejectedValue(new Error('rate limited'));
+
+    render(<Character />);
+
+    await userEvent.click(await screen.findByRole('button', { name: '닉네임 다시 입력' }));
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith({});
+    expect(screen.getByRole('button', { name: '캐릭터 조회' })).toBeInTheDocument();
+  });
+
+  it('shows the empty branch when profile lookup succeeds with no data', async () => {
+    mockedFetchProfile.mockResolvedValue(null as never);
+
+    render(<Character />);
+
+    expect(await screen.findByRole('status', { name: '캐릭터 정보가 없습니다' })).toHaveTextContent(
+      '닉네임을 확인한 뒤 다시 검색해 주세요',
+    );
   });
 });

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -13,6 +13,8 @@ import NavBar from '../components/NavBar';
 import NicknameInput from '../components/NicknameInput';
 import NicknameSearchBar from '../components/NicknameSearchBar';
 import GlassCard from '../components/GlassCard';
+import FallbackImage from '../components/FallbackImage';
+import StateFeedback from '../components/StateFeedback';
 import { SkeletonBlock } from '../components/Loading';
 import { fetchProfile, fetchEquipment, fetchGems, fetchEngravings, fetchArkGrid, LS_NICKNAME } from '../utils/api';
 import { type EffectSegment, stripHtml, htmlColorToGrade, parseBraceletLine } from '../utils/tooltipParser';
@@ -120,10 +122,11 @@ const ProfileCard: React.FC<{ profile: CharacterProfile; nickname: string }> = (
   <GlassCard className="overflow-hidden animate-slide-up">
     {/* 캐릭터 이미지 + 이름 오버레이 */}
     <div className="relative">
-      <img
+      <FallbackImage
         src={profile.CharacterImage}
         alt={profile.CharacterName}
         className="w-full h-auto max-h-[240px] sm:max-h-[340px] md:max-h-none object-cover object-top"
+        fallbackClassName="min-h-60 sm:min-h-80"
       />
       <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
       <div className="absolute bottom-0 left-0 right-0 p-4">
@@ -707,6 +710,17 @@ const Character: React.FC = () => {
     setNickname(name);
   };
 
+  const handleResetSearch = (): void => {
+    setSearchParams({});
+    setNickname(null);
+    setProfile(null);
+    setEquipment(null);
+    setGems(null);
+    setEngravings(null);
+    setArkGrid(null);
+    setError(null);
+  };
+
   if (!nickname) {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-la-dark transition-colors duration-300">
@@ -731,11 +745,17 @@ const Character: React.FC = () => {
         </div>
 
         {loading ? (
-          <PageSkeleton />
+          <div role="status" aria-label={`${nickname} 캐릭터 정보 불러오는 중`}>
+            <PageSkeleton />
+          </div>
         ) : error ? (
-          <GlassCard className="p-8 text-center animate-fade-in">
-            <p className="text-red-500 dark:text-red-400 text-lg">{error}</p>
-          </GlassCard>
+          <StateFeedback
+            tone="error"
+            title="캐릭터 조회에 실패했습니다"
+            description={`${error} 요청이 많거나 서버 응답이 지연될 수 있습니다. 잠시 후 다시 검색해 주세요.`}
+            action={{ label: '닉네임 다시 입력', onClick: handleResetSearch }}
+            className="animate-fade-in"
+          />
         ) : profile ? (
           <div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-6 items-start">
             {/* 왼쪽 컬럼 */}
@@ -753,9 +773,13 @@ const Character: React.FC = () => {
             </div>
           </div>
         ) : (
-          <GlassCard className="p-8 text-center animate-fade-in">
-            <p className="text-gray-500 dark:text-gray-400">캐릭터 정보를 불러오는 데 실패했습니다.</p>
-          </GlassCard>
+          <StateFeedback
+            tone="empty"
+            title="캐릭터 정보가 없습니다"
+            description="닉네임을 확인한 뒤 다시 검색해 주세요."
+            action={{ label: '닉네임 다시 입력', onClick: handleResetSearch }}
+            className="animate-fade-in"
+          />
         )}
       </main>
       </PullToRefresh>

--- a/src/pages/Compare.test.tsx
+++ b/src/pages/Compare.test.tsx
@@ -78,6 +78,21 @@ describe('Compare', () => {
     mockedFetchArkGrid.mockResolvedValue(null as never);
   });
 
+  it('explains why comparison is disabled until both nicknames are entered', () => {
+    render(<Compare />);
+
+    const compareButton = screen.getByRole('button', { name: '비교하기' });
+    expect(compareButton).toBeDisabled();
+    expect(screen.getByText('비교하려면 두 캐릭터 닉네임을 모두 입력해 주세요.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('캐릭터 닉네임'), { target: { value: '정상캐릭터' } });
+    expect(screen.getByText('비교할 캐릭터 닉네임을 한쪽 더 입력해 주세요.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('비교할 캐릭터'), { target: { value: '비교캐릭터' } });
+    expect(compareButton).toBeEnabled();
+    expect(screen.queryByText(/비교하려면|한쪽 더 입력/)).not.toBeInTheDocument();
+  });
+
   it('한쪽 캐릭터 프로필이 null이면 부분 실패 메시지를 표시하고 비교 섹션을 렌더링하지 않는다', async () => {
     render(<Compare />);
 

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -1049,6 +1049,13 @@ const Compare: React.FC = () => {
     if (e.key === 'Enter' && !loading) handleCompare();
   };
 
+  const hasLeftName = leftName.trim().length > 0;
+  const hasRightName = rightName.trim().length > 0;
+  const canCompare = hasLeftName && hasRightName;
+  const compareGuidance = hasLeftName || hasRightName
+    ? '비교할 캐릭터 닉네임을 한쪽 더 입력해 주세요.'
+    : '비교하려면 두 캐릭터 닉네임을 모두 입력해 주세요.';
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-la-dark transition-colors duration-300">
       <NavBar />
@@ -1084,11 +1091,22 @@ const Compare: React.FC = () => {
 
           <button
             onClick={handleCompare}
-            disabled={loading || !leftName.trim() || !rightName.trim()}
+            disabled={loading || !canCompare}
+            aria-describedby={!canCompare ? 'compare-submit-guidance' : undefined}
             className="w-full mt-4 btn-gold disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? '조회 중...' : '비교하기'}
           </button>
+
+          {!canCompare && (
+            <p
+              id="compare-submit-guidance"
+              role="status"
+              className="mt-2 break-keep text-center text-xs leading-relaxed text-gray-500 dark:text-gray-400"
+            >
+              {compareGuidance}
+            </p>
+          )}
 
           {error && (
             <p className="mt-3 text-sm text-red-500 dark:text-red-400 text-center">{error}</p>

--- a/src/pages/Enhancement.test.tsx
+++ b/src/pages/Enhancement.test.tsx
@@ -63,8 +63,17 @@ const chooseTarget = (slot: string, target: number): void => {
   fireEvent.click(screen.getByRole('option', { name: `${target}강` }));
 };
 
+const setViewportWidth = (width: number): void => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+};
+
 describe('Enhancement armlet calculations', () => {
   beforeEach(() => {
+    setViewportWidth(1024);
     jest.clearAllMocks();
     mockedFetchMarketOptions.mockResolvedValue({ Categories: [] });
     mockedFetchMarketItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 0, Items: [] });
@@ -84,6 +93,32 @@ describe('Enhancement armlet calculations', () => {
 
     expect(armletCard).toHaveTextContent('—');
     expect(armletCard).not.toHaveTextContent('+0');
+  });
+
+
+  it('keeps bulk and slot target context in mobile panels', async () => {
+    setViewportWidth(390);
+    mockedFetchEquipment.mockResolvedValue([
+      equipment('무기', 10),
+      equipment('완갑', 0),
+    ]);
+
+    render(<Enhancement />);
+
+    fireEvent.change(screen.getByPlaceholderText('캐릭터명 입력'), { target: { value: '테스트캐릭터' } });
+    fireEvent.click(screen.getByRole('button', { name: '조회' }));
+    await screen.findByText('종합 아이템 레벨');
+
+    fireEvent.click(screen.getByRole('button', { name: '일반 재련 일괄 목표 선택' }));
+    expect(screen.getByRole('dialog', { name: '일반 재련 일괄 목표' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '일반 재련 일괄 목표 닫기' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '완갑 일반 재련 목표 선택' }));
+    expect(screen.getByRole('dialog', { name: '완갑 일반 재련 목표' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '완갑 일반 재련 목표 닫기' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '상급 재련 일괄 목표 선택' }));
+    expect(screen.getByRole('dialog', { name: '상급 재련 일괄 목표' })).toBeInTheDocument();
   });
 
   it('applies breath and ceiling to the armlet calculation', async () => {

--- a/src/pages/Enhancement.test.tsx
+++ b/src/pages/Enhancement.test.tsx
@@ -121,6 +121,46 @@ describe('Enhancement armlet calculations', () => {
     expect(screen.getByRole('dialog', { name: '상급 재련 일괄 목표' })).toBeInTheDocument();
   });
 
+  it('offers a retry action when the character lookup fails', async () => {
+    mockedFetchEquipment.mockRejectedValue(new Error('lookup failed'));
+
+    render(<Enhancement />);
+
+    const input = screen.getByPlaceholderText('캐릭터명 입력');
+    fireEvent.change(input, { target: { value: '없는캐릭터' } });
+    fireEvent.click(screen.getByRole('button', { name: '조회' }));
+
+    const failure = await screen.findByRole('alert', { name: '캐릭터 강화 현황 조회에 실패했습니다' });
+    expect(failure).toHaveTextContent('캐릭터를 찾을 수 없습니다');
+
+    fireEvent.click(screen.getByRole('button', { name: '닉네임 다시 입력' }));
+
+    expect(
+      screen.queryByRole('alert', { name: '캐릭터 강화 현황 조회에 실패했습니다' }),
+    ).not.toBeInTheDocument();
+    expect(input).toHaveFocus();
+  });
+
+  it('refetches material prices from the failure state', async () => {
+    mockedFetchEquipment.mockResolvedValue([equipment('무기', 10)]);
+    mockedFetchMarketOptions.mockRejectedValueOnce(new Error('market down'));
+
+    render(<Enhancement />);
+
+    const failure = await screen.findByRole('alert', { name: '재료 시세 조회에 실패했습니다' });
+    expect(failure).toHaveTextContent('가격 조회 실패');
+    expect(mockedFetchMarketOptions).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: '시세 다시 조회' }));
+
+    await waitFor(() => expect(mockedFetchMarketOptions).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('alert', { name: '재료 시세 조회에 실패했습니다' }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
   it('applies breath and ceiling to the armlet calculation', async () => {
     mockedFetchEquipment.mockResolvedValue([
       equipment('무기', 10),

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -927,6 +927,7 @@ const Enhancement: React.FC = () => {
               options={NORMAL_BULK_TARGET_OPTIONS}
               placeholder="일반 재련 일괄"
               ariaLabel="일반 재련 일괄 목표 선택"
+              panelTitle="일반 재련 일괄 목표"
               onChange={(val) => {
                 if (val === undefined) return;
                 const targetLevel = Number(val);
@@ -950,6 +951,7 @@ const Enhancement: React.FC = () => {
                   options={targetOptions}
                   placeholder="목표"
                   ariaLabel={`${slot} 일반 재련 목표 선택`}
+                  panelTitle={`${slot} 일반 재련 목표`}
                   onChange={(val) => handleTargetChange(slot, val === undefined ? undefined : Number(val))}
                   fullWidth
                   compact
@@ -969,6 +971,7 @@ const Enhancement: React.FC = () => {
                   options={ADV_TARGET_OPTIONS}
                   placeholder="상급 재련 일괄"
                   ariaLabel="상급 재련 일괄 목표 선택"
+                  panelTitle="상급 재련 일괄 목표"
                   variant="purple"
                   onChange={(val) => {
                     if (val === undefined) return;
@@ -995,6 +998,7 @@ const Enhancement: React.FC = () => {
                       options={availableTargets}
                       placeholder="상급"
                       ariaLabel={`${slot} 상급 재련 목표 선택`}
+                      panelTitle={`${slot} 상급 재련 목표`}
                       onChange={(val) => handleAdvTargetChange(slot, val === undefined ? undefined : Number(val))}
                       variant="purple"
                       fullWidth

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import NavBar from '../components/NavBar';
 import GlassCard from '../components/GlassCard';
 import SelectMenu from '../components/SelectMenu';
+import StateFeedback from '../components/StateFeedback';
 import {
   fetchEquipment,
   fetchProfile,
@@ -328,6 +329,7 @@ const Enhancement: React.FC = () => {
   const [charItemLevel, setCharItemLevel] = useState<number | null>(null);
   const [charLoading, setCharLoading] = useState(false);
   const [charError, setCharError] = useState<string | null>(null);
+  const charInputRef = useRef<HTMLInputElement>(null);
 
   // ── 슬롯별 목표 강 ───────────────────────────
   const [targetMap, setTargetMap] = useState<Partial<Record<SlotName, number>>>({});
@@ -354,48 +356,49 @@ const Enhancement: React.FC = () => {
   const [ownedMaterials, setOwnedMaterials] = useState<Partial<Record<MaterialType, number>>>({});
   const [showOwnedSection, setShowOwnedSection] = useState(false);
 
-  // ── 거래소 가격 조회 (마운트 시 1회) ──────────
-  useEffect(() => {
-    const load = async () => {
-      setPriceLoading(true);
-      setPriceError(null);
-      try {
-        const options = await fetchMarketOptions();
-        const allCats = flattenCategories(options.Categories);
-        const findCode = (keyword: string): number => {
-          const found = allCats.find((c) => c.CodeName.includes(keyword));
-          return found?.Code ?? allCats[0]?.Code ?? 50000;
-        };
+  // ── 거래소 가격 조회 (마운트 시 1회 + 실패 시 재시도) ──
+  const loadPrices = useCallback(async () => {
+    setPriceLoading(true);
+    setPriceError(null);
+    try {
+      const options = await fetchMarketOptions();
+      const allCats = flattenCategories(options.Categories);
+      const findCode = (keyword: string): number => {
+        const found = allCats.find((c) => c.CodeName.includes(keyword));
+        return found?.Code ?? allCats[0]?.Code ?? 50000;
+      };
 
-        const results = await Promise.allSettled(
-          ALL_MATERIAL_TYPES.filter((type) => !MARKET_SEARCH[type].untradeable).map(async (type) => {
-            const config = MARKET_SEARCH[type];
-            const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
-            const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
-            const item = data.Items?.[0];
-            if (!item) return { type, price: 0, icon: '' };
-            const itemsPerUnit = config.itemsPerUnit ?? 1;
-            return { type, price: item.CurrentMinPrice / item.BundleCount / itemsPerUnit, icon: item.Icon };
-          })
-        );
-        const priceMap: PriceMap = {};
-        const iconMap: IconMap = {};
-        for (const r of results) {
-          if (r.status === 'fulfilled') {
-            priceMap[r.value.type] = r.value.price;
-            if (r.value.icon) iconMap[r.value.type] = r.value.icon;
-          }
+      const results = await Promise.allSettled(
+        ALL_MATERIAL_TYPES.filter((type) => !MARKET_SEARCH[type].untradeable).map(async (type) => {
+          const config = MARKET_SEARCH[type];
+          const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
+          const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
+          const item = data.Items?.[0];
+          if (!item) return { type, price: 0, icon: '' };
+          const itemsPerUnit = config.itemsPerUnit ?? 1;
+          return { type, price: item.CurrentMinPrice / item.BundleCount / itemsPerUnit, icon: item.Icon };
+        })
+      );
+      const priceMap: PriceMap = {};
+      const iconMap: IconMap = {};
+      for (const r of results) {
+        if (r.status === 'fulfilled') {
+          priceMap[r.value.type] = r.value.price;
+          if (r.value.icon) iconMap[r.value.type] = r.value.icon;
         }
-        setPrices(priceMap);
-        setIcons(iconMap);
-      } catch {
-        setPriceError('가격 조회 실패');
-      } finally {
-        setPriceLoading(false);
       }
-    };
-    load();
+      setPrices(priceMap);
+      setIcons(iconMap);
+    } catch {
+      setPriceError('가격 조회 실패');
+    } finally {
+      setPriceLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    loadPrices();
+  }, [loadPrices]);
 
   // ── 슬롯별 현재 레벨 ─────────────────────────
   const slotCurrentLevel = useMemo<Record<SlotName, number>>(() => ({
@@ -517,6 +520,12 @@ const Enhancement: React.FC = () => {
   }, []);
 
   const handleSearch = () => searchCharacter(charInput);
+
+  const handleResetCharSearch = (): void => {
+    setCharError(null);
+    charInputRef.current?.focus();
+    charInputRef.current?.select();
+  };
 
   // ── 목표 강 변경 ──────────────────────────────
   const handleTargetChange = (slot: SlotName, val: number | undefined) => {
@@ -844,6 +853,7 @@ const Enhancement: React.FC = () => {
           </p>
           <div className="flex gap-2 mb-4">
             <input
+              ref={charInputRef}
               type="text"
               value={charInput}
               onChange={(e) => setCharInput(e.target.value)}
@@ -861,7 +871,14 @@ const Enhancement: React.FC = () => {
           </div>
 
           {charError && (
-            <p className="text-sm text-red-400 mb-3">{charError}</p>
+            <StateFeedback
+              tone="error"
+              title="캐릭터 강화 현황 조회에 실패했습니다"
+              description={`${charError} 닉네임을 확인한 뒤 다시 검색해 주세요.`}
+              action={{ label: '닉네임 다시 입력', onClick: handleResetCharSearch }}
+              compact
+              className="mb-3"
+            />
           )}
 
           {/* 슬롯 카드 - 현재 강화 수치 표시 */}
@@ -1472,8 +1489,17 @@ const Enhancement: React.FC = () => {
               재련 재료 시세
             </p>
             {priceLoading && <span className="text-xs text-gray-400 animate-pulse">조회 중…</span>}
-            {priceError && <span className="text-xs text-red-400">{priceError}</span>}
           </div>
+          {priceError && (
+            <StateFeedback
+              tone="error"
+              title="재료 시세 조회에 실패했습니다"
+              description={`${priceError} 거래소 요청이 많거나 서버 응답이 지연될 수 있습니다.`}
+              action={{ label: '시세 다시 조회', onClick: () => { void loadPrices(); } }}
+              compact
+              className="mb-3"
+            />
+          )}
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>

--- a/src/pages/Expedition.test.tsx
+++ b/src/pages/Expedition.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Expedition from './Expedition';
+import type { CharacterProfile } from '../types/lostark';
+import { fetchProfile, fetchSiblings } from '../utils/api';
+
+const mockSetSearchParams = jest.fn();
+let mockCurrentSearchParams = new URLSearchParams('nickname=원정대장');
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useLocation: () => ({ pathname: '/expedition' }),
+    useSearchParams: () => [mockCurrentSearchParams, mockSetSearchParams],
+  }),
+  { virtual: true },
+);
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+jest.mock('../components/PullToRefresh', () => ({ children }: { children: React.ReactNode }) => <>{children}</>);
+
+jest.mock('../utils/api', () => ({
+  fetchProfile: jest.fn(),
+  fetchSiblings: jest.fn(),
+  LS_NICKNAME: 'lostark_nickname',
+}));
+
+const mockedFetchProfile = fetchProfile as jest.MockedFunction<typeof fetchProfile>;
+const mockedFetchSiblings = fetchSiblings as jest.MockedFunction<typeof fetchSiblings>;
+
+const profile: CharacterProfile = {
+  CharacterImage: 'https://example.com/expedition.png',
+  CharacterName: '원정대장',
+  CharacterClassName: '슬레이어',
+  CharacterLevel: 70,
+  ItemAvgLevel: '1,710.00',
+  ItemMaxLevel: '1,710.00',
+  ServerName: '루페온',
+  Title: null,
+  GuildName: null,
+  ExpeditionLevel: 300,
+  PvpGradeName: '',
+  TownLevel: null,
+  TownName: '',
+  UsingSkillPoint: 0,
+  TotalSkillPoint: 0,
+  Stats: [],
+  Tendencies: [],
+  CombatPower: null,
+};
+
+describe('Expedition route state affordances', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentSearchParams = new URLSearchParams('nickname=원정대장');
+    mockSetSearchParams.mockImplementation((nextInit) => {
+      mockCurrentSearchParams = new URLSearchParams(nextInit);
+    });
+  });
+
+  it('shows an intentional fallback when a character card image fails', async () => {
+    mockedFetchSiblings.mockResolvedValue([
+      { ServerName: '루페온', CharacterName: '원정대장', CharacterLevel: 70, CharacterClassName: '슬레이어', ItemAvgLevel: '1,710.00', ItemMaxLevel: '1,710.00' },
+    ]);
+    mockedFetchProfile.mockResolvedValue(profile);
+
+    render(<Expedition />);
+
+    const image = await screen.findByRole('img', { name: '원정대장' });
+    fireEvent.error(image);
+
+    expect(screen.getByRole('img', { name: '원정대장 이미지 없음' })).toBeInTheDocument();
+  });
+
+  it('explains a failed search and offers a next action', async () => {
+    mockedFetchSiblings.mockRejectedValue(new Error('rate limited'));
+
+    render(<Expedition />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('요청이 많거나 서버 응답이 지연될 수 있습니다');
+    expect(screen.getByRole('button', { name: '닉네임 다시 입력' })).toBeInTheDocument();
+  });
+
+  it('returns to nickname input and clears query params after reset action', async () => {
+    mockedFetchSiblings.mockRejectedValue(new Error('rate limited'));
+
+    render(<Expedition />);
+
+    await userEvent.click(await screen.findByRole('button', { name: '닉네임 다시 입력' }));
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith({});
+    expect(await screen.findByRole('button', { name: '원정대 조회' })).toBeInTheDocument();
+  });
+
+  it('shows the empty branch when siblings lookup succeeds with no characters', async () => {
+    mockedFetchSiblings.mockResolvedValue([]);
+
+    render(<Expedition />);
+
+    expect(await screen.findByText('원정대 캐릭터가 없습니다')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('원정대 캐릭터가 없습니다');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows the no-profile branch when sibling profile lookups all return empty', async () => {
+    mockedFetchSiblings.mockResolvedValue([
+      { ServerName: '루페온', CharacterName: '부캐1', CharacterLevel: 70, CharacterClassName: '바드', ItemAvgLevel: '1,600.00', ItemMaxLevel: '1,600.00' },
+    ]);
+    mockedFetchProfile.mockResolvedValue(null as never);
+
+    render(<Expedition />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('원정대 프로필을 불러오지 못했습니다');
+  });
+});

--- a/src/pages/Expedition.tsx
+++ b/src/pages/Expedition.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import PullToRefresh from '../components/PullToRefresh';
 import NicknameInput from '../components/NicknameInput';
 import NicknameSearchBar from '../components/NicknameSearchBar';
 import GlassCard from '../components/GlassCard';
+import StateFeedback from '../components/StateFeedback';
 import { SkeletonBlock } from '../components/Loading';
+import ExpeditionProfiles from '../components/expedition/ExpeditionProfiles';
 import type { CharacterProfile, SiblingCharacter } from '../types/lostark';
 import { fetchProfile, fetchSiblings, LS_NICKNAME } from '../utils/api';
 import { safeLocalStorage } from '../utils/safeStorage';
@@ -42,6 +44,15 @@ const Expedition: React.FC = () => {
     setError(null);
   };
 
+  const handleResetSearch = (): void => {
+    setSearchParams({});
+    setNickname(null);
+    setServer(null);
+    setSiblings([]);
+    setProfiles([]);
+    setError(null);
+  };
+
   const fetchCharacterProfile = useCallback(async (characterName: string): Promise<CharacterProfile | null> => {
     try {
       const profile = await fetchProfile(characterName);
@@ -65,11 +76,18 @@ const Expedition: React.FC = () => {
         const data = await fetchSiblings(nickname);
         if (cancelled) return;
 
-        if (!Array.isArray(data) || data.length === 0) {
+        if (!Array.isArray(data)) {
           setSiblings([]);
           setProfiles([]);
           setServer(null);
           setError('원정대 캐릭터 정보를 불러올 수 없습니다.');
+          return;
+        }
+
+        if (data.length === 0) {
+          setSiblings([]);
+          setProfiles([]);
+          setServer(null);
           return;
         }
 
@@ -160,7 +178,11 @@ const Expedition: React.FC = () => {
           </div>
 
           {loading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            <div
+              role="status"
+              aria-label={`${nickname} 원정대 정보 불러오는 중`}
+              className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+            >
               {Array.from({ length: 6 }).map((_, index) => (
                 <GlassCard key={index} className="p-5">
                   <div className="flex items-center gap-4 mb-4">
@@ -179,95 +201,31 @@ const Expedition: React.FC = () => {
               ))}
             </div>
           ) : error ? (
-            <GlassCard className="p-8 text-center animate-fade-in">
-              <p className="text-red-500 dark:text-red-400 text-lg">{error}</p>
-            </GlassCard>
+            <StateFeedback
+              tone="error"
+              title="원정대 조회에 실패했습니다"
+              description={`${error} 요청이 많거나 서버 응답이 지연될 수 있습니다. 잠시 후 다시 검색해 주세요.`}
+              action={{ label: '닉네임 다시 입력', onClick: handleResetSearch }}
+              className="animate-fade-in"
+            />
           ) : profiles.length > 0 ? (
-            <div className="space-y-6 animate-fade-in">
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <GlassCard className="p-4 text-center">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">원정대 캐릭터</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">{profiles.length}</p>
-                </GlassCard>
-                <GlassCard className="p-4 text-center">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">최고 레벨</p>
-                  <p className="text-2xl font-bold text-la-gold-dark dark:text-la-gold">
-                    {summary.highestLevel?.toFixed(2) ?? '-'}
-                  </p>
-                </GlassCard>
-                <GlassCard className="p-4 text-center">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">평균 레벨</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {summary.averageLevel?.toFixed(2) ?? '-'}
-                  </p>
-                </GlassCard>
-                <GlassCard className="p-4 text-center">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">주간 골드</p>
-                  <Link
-                    to={`/simulation?nickname=${encodeURIComponent(nickname)}`}
-                    className="inline-flex items-center justify-center px-3 py-2 rounded-lg text-sm font-medium bg-la-gold/20 text-la-gold-dark dark:text-la-gold hover:bg-la-gold/30 transition-colors"
-                  >
-                    계산하러 가기
-                  </Link>
-                </GlassCard>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
-                {profiles.map((profile) => (
-                  <Link
-                    key={profile.CharacterName}
-                    to={`/character?nickname=${encodeURIComponent(profile.CharacterName)}`}
-                    className="block self-start"
-                  >
-                    <GlassCard className="p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20">
-                      <div className="flex items-center gap-4">
-                        <div className="w-16 h-16 rounded-2xl overflow-hidden bg-gray-100 dark:bg-white/5 flex-shrink-0">
-                          <img
-                            src={profile.CharacterImage}
-                            alt={profile.CharacterName}
-                            className="w-full h-full object-cover object-top"
-                          />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <h2 className="text-lg font-bold text-gray-900 dark:text-white truncate">{profile.CharacterName}</h2>
-                          <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{profile.CharacterClassName}</p>
-                          <div className="mt-2 inline-flex items-center rounded-full bg-la-gold/15 px-2.5 py-1 text-xs font-medium text-la-gold-dark dark:text-la-gold">
-                            아이템 레벨 {profile.ItemAvgLevel}
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
-                        <div>
-                          <p className="text-gray-500 dark:text-gray-400">캐릭터 레벨</p>
-                          <p className="mt-1 font-semibold text-gray-900 dark:text-white">Lv.{profile.CharacterLevel}</p>
-                        </div>
-                        <div>
-                          <p className="text-gray-500 dark:text-gray-400">원정대 레벨</p>
-                          <p className="mt-1 font-semibold text-gray-900 dark:text-white">Lv.{profile.ExpeditionLevel}</p>
-                        </div>
-                        <div>
-                          <p className="text-gray-500 dark:text-gray-400">서버</p>
-                          <p className="mt-1 font-semibold text-gray-900 dark:text-white">{profile.ServerName}</p>
-                        </div>
-                        <div>
-                          <p className="text-gray-500 dark:text-gray-400">길드</p>
-                          <p className="mt-1 font-semibold text-gray-900 dark:text-white truncate">{profile.GuildName || '-'}</p>
-                        </div>
-                      </div>
-                    </GlassCard>
-                  </Link>
-                ))}
-              </div>
-            </div>
+            <ExpeditionProfiles nickname={nickname} profiles={profiles} summary={summary} />
           ) : siblings.length === 0 ? (
-            <GlassCard className="p-8 text-center animate-fade-in">
-              <p className="text-gray-500 dark:text-gray-400">원정대 캐릭터가 없습니다.</p>
-            </GlassCard>
+            <StateFeedback
+              tone="empty"
+              title="원정대 캐릭터가 없습니다"
+              description="다른 닉네임을 입력해 원정대를 다시 조회해 주세요."
+              action={{ label: '닉네임 다시 입력', onClick: handleResetSearch }}
+              className="animate-fade-in"
+            />
           ) : (
-            <GlassCard className="p-8 text-center animate-fade-in">
-              <p className="text-gray-500 dark:text-gray-400">캐릭터 프로필을 불러오지 못했습니다.</p>
-            </GlassCard>
+            <StateFeedback
+              tone="error"
+              title="원정대 프로필을 불러오지 못했습니다"
+              description="일부 캐릭터 응답이 지연되었습니다. 잠시 후 다시 검색해 주세요."
+              action={{ label: '닉네임 다시 입력', onClick: handleResetSearch }}
+              className="animate-fade-in"
+            />
           )}
         </main>
       </PullToRefresh>

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -86,6 +86,10 @@ describe('Home event links', () => {
     for (const title of ['외부 도메인 이벤트', '자바스크립트 이벤트', 'HTTP 이벤트', '깨진 이벤트']) {
       const card = screen.getByRole('article', { name: `${title} 이벤트 안내 링크 없음` });
       expect(within(card).getByText(title)).toBeInTheDocument();
+      expect(within(card).getByText('링크 없음')).toBeInTheDocument();
+      expect(card).toHaveClass('cursor-default');
+      expect(card).not.toHaveClass('hover:shadow-gold-glow');
+      expect(within(card).getByRole('img')).not.toHaveClass('group-hover:scale-105');
       expect(within(card).queryByRole('link')).not.toBeInTheDocument();
     }
   });

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, within } from '@testing-library/react';
+import Home from './Home';
+import { fetchCalendar, fetchEvents } from '../utils/api';
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+jest.mock('../components/PullToRefresh', () => ({ children }: { readonly children: React.ReactNode }) => <>{children}</>);
+jest.mock('../components/home/HomeDashboardIntro', () => () => <section>Dashboard intro</section>);
+
+jest.mock('../utils/api', () => ({
+  fetchEvents: jest.fn(),
+  fetchCalendar: jest.fn(),
+}));
+
+const mockedFetchEvents = fetchEvents as jest.MockedFunction<typeof fetchEvents>;
+const mockedFetchCalendar = fetchCalendar as jest.MockedFunction<typeof fetchCalendar>;
+
+const activeDate = new Date(Date.now() + 86_400_000).toISOString();
+
+describe('Home event links', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchCalendar.mockResolvedValue([]);
+  });
+
+  it('renders only https Lost Ark and STOVE event links as anchors', async () => {
+    mockedFetchEvents.mockResolvedValue([
+      {
+        Title: '공식 로스트아크 이벤트',
+        Thumbnail: '/official.webp',
+        Link: 'https://lostark.game.onstove.com/Promotion/Event/Views/1',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+      {
+        Title: 'STOVE 안내 이벤트',
+        Thumbnail: '/stove.webp',
+        Link: 'https://event.onstove.com/lostark/notice',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+      {
+        Title: '외부 도메인 이벤트',
+        Thumbnail: '/external.webp',
+        Link: 'https://example.com/phishing',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+      {
+        Title: '자바스크립트 이벤트',
+        Thumbnail: '/script.webp',
+        Link: 'javascript:alert(1)',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+      {
+        Title: 'HTTP 이벤트',
+        Thumbnail: '/http.webp',
+        Link: 'http://lostark.game.onstove.com/event',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+      {
+        Title: '깨진 이벤트',
+        Thumbnail: '/broken.webp',
+        Link: 'https://',
+        StartDate: '2026-01-01T00:00:00',
+        EndDate: activeDate,
+        RewardDate: null,
+      },
+    ]);
+
+    render(<Home />);
+
+    const official = await screen.findByRole('link', { name: /공식 로스트아크 이벤트/ });
+    expect(official).toHaveAttribute('href', 'https://lostark.game.onstove.com/Promotion/Event/Views/1');
+    expect(screen.getByRole('link', { name: /STOVE 안내 이벤트/ })).toHaveAttribute(
+      'href',
+      'https://event.onstove.com/lostark/notice',
+    );
+
+    for (const title of ['외부 도메인 이벤트', '자바스크립트 이벤트', 'HTTP 이벤트', '깨진 이벤트']) {
+      const card = screen.getByRole('article', { name: `${title} 이벤트 안내 링크 없음` });
+      expect(within(card).getByText(title)).toBeInTheDocument();
+      expect(within(card).queryByRole('link')).not.toBeInTheDocument();
+    }
+  });
+});

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Link } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import PullToRefresh from '../components/PullToRefresh';
 import { SkeletonBlock } from '../components/Loading';
+import HomeDashboardIntro from '../components/home/HomeDashboardIntro';
 import { fetchEvents, fetchCalendar } from '../utils/api';
 import type { GameEvent, CalendarItem } from '../types/lostark';
 
@@ -63,50 +63,20 @@ function getTodayTimes(startTimes: string[] | null): string[] {
 }
 
 const CALENDAR_CATEGORIES = ['모험 섬', '카오스게이트', '필드보스', '항해'];
+const EVENT_LINK_ALLOWED_HOSTS = ['lostark.game.onstove.com', 'onstove.com'] as const;
 
-const QUICK_ACTIONS = [
-  {
-    to: '/simulation',
-    title: '주간 골드 계산',
-    description: '주간 골드와 숙제 현황',
-    action: '계산하기',
-    iconBg: 'bg-amber-500/15',
-    iconText: 'text-amber-700 dark:text-amber-400',
-    ctaText: 'text-amber-700 dark:text-amber-400',
-    path: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-    featured: true,
-  },
-  {
-    to: '/enhancement',
-    title: '재련 계산',
-    description: '재료 시세 기반 강화 비용',
-    action: '계산하기',
-    iconBg: 'bg-emerald-500/15',
-    iconText: 'text-emerald-600 dark:text-emerald-400',
-    ctaText: 'text-emerald-600 dark:text-emerald-400',
-    path: 'M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396c.251.023.501.05.75.082M19 14.5l-2.14 3.21a2.25 2.25 0 01-1.873 1.002H9.013A2.25 2.25 0 017.14 17.71L5 14.5m14 0H5',
-  },
-  {
-    to: '/market',
-    title: '시세 랭킹',
-    description: '각인서·보석 최저가 순위',
-    action: '랭킹 보기',
-    iconBg: 'bg-la-gold/20',
-    iconText: 'text-la-gold-dark dark:text-la-gold',
-    ctaText: 'text-la-gold-dark dark:text-la-gold',
-    path: 'M3 10h18M7 15h1m4 0h1m4 0h1M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z',
-  },
-  {
-    to: '/compare',
-    title: '캐릭터 비교',
-    description: '두 캐릭터 스펙 비교',
-    action: '비교하기',
-    iconBg: 'bg-sky-500/15',
-    iconText: 'text-sky-600 dark:text-sky-400',
-    ctaText: 'text-sky-600 dark:text-sky-400',
-    path: 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3',
-  },
-];
+function getSafeEventLink(link: string): string | null {
+  try {
+    const url = new URL(link);
+    if (url.protocol !== 'https:') return null;
+    const hostname = url.hostname.toLowerCase();
+    const allowed = EVENT_LINK_ALLOWED_HOSTS.some((host) => hostname === host || hostname.endsWith(`.${host}`));
+    return allowed ? url.toString() : null;
+  } catch (error) {
+    if (error && typeof error === 'object' && 'message' in error) return null;
+    throw error;
+  }
+}
 
 const Home: React.FC = () => {
   const [events, setEvents] = useState<GameEvent[]>([]);
@@ -159,73 +129,19 @@ const Home: React.FC = () => {
       <NavBar />
       <PullToRefresh>
       <main className="max-w-7xl mx-auto px-4 py-8 space-y-8">
-        {/* Dashboard Hero */}
-        <section className="glass-card relative overflow-hidden p-6 sm:p-8 animate-fade-in">
-          <div className="absolute -left-20 -top-20 h-56 w-56 rounded-full bg-la-gold/20 blur-3xl" aria-hidden />
-          <div className="absolute -right-20 bottom-0 h-48 w-48 rounded-full bg-amber-500/10 blur-3xl" aria-hidden />
-          <div className="relative grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
-            <div>
-              <span className="inline-flex rounded-full border border-la-gold/20 bg-la-gold/10 px-3 py-1 text-xs font-bold text-la-gold-dark dark:text-la-gold">
-                로아 성장 관리 대시보드
-              </span>
-              <h1 className="mt-4 text-3xl sm:text-4xl md:text-5xl font-black tracking-tight text-gray-950 dark:text-white">
-                성장에 필요한 도구를 한곳에
-              </h1>
-              <p className="mt-4 max-w-2xl text-sm sm:text-base leading-relaxed text-gray-500 dark:text-gray-400">
-                시세, 골드, 캐릭터 비교, 재련 계산까지 필요한 순간 바로 확인하세요.
-              </p>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-2xl border border-la-gold/20 bg-la-gold/10 p-4">
-                <p className="text-xs font-bold tracking-wider text-la-gold-dark dark:text-la-gold">이벤트</p>
-                <p className="mt-2 text-3xl font-black text-gray-950 dark:text-white">
-                  {loadingEvents ? '-' : activeEvents.length}
-                </p>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">진행 중</p>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-white/60 p-4 dark:bg-white/5">
-                <p className="text-xs font-bold tracking-wider text-gray-500 dark:text-gray-400">일정</p>
-                <p className="mt-2 text-3xl font-black text-gray-950 dark:text-white">
-                  {loadingCalendar ? '-' : calendarGroups.size}
-                </p>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">오늘 일정</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Quick Links */}
-        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in">
-          {QUICK_ACTIONS.map((action) => (
-            <Link
-              key={action.to}
-              to={action.to}
-              className={`glass-card p-5 text-left transition-all duration-300 group cursor-pointer hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20 ${action.featured ? 'ring-1 ring-la-gold/20' : ''}`}
-            >
-              <div className="flex items-center gap-3 mb-3">
-                <div className={`w-10 h-10 rounded-xl ${action.iconBg} flex items-center justify-center flex-shrink-0`}>
-                  <svg className={`w-5 h-5 ${action.iconText}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d={action.path} />
-                  </svg>
-                </div>
-                <h2 className="text-base font-bold text-gray-900 dark:text-white">{action.title}</h2>
-              </div>
-              <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-                {action.description}
-              </p>
-              <div className={`mt-3 flex items-center gap-1 text-sm font-medium ${action.ctaText} opacity-0 group-hover:opacity-100 transition-opacity`}>
-                <span>{action.action}</span>
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                </svg>
-              </div>
-            </Link>
-          ))}
-        </section>
+        <HomeDashboardIntro
+          activeEventCount={activeEvents.length}
+          calendarGroupCount={calendarGroups.size}
+          loadingEvents={loadingEvents}
+          loadingCalendar={loadingCalendar}
+        />
 
         {/* Today's Calendar - 카테고리별 접기, 기본 접힘 */}
-        <section className="animate-fade-in">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">오늘의 일정</h2>
+        <section className="animate-fade-in" aria-labelledby="home-calendar-title">
+          <div className="mb-4">
+            <h2 id="home-calendar-title" className="text-xl font-bold text-gray-900 dark:text-white">오늘의 일정</h2>
+            <p className="mt-1 break-keep text-sm text-gray-500 dark:text-gray-400">카테고리를 열어 오늘 참여 가능한 시간을 확인하세요.</p>
+          </div>
           {loadingCalendar ? (
             <div className="space-y-4">
               {Array.from({ length: 3 }).map((_, i) => (
@@ -252,6 +168,7 @@ const Home: React.FC = () => {
                       onClick={() => toggleCategory(category)}
                       className="w-full flex items-center justify-between text-left p-4 hover:bg-white/5 dark:hover:bg-white/5 transition-colors"
                       aria-expanded={isExpanded}
+                      aria-label={`${category} 일정 ${isExpanded ? '접기' : '펼치기'}`}
                     >
                       <h3 className="text-sm font-bold text-la-gold-dark dark:text-la-gold">{category}</h3>
                       <span
@@ -310,8 +227,11 @@ const Home: React.FC = () => {
         </section>
 
         {/* Events Section */}
-        <section className="animate-fade-in">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">진행 중인 이벤트</h2>
+        <section className="animate-fade-in" aria-labelledby="home-events-title">
+          <div className="mb-4">
+            <h2 id="home-events-title" className="text-xl font-bold text-gray-900 dark:text-white">진행 중인 이벤트</h2>
+            <p className="mt-1 break-keep text-sm text-gray-500 dark:text-gray-400">이벤트를 선택하면 공식 안내 페이지가 새 탭에서 열립니다.</p>
+          </div>
           {loadingEvents ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {Array.from({ length: 3 }).map((_, i) => (
@@ -326,14 +246,11 @@ const Home: React.FC = () => {
             </div>
           ) : activeEvents.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {activeEvents.map((event, i) => (
-                <a
-                  key={i}
-                  href={event.Link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="glass-card overflow-hidden transition-all duration-300 hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20 group"
-                >
+              {activeEvents.map((event, i) => {
+                const safeLink = getSafeEventLink(event.Link);
+                const eventCardClassName = 'glass-card overflow-hidden transition-all duration-300 hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20 group';
+                const eventCard = (
+                  <>
                   <div className="relative h-36 overflow-hidden">
                     <img
                       src={event.Thumbnail}
@@ -342,15 +259,32 @@ const Home: React.FC = () => {
                     />
                   </div>
                   <div className="p-4">
-                    <h3 className="text-sm font-bold text-gray-900 dark:text-white line-clamp-2 leading-snug">
+                    <h3 className="line-clamp-2 break-words text-sm font-bold leading-snug text-gray-900 dark:text-white">
                       {event.Title}
                     </h3>
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                       {formatShortDate(event.StartDate)} ~ {formatShortDate(event.EndDate)}
                     </p>
                   </div>
-                </a>
-              ))}
+                  </>
+                );
+
+                return safeLink ? (
+                  <a
+                    key={i}
+                    href={safeLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={eventCardClassName}
+                  >
+                    {eventCard}
+                  </a>
+                ) : (
+                  <article key={i} className={eventCardClassName} aria-label={`${event.Title} 이벤트 안내 링크 없음`}>
+                    {eventCard}
+                  </article>
+                );
+              })}
             </div>
           ) : (
             <div className="glass-card p-6 text-center">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -248,14 +248,17 @@ const Home: React.FC = () => {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {activeEvents.map((event, i) => {
                 const safeLink = getSafeEventLink(event.Link);
-                const eventCardClassName = 'glass-card overflow-hidden transition-all duration-300 hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20 group';
+                const eventCardClassName = 'glass-card overflow-hidden transition-all duration-300 group';
+                const linkedEventCardClassName = `${eventCardClassName} hover:shadow-gold-glow hover:border-la-gold/30 dark:hover:border-la-gold/20`;
+                const unavailableEventCardClassName = `${eventCardClassName} cursor-default`;
+                const eventImageClassName = 'w-full h-full object-cover transition-transform duration-300';
                 const eventCard = (
                   <>
                   <div className="relative h-36 overflow-hidden">
                     <img
                       src={event.Thumbnail}
                       alt={event.Title}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      className={`${eventImageClassName} ${safeLink ? 'group-hover:scale-105' : ''}`}
                     />
                   </div>
                   <div className="p-4">
@@ -265,6 +268,11 @@ const Home: React.FC = () => {
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                       {formatShortDate(event.StartDate)} ~ {formatShortDate(event.EndDate)}
                     </p>
+                    {!safeLink && (
+                      <p className="mt-2 inline-flex rounded-md bg-gray-100 px-2 py-1 text-[11px] font-semibold text-gray-500 dark:bg-white/10 dark:text-gray-400">
+                        링크 없음
+                      </p>
+                    )}
                   </div>
                   </>
                 );
@@ -275,12 +283,12 @@ const Home: React.FC = () => {
                     href={safeLink}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={eventCardClassName}
+                    className={linkedEventCardClassName}
                   >
                     {eventCard}
                   </a>
                 ) : (
-                  <article key={i} className={eventCardClassName} aria-label={`${event.Title} 이벤트 안내 링크 없음`}>
+                  <article key={i} className={unavailableEventCardClassName} aria-label={`${event.Title} 이벤트 안내 링크 없음`}>
                     {eventCard}
                   </article>
                 );

--- a/src/pages/Market.test.tsx
+++ b/src/pages/Market.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import Market, { EngravingRanking, GemRanking } from './Market';
+import { fetchAuctionItems, fetchMarketItems } from '../utils/api';
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+
+jest.mock('../utils/api', () => ({
+  fetchAuctionItems: jest.fn(),
+  fetchMarketItems: jest.fn(),
+}));
+
+const mockedFetchAuctionItems = fetchAuctionItems as jest.MockedFunction<typeof fetchAuctionItems>;
+const mockedFetchMarketItems = fetchMarketItems as jest.MockedFunction<typeof fetchMarketItems>;
+
+describe('Market ranking states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses shared feedback for loading and empty rankings', () => {
+    const { rerender } = render(
+      <EngravingRanking
+        state={{ status: 'loading', items: [], fetchedAt: null, failedCount: 0 }}
+        onRetry={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('유물 각인서 시세를 불러오는 중입니다');
+
+    rerender(
+      <GemRanking
+        state={{ status: 'success', items: [], fetchedAt: null, failedCount: 0 }}
+        onRetry={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('표시할 보석 시세가 없습니다')).toBeInTheDocument();
+  });
+
+  it('offers retry from the shared error feedback', () => {
+    const onRetry = jest.fn();
+
+    render(
+      <EngravingRanking
+        state={{ status: 'error', items: [], fetchedAt: null, failedCount: 0 }}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('잠시 후 다시 시도해 주세요');
+    fireEvent.click(screen.getByRole('button', { name: '다시 불러오기' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps compact mobile price and change labels together', () => {
+    render(
+      <EngravingRanking
+        state={{
+          status: 'success',
+          fetchedAt: null,
+          failedCount: 0,
+          items: [{
+            rank: 1,
+            name: '원한',
+            itemName: '원한 각인서',
+            icon: 'https://example.com/engraving.png',
+            price: 12000,
+            yDayAvgPrice: 10000,
+          }],
+        }}
+        onRetry={jest.fn()}
+      />,
+    );
+
+    const mobileRow = screen.getByRole('group', { name: '원한 각인서 모바일 시세' });
+    expect(within(mobileRow).getByText('최저가')).toBeInTheDocument();
+    expect(within(mobileRow).getByText('전일 평균')).toBeInTheDocument();
+    expect(within(mobileRow).getByText('변동')).toBeInTheDocument();
+    expect(within(mobileRow).getByText('12,000G')).toBeInTheDocument();
+  });
+
+  it('retries the page-level ranking request after an initial failure', async () => {
+    mockedFetchAuctionItems.mockResolvedValue({ PageNo: 0, PageSize: 1, TotalCount: 0, Items: [] });
+    mockedFetchMarketItems
+      .mockRejectedValueOnce(new Error('market unavailable'))
+      .mockResolvedValueOnce({
+        PageNo: 1,
+        PageSize: 50,
+        TotalCount: 1,
+        Items: [{
+          Id: 1,
+          Name: '유물 원한 각인서',
+          Grade: '유물',
+          Icon: 'https://example.com/engraving.png',
+          BundleCount: 1,
+          TradeRemainCount: null,
+          YDayAvgPrice: 1000,
+          RecentPrice: 1200,
+          CurrentMinPrice: 1200,
+        }],
+      });
+
+    render(<Market />);
+
+    const retryButton = await screen.findByRole('button', { name: '다시 불러오기' });
+    expect(screen.getByRole('alert')).toHaveTextContent('유물 각인서 시세를 불러오지 못했습니다');
+    expect(mockedFetchMarketItems).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(mockedFetchMarketItems).toHaveBeenCalledTimes(2));
+    expect(await screen.findAllByText('유물 원한 각인서')).toHaveLength(2);
+  });
+});

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,41 +1,20 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import NavBar from '../components/NavBar';
 import GlassCard from '../components/GlassCard';
-import { SkeletonBlock } from '../components/Loading';
+import { EngravingRanking, GemRanking } from '../components/market/MarketRankings';
+import type {
+  EngravingRankItem,
+  GemKind,
+  GemRankItem,
+  RankState,
+} from '../components/market/MarketRankings';
 import {
   fetchAuctionItems,
   fetchMarketItems,
   type AuctionItem,
 } from '../utils/api';
 
-type RankStatus = 'loading' | 'success' | 'error';
 type ActiveTab = 'engraving' | 'gem';
-type GemKind = '겁화' | '작열';
-
-interface EngravingRankItem {
-  rank: number;
-  name: string;
-  itemName: string;
-  icon: string;
-  price: number;
-  yDayAvgPrice: number;
-}
-
-interface GemRankItem {
-  rank: number;
-  level: number;
-  kind: GemKind;
-  name: string;
-  icon: string;
-  price: number;
-}
-
-interface RankState<T> {
-  status: RankStatus;
-  items: T[];
-  fetchedAt: Date | null;
-  failedCount: number;
-}
 
 const GEM_KINDS: GemKind[] = ['겁화', '작열'];
 const GEM_TARGETS = Array.from({ length: 10 }, (_, index) => 10 - index).flatMap((level) =>
@@ -91,27 +70,6 @@ const initialRankState = <T,>(): RankState<T> => ({
   fetchedAt: null,
   failedCount: 0,
 });
-
-const formatGold = (value?: number | null): string => {
-  if (value == null || value <= 0) return '-';
-  return `${value.toLocaleString()}G`;
-};
-
-type PriceDeltaDirection = 'up' | 'down' | 'flat';
-
-const getPriceDelta = (current?: number | null, previous?: number | null): { label: string; direction: PriceDeltaDirection } => {
-  if (current == null || previous == null || current <= 0 || previous <= 0 || current === previous) {
-    return { label: '-', direction: 'flat' };
-  }
-
-  const difference = Math.abs(current - previous);
-  return current > previous
-    ? { label: `▲ ${formatGold(difference)}`, direction: 'up' }
-    : { label: `▼ ${formatGold(difference)}`, direction: 'down' };
-};
-
-const formatTime = (date: Date | null): string =>
-  date ? date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }) : '-';
 
 const getLowestAuctionItem = (items: AuctionItem[] | undefined): AuctionItem | null => {
   if (!items) return null;
@@ -220,193 +178,6 @@ const fetchRankingStates = async (): Promise<[RankState<EngravingRankItem>, Rank
   ];
 };
 
-const RankingSkeleton: React.FC<{ rows?: number }> = ({ rows = 8 }) => (
-  <GlassCard className="overflow-hidden">
-    <div className="space-y-0 divide-y divide-gray-200/50 dark:divide-white/10">
-      {Array.from({ length: rows }).map((_, index) => (
-        <div key={index} className="flex items-center gap-3 p-4">
-          <SkeletonBlock className="h-7 w-8 rounded-lg" />
-          <SkeletonBlock className="h-11 w-11 rounded-xl" />
-          <div className="flex-1 space-y-2">
-            <SkeletonBlock className="h-4 w-40" />
-            <SkeletonBlock className="h-3 w-28" />
-          </div>
-          <SkeletonBlock className="h-5 w-24" />
-        </div>
-      ))}
-    </div>
-  </GlassCard>
-);
-
-const SectionHeader: React.FC<{
-  title: string;
-  count: number;
-  fetchedAt: Date | null;
-  failedCount: number;
-}> = ({ title, count, fetchedAt, failedCount }) => (
-  <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-    <div>
-      <h2 className="text-xl font-black text-gray-950 dark:text-white">{title}</h2>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        {count}개 · 최저가 기준 · {formatTime(fetchedAt)}
-      </p>
-    </div>
-    {failedCount > 0 && (
-      <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-xs font-bold text-amber-700 dark:text-amber-300">
-        {failedCount}개 실패
-      </span>
-    )}
-  </div>
-);
-
-const RankBadge: React.FC<{ rank: number }> = ({ rank }) => (
-  <span className="inline-flex h-8 min-w-8 items-center justify-center rounded-lg bg-la-gold/15 px-2 text-sm font-black text-la-gold-dark dark:text-la-gold">
-    #{rank}
-  </span>
-);
-
-const PriceDelta: React.FC<{ current?: number | null; previous?: number | null }> = ({ current, previous }) => {
-  const delta = getPriceDelta(current, previous);
-  const colorClass = delta.direction === 'up'
-    ? 'text-red-600 dark:text-red-400'
-    : delta.direction === 'down'
-      ? 'text-blue-600 dark:text-blue-400'
-      : 'text-gray-500 dark:text-gray-400';
-
-  return <span className={`tabular-nums ${colorClass}`}>{delta.label}</span>;
-};
-
-const EngravingRanking: React.FC<{ state: RankState<EngravingRankItem> }> = ({ state }) => (
-  <section>
-    <SectionHeader title="유물 각인서" count={state.items.length} fetchedAt={state.fetchedAt} failedCount={state.failedCount} />
-    {state.status === 'loading' && <RankingSkeleton />}
-    {state.status === 'error' && (
-      <GlassCard className="border-red-500/20 bg-red-500/5 p-6 text-center text-sm font-bold text-red-600 dark:text-red-400">
-        시세를 불러오지 못했습니다.
-      </GlassCard>
-    )}
-    {state.status === 'success' && state.items.length === 0 && (
-      <GlassCard className="p-6 text-center text-sm text-gray-500 dark:text-gray-400">표시할 시세가 없습니다.</GlassCard>
-    )}
-    {state.status === 'success' && state.items.length > 0 && (
-      <GlassCard className="overflow-hidden">
-        <div className="hidden md:block">
-          <div className="grid grid-cols-[72px_minmax(0,1fr)_150px_150px_150px] gap-4 border-b border-gray-200/50 px-5 py-3 text-xs font-bold uppercase tracking-wider text-gray-400 dark:border-white/10">
-            <span>순위</span>
-            <span>아이템</span>
-            <span>최저가</span>
-            <span>전일 평균</span>
-            <span>변동</span>
-          </div>
-          {state.items.map((item) => (
-            <div key={item.name} className="grid grid-cols-[72px_minmax(0,1fr)_150px_150px_150px] gap-4 border-b border-gray-200/40 px-5 py-4 last:border-b-0 dark:border-white/5">
-              <div className="flex items-center"><RankBadge rank={item.rank} /></div>
-              <div className="flex min-w-0 items-center gap-3">
-                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
-                <p className="truncate text-sm font-bold text-gray-900 dark:text-white">{item.itemName}</p>
-              </div>
-              <div className="flex items-center text-sm font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</div>
-              <div className="flex items-center text-sm tabular-nums text-gray-600 dark:text-gray-300">{formatGold(item.yDayAvgPrice)}</div>
-              <div className="flex items-center text-sm font-bold"><PriceDelta current={item.price} previous={item.yDayAvgPrice} /></div>
-            </div>
-          ))}
-        </div>
-
-        <div className="divide-y divide-gray-200/50 md:hidden dark:divide-white/10">
-          {state.items.map((item) => (
-            <div key={`${item.name}-mobile`} className="p-4">
-              <div className="flex items-start gap-3">
-                <RankBadge rank={item.rank} />
-                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-start justify-between gap-3">
-                    <p className="line-clamp-2 text-sm font-bold text-gray-900 dark:text-white">{item.itemName}</p>
-                  </div>
-                  <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
-                    <div>
-                      <p className="text-gray-400 dark:text-gray-500">최저가</p>
-                      <p className="mt-1 font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
-                    </div>
-                    <div>
-                      <p className="text-gray-400 dark:text-gray-500">전일 평균</p>
-                      <p className="mt-1 tabular-nums text-gray-600 dark:text-gray-300">{formatGold(item.yDayAvgPrice)}</p>
-                    </div>
-                    <div>
-                      <p className="text-gray-400 dark:text-gray-500">변동</p>
-                      <p className="mt-1 font-bold"><PriceDelta current={item.price} previous={item.yDayAvgPrice} /></p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </GlassCard>
-    )}
-  </section>
-);
-
-const GemRanking: React.FC<{ state: RankState<GemRankItem> }> = ({ state }) => (
-  <section>
-    <SectionHeader title="보석" count={state.items.length} fetchedAt={state.fetchedAt} failedCount={state.failedCount} />
-    {state.status === 'loading' && <RankingSkeleton rows={10} />}
-    {state.status === 'error' && (
-      <GlassCard className="border-red-500/20 bg-red-500/5 p-6 text-center text-sm font-bold text-red-600 dark:text-red-400">
-        시세를 불러오지 못했습니다.
-      </GlassCard>
-    )}
-    {state.status === 'success' && state.items.length === 0 && (
-      <GlassCard className="p-6 text-center text-sm text-gray-500 dark:text-gray-400">표시할 시세가 없습니다.</GlassCard>
-    )}
-    {state.status === 'success' && state.items.length > 0 && (
-      <GlassCard className="overflow-hidden">
-        <div className="hidden md:block">
-          <div className="grid grid-cols-[72px_minmax(0,1fr)_150px] gap-4 border-b border-gray-200/50 px-5 py-3 text-xs font-bold uppercase tracking-wider text-gray-400 dark:border-white/10">
-            <span>순위</span>
-            <span>아이템</span>
-            <span>최저가</span>
-          </div>
-          {state.items.map((item) => (
-            <div key={`${item.level}-${item.kind}`} className="grid grid-cols-[72px_minmax(0,1fr)_150px] gap-4 border-b border-gray-200/40 px-5 py-4 last:border-b-0 dark:border-white/5">
-              <div className="flex items-center"><RankBadge rank={item.rank} /></div>
-              <div className="flex min-w-0 items-center gap-3">
-                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="text-sm font-bold text-gray-900 dark:text-white">Lv.{item.level}</p>
-                    <span className="rounded-full border border-la-gold/20 bg-la-gold/10 px-2.5 py-1 text-xs font-bold text-la-gold-dark dark:text-la-gold">{item.kind}</span>
-                  </div>
-                  <p className="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">{item.name}</p>
-                </div>
-              </div>
-              <div className="flex items-center text-sm font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</div>
-            </div>
-          ))}
-        </div>
-
-        <div className="divide-y divide-gray-200/50 md:hidden dark:divide-white/10">
-          {state.items.map((item) => (
-            <div key={`${item.level}-${item.kind}-mobile`} className="p-4">
-              <div className="flex items-start gap-3">
-                <RankBadge rank={item.rank} />
-                <img src={item.icon} alt="" className="h-11 w-11 flex-shrink-0 rounded-xl bg-gray-100 object-cover dark:bg-white/5" />
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-bold text-gray-900 dark:text-white">Lv.{item.level} {item.kind}</p>
-                  <p className="mt-1 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">{item.name}</p>
-                  <div className="mt-3 text-xs">
-                    <p className="text-gray-400 dark:text-gray-500">최저가</p>
-                    <p className="mt-1 font-black tabular-nums text-la-gold-dark dark:text-la-gold">{formatGold(item.price)}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </GlassCard>
-    )}
-  </section>
-);
-
 const Market: React.FC = () => {
   const requestIdRef = useRef(0);
   const [activeTab, setActiveTab] = useState<ActiveTab>('engraving');
@@ -496,9 +267,9 @@ const Market: React.FC = () => {
         </GlassCard>
 
         {activeTab === 'engraving' ? (
-          <EngravingRanking state={engravingState} />
+          <EngravingRanking state={engravingState} onRetry={() => void loadRankings(true)} />
         ) : (
-          <GemRanking state={gemState} />
+          <GemRanking state={gemState} onRetry={() => void loadRankings(true)} />
         )}
       </main>
     </div>
@@ -506,3 +277,4 @@ const Market: React.FC = () => {
 };
 
 export default Market;
+export { EngravingRanking, GemRanking } from '../components/market/MarketRankings';

--- a/src/pages/SpecSimulator.test.tsx
+++ b/src/pages/SpecSimulator.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import SpecSimulator from './SpecSimulator';
+import { fetchProfile } from '../utils/api';
+
+const longNickname = '모바일에서도아주긴캐릭터닉네임이잘리는일없이표시되어야합니다';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useSearchParams: () => [new URLSearchParams(`nickname=${longNickname}`), jest.fn()],
+  }),
+  { virtual: true },
+);
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+jest.mock('../components/PullToRefresh', () => ({ children }: { children: React.ReactNode }) => <>{children}</>);
+jest.mock('../components/simulation/SpecScoreSimulator', () => () => <div>SpecScoreSimulator</div>);
+
+jest.mock('../utils/api', () => ({
+  fetchProfile: jest.fn(),
+  LS_NICKNAME: 'lostark_nickname',
+}));
+
+const mockedFetchProfile = fetchProfile as jest.MockedFunction<typeof fetchProfile>;
+
+describe('SpecSimulator route error guidance', () => {
+  it('keeps the searched nickname in a wrapping-friendly error heading', async () => {
+    mockedFetchProfile.mockRejectedValue(new Error('rate limited'));
+
+    render(<SpecSimulator />);
+
+    const alert = await screen.findByRole('alert');
+    const heading = screen.getByRole('heading', { name: `${longNickname} 프로필을 불러오지 못했습니다` });
+    expect(alert).toHaveTextContent('다른 닉네임으로 다시 검색해 주세요');
+    expect(heading).toHaveClass('break-words');
+  });
+
+  it('shows the not-found branch when profile lookup succeeds with no data', async () => {
+    mockedFetchProfile.mockResolvedValue(null as never);
+
+    render(<SpecSimulator />);
+
+    expect(await screen.findByRole('status', { name: `${longNickname} 프로필을 찾을 수 없습니다` })).toHaveTextContent(
+      '닉네임을 확인한 뒤 다른 캐릭터를 다시 검색해 주세요',
+    );
+  });
+});

--- a/src/pages/SpecSimulator.tsx
+++ b/src/pages/SpecSimulator.tsx
@@ -6,6 +6,7 @@ import PullToRefresh from '../components/PullToRefresh';
 import NicknameInput from '../components/NicknameInput';
 import NicknameSearchBar from '../components/NicknameSearchBar';
 import GlassCard from '../components/GlassCard';
+import StateFeedback from '../components/StateFeedback';
 import { SkeletonBlock } from '../components/Loading';
 import SpecScoreSimulator from '../components/simulation/SpecScoreSimulator';
 import { fetchProfile, LS_NICKNAME } from '../utils/api';
@@ -60,7 +61,6 @@ const SpecSimulator: React.FC = () => {
           setProfile(data);
           return;
         }
-        setError('캐릭터 프로필을 찾을 수 없습니다. 닉네임을 다시 확인해 주세요.');
       })
       .catch((err: unknown) => {
         if (!active || controller.signal.aborted) return;
@@ -139,7 +139,7 @@ const SpecSimulator: React.FC = () => {
                   </span>
                 </div>
               </div>
-              <div className="w-full rounded-xl border border-gray-200/70 bg-gray-50/80 p-3 dark:border-white/10 dark:bg-black/20 lg:justify-self-end">
+              <div className="min-w-0 w-full rounded-xl border border-gray-200/70 bg-gray-50/80 p-3 dark:border-white/10 dark:bg-black/20 lg:justify-self-end">
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <p className="text-xs font-bold text-gray-700 dark:text-gray-200">캐릭터 불러오기</p>
                   <span className="text-[10px] font-medium text-gray-400 dark:text-gray-500">닉네임 검색</span>
@@ -152,10 +152,12 @@ const SpecSimulator: React.FC = () => {
           {loading ? (
             <ProfileLoadingCard />
           ) : error ? (
-            <GlassCard className="spec-lab-card p-8 text-center animate-fade-in">
-              <p className="text-lg text-red-500 dark:text-red-400">{error}</p>
-              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">다른 닉네임으로 다시 검색해 주세요.</p>
-            </GlassCard>
+            <StateFeedback
+              tone="error"
+              title={`${nickname} 프로필을 불러오지 못했습니다`}
+              description={`${error} 다른 닉네임으로 다시 검색해 주세요.`}
+              className="spec-lab-card animate-fade-in"
+            />
           ) : profile ? (
             <>
               <section className="spec-lab-card overflow-hidden animate-fade-in" aria-labelledby="current-character-title">
@@ -192,9 +194,12 @@ const SpecSimulator: React.FC = () => {
               <SpecScoreSimulator profile={profile} />
             </>
           ) : (
-            <GlassCard className="spec-lab-card p-8 text-center animate-fade-in">
-              <p className="text-gray-500 dark:text-gray-400">캐릭터 프로필을 불러오는 데 실패했습니다.</p>
-            </GlassCard>
+            <StateFeedback
+              tone="empty"
+              title={`${nickname} 프로필을 찾을 수 없습니다`}
+              description="닉네임을 확인한 뒤 다른 캐릭터를 다시 검색해 주세요."
+              className="spec-lab-card animate-fade-in"
+            />
           )}
         </main>
       </PullToRefresh>

--- a/src/pages/Spending.test.tsx
+++ b/src/pages/Spending.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Spending from './Spending';
+
+jest.mock('../components/NavBar', () => () => <div>NavBar</div>);
+
+describe('Spending mobile guidance', () => {
+  it('makes the PC-only requirement and script wrapping explicit', () => {
+    render(<Spending />);
+
+    expect(screen.getByRole('heading', { name: 'PC 브라우저에서 진행해 주세요' })).toBeInTheDocument();
+    expect(screen.getByText('allow pasting')).toHaveClass('break-all');
+
+    fireEvent.click(screen.getByRole('button', { name: /스크립트 미리보기/ }));
+
+    const preview = screen.getByText(/analyzeLostArkFinal/);
+    expect(preview).toHaveClass('max-w-full', 'whitespace-pre-wrap', 'break-all');
+  });
+});

--- a/src/pages/Spending.tsx
+++ b/src/pages/Spending.tsx
@@ -24,7 +24,7 @@ const STEPS = [
     title: '개발자 도구 열기',
     desc: (
       <>
-        키보드 <kbd className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-white/10 text-xs font-mono">F12</kbd> 를 눌러 개발자 도구를 여세요.
+        키보드 <kbd className="inline-block max-w-full break-all whitespace-normal rounded bg-gray-200 px-1.5 py-0.5 font-mono text-xs dark:bg-white/10">F12</kbd> 를 눌러 개발자 도구를 여세요.
         상단 탭에서 <strong>Console</strong>을 선택하세요.
       </>
     ),
@@ -40,10 +40,10 @@ const STEPS = [
     desc: (
       <>
         Console 입력창에 붙여넣기{' '}
-        <kbd className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-white/10 text-xs font-mono">Ctrl+V</kbd>{' '}
-        후 <kbd className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-white/10 text-xs font-mono">Enter</kbd>를 누르세요.
+        <kbd className="inline-block max-w-full break-all whitespace-normal rounded bg-gray-200 px-1.5 py-0.5 font-mono text-xs dark:bg-white/10">Ctrl+V</kbd>{' '}
+        후 <kbd className="inline-block max-w-full break-all whitespace-normal rounded bg-gray-200 px-1.5 py-0.5 font-mono text-xs dark:bg-white/10">Enter</kbd>를 누르세요.
         <br />
-        <span className="text-amber-600 dark:text-amber-400">붙여넣기가 안 되면 입력창에 <kbd className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-white/10 text-xs font-mono">allow pasting</kbd> 을 먼저 입력하세요.</span>
+        <span className="text-amber-600 dark:text-amber-400">붙여넣기가 안 되면 입력창에 <kbd className="inline-block max-w-full break-all whitespace-normal rounded bg-gray-200 px-1.5 py-0.5 font-mono text-xs dark:bg-white/10">allow pasting</kbd> 을 먼저 입력하세요.</span>
       </>
     ),
   },
@@ -65,7 +65,7 @@ const Spending: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="min-h-screen bg-gray-50 transition-colors duration-300 dark:bg-la-dark">
       <NavBar />
       <main className="max-w-2xl mx-auto px-4 py-6 space-y-5">
 
@@ -79,15 +79,24 @@ const Spending: React.FC = () => {
         </div>
 
         {/* 안내 배너 */}
-        <div className="flex gap-3 p-4 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40 text-sm text-amber-800 dark:text-amber-300">
-          <span className="shrink-0 text-base">⚠️</span>
-          <ul className="space-y-1 list-none">
-            <li><strong>PC 브라우저 전용</strong>입니다. 모바일에서는 개발자 도구를 사용할 수 없습니다.</li>
+        <section
+          role="note"
+          aria-labelledby="spending-pc-guidance-title"
+          className="flex gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-300"
+        >
+          <svg aria-hidden="true" className="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-1.5a9 9 0 11-18 0 9 9 0 0118 0zM12 16.5h.008v.008H12V16.5z" />
+          </svg>
+          <div className="min-w-0">
+            <h2 id="spending-pc-guidance-title" className="break-keep font-bold">PC 브라우저에서 진행해 주세요</h2>
+            <ul className="mt-2 list-none space-y-1 break-keep leading-relaxed">
+            <li>모바일에서는 개발자 도구를 사용할 수 없어 스크립트를 실행할 수 없습니다.</li>
             <li>본인 계정 정보만 조회되며 외부 서버로 전송되지 않습니다.</li>
             <li>로스트아크 홈페이지에 로그인된 상태에서 실행해야 합니다.</li>
             <li>결제 수단 합계는 <strong>스토브 통합</strong> 기준으로 표시됩니다.</li>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        </section>
 
         {/* 단계별 안내 */}
         <GlassCard className="p-4 space-y-5">
@@ -97,12 +106,13 @@ const Spending: React.FC = () => {
               <span className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full bg-la-gold/20 text-la-gold-dark dark:text-la-gold text-sm font-bold">
                 {step.num}
               </span>
-              <div className="space-y-2 pt-0.5">
+              <div className="min-w-0 flex-1 space-y-2 pt-0.5">
                 <p className="text-sm font-semibold text-gray-900 dark:text-white">{step.title}</p>
-                <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">{step.desc}</p>
+                <p className="break-words text-sm leading-relaxed text-gray-500 dark:text-gray-400">{step.desc}</p>
                 {step.action}
                 {i === 2 && (
                   <button
+                    type="button"
                     onClick={handleCopy}
                     className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
                       copied
@@ -110,7 +120,10 @@ const Spending: React.FC = () => {
                         : 'bg-la-gold/20 hover:bg-la-gold/30 text-la-gold-dark dark:text-la-gold'
                     }`}
                   >
-                    {copied ? '복사됨 ✓' : '스크립트 복사 📋'}
+                    <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d={copied ? 'M4.5 12.75l6 6 9-13.5' : 'M8.25 7.5V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0120.25 6v7.5A2.25 2.25 0 0118 15.75h-1.5m-8.25-8.25h-2.25A2.25 2.25 0 003.75 9.75v7.5a2.25 2.25 0 002.25 2.25h7.5a2.25 2.25 0 002.25-2.25V15'} />
+                    </svg>
+                    {copied ? '복사됨' : '스크립트 복사'}
                   </button>
                 )}
               </div>
@@ -135,8 +148,8 @@ const Spending: React.FC = () => {
             </span>
           </button>
           {showScript && (
-            <div id="spending-script-preview" className="mt-3 rounded-lg overflow-hidden">
-              <pre className="p-4 bg-gray-900 text-gray-300 text-xs leading-relaxed overflow-x-auto whitespace-pre-wrap break-all">
+            <div id="spending-script-preview" className="mt-3 min-w-0 max-w-full overflow-hidden rounded-lg">
+              <pre className="max-w-full overflow-x-auto whitespace-pre-wrap break-all bg-gray-900 p-4 text-xs leading-relaxed text-gray-300">
                 {STOVE_SCRIPT}
               </pre>
             </div>


### PR DESCRIPTION
## Summary
- 모바일 내비게이션, 선택 메뉴, 레이드 선택 패널의 접근성과 breakpoint 동작을 보정했습니다.
- 공용 이미지 fallback/상태 피드백 컴포넌트를 추가하고 캐릭터/원정대/시뮬레이터/강화 피드백 상태를 개선했습니다.
- Home/Expedition/Market 표시 컴포넌트를 분리하고 관련 regression tests를 보강했습니다.
- 레이드 선택 패널에 그룹 접기 상태를 추가하고, Enhancement 실패 상태를 공통 컴포넌트로 통일했습니다.

## Issue #17 Work Items
High
- [x] `/character`, `/expedition`, `/simulation` 캐릭터 이미지 공통 fallback
- [x] `/simulation` 모바일 레이드 변경 bottom sheet 재설계 + 참여 가능/불가 그룹 접기 상태
- [x] `/enhancement` 모바일 드롭다운 full-width panel 전환, nested-scroll 제거

Medium
- [x] `/market`, `/character`, `/enhancement`, `/simulation` 로딩/빈/실패 상태 공통 컴포넌트 통일
- [x] CJK 줄바꿈과 inline keyboard/code 표현 개선
- [x] `/compare` disabled 버튼 입력 안내
- [x] `/spending` 모바일 PC 전용 안내

## Verification
- yarn test --watchAll=false (46 suites / 283 tests)
  - 유일한 실패는 `src/utils/lopecSimulator.invenFormula.test.ts`의 Serka armor denominator 케이스로, `origin/main`에서도 동일하게 실패하는 기존 항목이며 이 PR 변경 파일에 포함되지 않습니다.
- npx tsc --noEmit
- yarn build
- self-review final verdict: PASS
- 리뷰 스레드 8건 전부 해소 후 resolve

## Notes
- 접기 정책: 참여 불가 그룹은 기본 접기. 단 참여 불가에 이미 체크가 있거나 참여 가능 그룹이 비어 있으면 펼친 상태로 시작합니다. 접힌 그룹 안의 선택 상태가 화면에서 사라지지 않도록 한 결정입니다.
- 접힌 그룹(`[hidden]`) 내부 요소는 focus 불가하므로 Tab trap 경계 계산에서 제외했습니다.
- No co-author trailer was added.
- LOW-only residual: real-browser focus ring/rapid breakpoint manual QA gap and existing SpecSimulator expected-error console noise.

Refs #17