### PR TITLE
SEO 후속 작업: SearchAction·lazy loading·헤딩 정리·검색엔진 등록

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,15 @@
             "name": "로아끼욧",
             "url": "https://lokki.vercel.app/",
             "inLanguage": "ko-KR",
-            "description": "로아끼욧에서 로스트아크 캐릭터 조회, 원정대 주간 골드 계산, 스펙 시뮬레이터, 강화·거래소·지출 관리를 한 번에 확인하세요."
+            "description": "로아끼욧에서 로스트아크 캐릭터 조회, 원정대 주간 골드 계산, 스펙 시뮬레이터, 강화·거래소·지출 관리를 한 번에 확인하세요.",
+            "potentialAction": {
+              "@type": "SearchAction",
+              "target": {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://lokki.vercel.app/character?nickname={search_term_string}"
+              },
+              "query-input": "required name=search_term_string"
+            }
           },
           {
             "@type": "SoftwareApplication",

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://lokki.vercel.app/" />
     <meta name="naver-site-verification" content="1e45ff957cc162a8a47a77c99b62d4fbae8c3ba1" />
+    <meta name="google-site-verification" content="gGGj9dLWx0saUcjGyXd5-i5f4vhTlcNw6MkOH3bpn4s" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:site_name" content="로아끼욧" />

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <meta name="keywords" content="로아끼욧, 로스트아크, 로아, 캐릭터 조회, 원정대 골드, 주간 골드 계산기, 스펙 시뮬레이터, 강화 계산기, 거래소" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://lokki.vercel.app/" />
+    <meta name="naver-site-verification" content="1e45ff957cc162a8a47a77c99b62d4fbae8c3ba1" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:site_name" content="로아끼욧" />

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -141,4 +141,5 @@ test('keeps static social and structured metadata available before hydration', (
     '"urlTemplate": "https://lokki.vercel.app/character?nickname={search_term_string}"'
   );
   expect(indexHtml).toContain('"query-input": "required name=search_term_string"');
+  expect(indexHtml).toContain('name="naver-site-verification"');
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -142,4 +142,5 @@ test('keeps static social and structured metadata available before hydration', (
   );
   expect(indexHtml).toContain('"query-input": "required name=search_term_string"');
   expect(indexHtml).toContain('name="naver-site-verification"');
+  expect(indexHtml).toContain('name="google-site-verification"');
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -136,4 +136,9 @@ test('keeps static social and structured metadata available before hydration', (
   expect(indexHtml).toContain('property="og:image:width" content="1200"');
   expect(indexHtml).toContain('type="application/ld+json"');
   expect(indexHtml).toContain('"@type": "SoftwareApplication"');
+  expect(indexHtml).toContain('"@type": "SearchAction"');
+  expect(indexHtml).toContain(
+    '"urlTemplate": "https://lokki.vercel.app/character?nickname={search_term_string}"'
+  );
+  expect(indexHtml).toContain('"query-input": "required name=search_term_string"');
 });

--- a/src/components/simulation/ArkGridGemEditorModal.tsx
+++ b/src/components/simulation/ArkGridGemEditorModal.tsx
@@ -69,7 +69,7 @@ export const ArkGridGemEditorModal = ({
           <div className="flex items-center gap-3">
             <div className="h-14 w-14 overflow-hidden rounded-xl border border-la-gold/40 bg-gray-100 shadow-inner dark:bg-black/30">
               {editingArkGridGemData?.Icon ? (
-                <img src={editingArkGridGemData.Icon} alt="" className="h-full w-full object-cover" />
+                <img src={editingArkGridGemData.Icon} alt="" loading="lazy" className="h-full w-full object-cover" />
               ) : (
                 <div className="h-full w-full bg-gray-100 dark:bg-white/5" />
               )}

--- a/src/components/simulation/ArkGridSimulatorPanel.tsx
+++ b/src/components/simulation/ArkGridSimulatorPanel.tsx
@@ -99,7 +99,7 @@ export const ArkGridSimulatorPanel = ({
                       >
                         <div className="relative h-full w-full overflow-hidden rounded-[10px] bg-gray-100 dark:bg-black/30">
                           {slot.Icon ? (
-                            <img src={slot.Icon} alt="" className="h-full w-full object-cover" />
+                            <img src={slot.Icon} alt="" loading="lazy" className="h-full w-full object-cover" />
                           ) : (
                             <div className="h-full w-full bg-gray-100 dark:bg-white/5" />
                           )}
@@ -162,7 +162,7 @@ export const ArkGridSimulatorPanel = ({
                               title={gemTitle || `${gem?.Grade ?? '시뮬'} #${gem?.Index ?? gemIndex}`}
                             >
                               {gem?.Icon ? (
-                                <img src={gem.Icon} alt="" className="h-full w-full object-cover" />
+                                <img src={gem.Icon} alt="" loading="lazy" className="h-full w-full object-cover" />
                               ) : (
                                 <div className="flex h-full w-full items-center justify-center bg-la-gold/10 text-[10px] font-bold text-la-gold-dark dark:bg-la-gold/15 dark:text-la-gold">
                                   SIM

--- a/src/components/simulation/SelectedRaidRow.tsx
+++ b/src/components/simulation/SelectedRaidRow.tsx
@@ -54,6 +54,7 @@ const SelectedRaidRow: React.FC<SelectedRaidRowProps> = ({
             alt={`${raid.raidName} 레이드`}
             width={352}
             height={224}
+            loading="lazy"
             className={`h-full w-full object-cover transition-[filter,opacity] duration-200 ${completed ? 'grayscale opacity-60' : ''}`}
           />
           <div

--- a/src/components/simulation/SpecScoreAccessoriesPanel.tsx
+++ b/src/components/simulation/SpecScoreAccessoriesPanel.tsx
@@ -131,6 +131,7 @@ export const SpecScoreAccessoriesPanel = ({
                 <img
                   src={cur.raw.Icon}
                   alt=""
+                  loading="lazy"
                   className="w-14 h-14 rounded border border-gray-200 dark:border-white/10"
                 />
                 {quality !== null && (
@@ -183,6 +184,7 @@ export const SpecScoreAccessoriesPanel = ({
               <img
                 src={bracelet.raw.Icon}
                 alt=""
+                loading="lazy"
                 className="w-14 h-14 rounded border border-gray-200 dark:border-white/10"
               />
               <span className="absolute bottom-0.5 left-0.5 right-0.5 text-[9px] font-bold text-amber-300 bg-black/70 rounded text-center leading-tight">

--- a/src/components/simulation/SpecScoreCorePanel.tsx
+++ b/src/components/simulation/SpecScoreCorePanel.tsx
@@ -165,7 +165,7 @@ export const SpecScoreCorePanel = ({
                 >
                   <div className="h-9 w-9 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 dark:border-white/10 dark:bg-white/5">
                     {icon ? (
-                      <img src={icon} alt="" className="h-full w-full object-cover" />
+                      <img src={icon} alt="" loading="lazy" className="h-full w-full object-cover" />
                     ) : (
                       <div className="flex h-full w-full items-center justify-center text-[10px] font-bold text-gray-400">
                         {currentName.slice(0, 1)}
@@ -220,6 +220,7 @@ export const SpecScoreCorePanel = ({
               <img
                 src={stone.raw.Icon}
                 alt=""
+                loading="lazy"
                 className="h-14 w-14 rounded border border-gray-200 dark:border-white/10"
               />
               <span className="absolute bottom-0.5 left-0.5 right-0.5 rounded bg-black/70 text-center text-[9px] font-bold leading-tight text-amber-300">

--- a/src/components/simulation/SpecScoreEquipmentPanel.tsx
+++ b/src/components/simulation/SpecScoreEquipmentPanel.tsx
@@ -194,6 +194,7 @@ export const SpecScoreEquipmentPanel = ({
                     <img
                       src={armletIcon}
                       alt=""
+                      loading="lazy"
                       className={`h-full w-full object-contain ${armletIsUnequipped ? 'opacity-45 grayscale' : ''}`}
                     />
                   </div>
@@ -247,7 +248,7 @@ export const SpecScoreEquipmentPanel = ({
             >
               <div className="relative w-14 flex-shrink-0">
                 <div className={`h-14 w-14 overflow-hidden rounded border ${frame.className}`} style={frame.style}>
-                  <img src={cur.raw.Icon} alt="" className="h-full w-full object-contain" />
+                  <img src={cur.raw.Icon} alt="" loading="lazy" className="h-full w-full object-contain" />
                 </div>
                 <span className="absolute top-0.5 left-0.5 text-[9px] font-bold text-white bg-black/70 rounded px-1 leading-tight">
                   {SLOT_LABEL[slot]}

--- a/src/components/simulation/SpecScoreGemPanel.tsx
+++ b/src/components/simulation/SpecScoreGemPanel.tsx
@@ -84,7 +84,7 @@ export const SpecScoreGemPanel = ({
             >
               {/* 아이콘 + 레벨 뱃지 */}
               <div className="relative w-full aspect-square rounded bg-gray-50 dark:bg-white/5 border border-gray-200/60 dark:border-white/5 overflow-hidden">
-                <img src={g.Icon} alt="" className="w-full h-full object-cover" />
+                <img src={g.Icon} alt="" loading="lazy" className="w-full h-full object-cover" />
                 <span className="absolute top-0.5 right-0.5 text-[10px] font-bold text-white bg-black/70 rounded px-1 leading-tight">
                   {currentLevel}
                 </span>

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -338,7 +338,7 @@ const ArkGridCard: React.FC<{ data: ArkGridData }> = ({ data }) => {
                 style={frame.style}
               >
                 {slot.Icon
-                  ? <img src={slot.Icon} alt={name} className="w-full h-full object-cover" />
+                  ? <img src={slot.Icon} alt={name} loading="lazy" className="w-full h-full object-cover" />
                   : <div className="w-full h-full" />
                 }
               </div>
@@ -422,7 +422,7 @@ const GemsCard: React.FC<{ data: GemData }> = ({ data }) => {
               style={frame.style}
               title={gem.Name}
             >
-              <img src={gem.Icon} alt={gem.Name} className="w-9 h-9 rounded-lg" />
+              <img src={gem.Icon} alt={gem.Name} loading="lazy" className="w-9 h-9 rounded-lg" />
               <span className="text-[10px] font-bold">Lv.{gem.Level}</span>
             </div>
           );
@@ -449,6 +449,7 @@ const EquipmentItemCard: React.FC<{ item: EquipmentItem }> = ({ item }) => {
             <img
               src={item.Icon}
               alt={item.Name}
+              loading="lazy"
               className={`w-11 h-11 rounded-lg border-2 ${frame.className}`}
               style={frame.style}
             />

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -253,10 +253,10 @@ const ArkPassiveCard: React.FC<{ data: EngravingData }> = ({ data }) => {
   return (
     <>
       <GlassCard className="p-4 animate-fade-in">
-        <p className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+        <h2 className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
           <span className="h-3 w-0.5 rounded-full bg-la-gold/80" />
           <span>각인</span>
-        </p>
+        </h2>
         <div ref={wrapperRef} className="flex flex-wrap gap-2">
           {passives.map((effect, i) => {
             const frame = gradeStyles(effect.Grade, 'subtle');
@@ -326,7 +326,7 @@ const ArkGridCard: React.FC<{ data: ArkGridData }> = ({ data }) => {
   if (!data.Slots || data.Slots.length === 0) return null;
   return (
     <GlassCard className="p-4 animate-fade-in">
-      <p className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider"><span className="h-3 w-0.5 rounded-full bg-la-gold/80" /><span>아크 그리드</span></p>
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider"><span className="h-3 w-0.5 rounded-full bg-la-gold/80" /><span>아크 그리드</span></h2>
       <div className="grid grid-cols-3 gap-3">
         {data.Slots.map((slot) => {
           const frame = gradeFrame(slot.Grade, 'bg');
@@ -366,7 +366,7 @@ const EngravingsCard: React.FC<{ data: EngravingData }> = ({ data }) => {
   if (effects.length === 0) return null;
   return (
     <GlassCard className="p-4 animate-fade-in">
-      <p className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">각인</p>
+      <h2 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">각인</h2>
       <div className="space-y-1.5">
         {effects.map((effect, i) => (
           <div key={i} className="flex items-center gap-2 text-sm py-0.5">
@@ -385,7 +385,7 @@ const StatsCard: React.FC<{ profile: CharacterProfile }> = ({ profile }) => {
   if (stats.length === 0) return null;
   return (
     <GlassCard className="p-4 animate-fade-in">
-      <p className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider"><span className="h-3 w-0.5 rounded-full bg-la-gold/80" /><span>전투 스탯</span></p>
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider"><span className="h-3 w-0.5 rounded-full bg-la-gold/80" /><span>전투 스탯</span></h2>
       <div className="grid grid-cols-2 gap-x-4 gap-y-2">
         {stats.map((stat) => (
           <div key={stat.Type} className="flex justify-between text-sm">
@@ -406,12 +406,12 @@ const GemsCard: React.FC<{ data: GemData }> = ({ data }) => {
   if (!data.Gems || data.Gems.length === 0) return null;
   return (
     <GlassCard className="p-4 animate-fade-in">
-      <p className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
         <span className="h-3 w-0.5 rounded-full bg-la-gold/80" />
         <span>
           보석 <span className="normal-case font-normal text-gray-400">{data.Gems.length}개</span>
         </span>
-      </p>
+      </h2>
       <div className="flex flex-wrap gap-1.5">
         {data.Gems.map((gem) => {
           const frame = gradeStyles(gem.Grade, 'border');
@@ -538,10 +538,10 @@ const EquipmentCard: React.FC<{ items: EquipmentItem[] }> = ({ items }) => {
 
   return (
     <GlassCard className="p-4 animate-fade-in">
-      <p className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
         <span className="h-3 w-0.5 rounded-full bg-la-gold/80" />
         <span>장비</span>
-      </p>
+      </h2>
 
       {/* ① 전투 장비 + 장신구 */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -249,6 +249,7 @@ const EquipmentRow: React.FC<{
           <img
             src={item.Icon}
             alt=""
+            loading="lazy"
             className={`w-8 h-8 rounded border flex-shrink-0 ${frame.className}`}
             style={frame.style}
           />
@@ -308,6 +309,7 @@ const GemBadge: React.FC<{ gem: GemItem; skill?: GemSkillEffect }> = ({ gem, ski
         <img
           src={gem.Icon}
           alt=""
+          loading="lazy"
           className={`w-7 h-7 rounded border flex-shrink-0 ${frame.className}`}
           style={frame.style}
         />
@@ -806,7 +808,7 @@ const ArkGridSection: React.FC<{
                 style={frame.style}
               >
                 {slot.Icon ? (
-                  <img src={slot.Icon} alt={name} className="w-full h-full object-cover" />
+                  <img src={slot.Icon} alt={name} loading="lazy" className="w-full h-full object-cover" />
                 ) : (
                   <div className="w-full h-full" />
                 )}

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -341,6 +341,7 @@ const SectionHeader: React.FC<{
   expanded: boolean;
   onToggle: () => void;
 }> = ({ icon, title, expanded, onToggle }) => (
+  <h2>
   <button
     onClick={onToggle}
     className="w-full flex items-center justify-between gap-2 text-base font-bold text-gray-900 dark:text-white mb-0 cursor-pointer select-none group"
@@ -361,6 +362,7 @@ const SectionHeader: React.FC<{
       <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
     </svg>
   </button>
+  </h2>
 );
 
 /** 캐릭터 입력 필드 */
@@ -530,9 +532,9 @@ const EquipmentSection: React.FC<{
       {/* Armor section */}
       <div className="mb-4">
         <div className="flex items-center justify-between mb-2">
-          <h4 className="text-xs font-bold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+          <h3 className="text-xs font-bold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
             방어구
-          </h4>
+          </h3>
           <div className="flex gap-3 text-[10px]">
             <span className="text-gray-400">
               평균 품질:{' '}
@@ -561,9 +563,9 @@ const EquipmentSection: React.FC<{
       {/* Accessory section */}
       <div className="mb-4">
         <div className="flex items-center justify-between mb-2">
-          <h4 className="text-xs font-bold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+          <h3 className="text-xs font-bold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
             악세서리
-          </h4>
+          </h3>
           <div className="flex gap-3 text-[10px]">
             <span className="text-gray-400">
               평균 품질:{' '}

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -848,9 +848,9 @@ const Enhancement: React.FC = () => {
 
         {/* ── 캐릭터 검색 ── */}
         <GlassCard className="p-4">
-          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+          <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
             캐릭터 강화 현황
-          </p>
+          </h2>
           <div className="flex gap-2 mb-4">
             <input
               ref={charInputRef}
@@ -1055,7 +1055,7 @@ const Enhancement: React.FC = () => {
         {/* ── 일반 재련 설정 ── */}
         {hasResult && (
           <GlassCard className="p-4">
-            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">일반 재련 설정</p>
+            <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">일반 재련 설정</h2>
             <div className="flex flex-wrap items-center gap-3">
               {hasBookSteps && (
                 <Toggle
@@ -1119,7 +1119,7 @@ const Enhancement: React.FC = () => {
           ];
           return (
             <GlassCard className="p-4">
-              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">상급 재련 설정</p>
+              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">상급 재련 설정</h2>
               <div className="space-y-2">
                 {rows.map(({ label, opt, set, optimal }) => (
                   <div key={label} className="flex items-center gap-2">
@@ -1161,9 +1161,9 @@ const Enhancement: React.FC = () => {
           <>
             {/* ── 합산 견적 ── */}
             <GlassCard className="p-4 border border-la-gold/20">
-              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
                 강화 견적 합계{hasOwnedInput && hasPrices && <span className="ml-1 font-normal text-orange-500 dark:text-orange-400">(추가 구매 기준)</span>}
-              </p>
+              </h2>
               <div className={`grid gap-4 ${hasResult && hasAdvResult ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1 sm:grid-cols-2'}`}>
                 {hasResult && (
                   <div>
@@ -1207,9 +1207,9 @@ const Enhancement: React.FC = () => {
             {/* ── 슬롯별 소계 (2개 이상 선택 시) ── */}
             {activeSlots.length >= 2 && (
               <GlassCard className="p-4">
-                <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+                <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
                   슬롯별 예상 비용
-                </p>
+                </h2>
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-gray-200/40 dark:border-white/8">
@@ -1253,9 +1253,9 @@ const Enhancement: React.FC = () => {
 
             {/* ── 예상 총 비용 요약 ── */}
             <GlassCard className="p-4">
-              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
                 예상 총 비용{activeSlots.length >= 2 ? ' (전체)' : ''}
-              </p>
+              </h2>
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 <div>
                   <p className="text-xs text-gray-400 mb-0.5">총 기대 시도</p>
@@ -1356,9 +1356,9 @@ const Enhancement: React.FC = () => {
             {hasAdvResult && (
               <>
                 <GlassCard className="p-4">
-                  <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+                  <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
                     상급 재련 예상 비용
-                  </p>
+                  </h2>
                   <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-3">
                     <div>
                       <p className="text-xs text-gray-400 mb-0.5">총 기대 시도</p>
@@ -1431,10 +1431,10 @@ const Enhancement: React.FC = () => {
               onClick={() => setShowOwnedSection((v) => !v)}
               className="flex items-center justify-between w-full"
             >
-              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">
+              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400">
                 보유 재료 입력
                 <span className="ml-1.5 font-normal text-gray-400 dark:text-gray-500">(선택 사항)</span>
-              </p>
+              </h2>
               <span className="text-xs text-gray-400 dark:text-gray-500">
                 {showOwnedSection ? '▲' : '▼'}
               </span>
@@ -1485,9 +1485,9 @@ const Enhancement: React.FC = () => {
         {/* ── 재료 시세 ── */}
         <GlassCard className="p-4">
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">
+            <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400">
               재련 재료 시세
-            </p>
+            </h2>
             {priceLoading && <span className="text-xs text-gray-400 animate-pulse">조회 중…</span>}
           </div>
           {priceError && (

--- a/src/pages/Simulation.tsx
+++ b/src/pages/Simulation.tsx
@@ -618,6 +618,7 @@ const Simulation: React.FC = () => {
                                             <img
                                                 src={r.characterImage}
                                                 alt={r.characterName}
+                                                loading="lazy"
                                                 className="w-6 h-6 rounded-md object-cover object-top"
                                             />
                                             <span className="font-medium truncate">{r.characterName}</span>
@@ -671,6 +672,7 @@ const Simulation: React.FC = () => {
                                                             <img
                                                                 src={r.characterImage}
                                                                 alt={r.characterName}
+                                                                loading="lazy"
                                                                 className="w-6 h-6 rounded-md object-cover object-top"
                                                             />
                                                             <span className="font-medium truncate">{r.characterName}</span>

--- a/src/pages/Spending.tsx
+++ b/src/pages/Spending.tsx
@@ -100,14 +100,14 @@ const Spending: React.FC = () => {
 
         {/* 단계별 안내 */}
         <GlassCard className="p-4 space-y-5">
-          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">사용 방법</p>
+          <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400">사용 방법</h2>
           {STEPS.map((step, i) => (
             <div key={i} className="flex gap-4">
               <span className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full bg-la-gold/20 text-la-gold-dark dark:text-la-gold text-sm font-bold">
                 {step.num}
               </span>
               <div className="min-w-0 flex-1 space-y-2 pt-0.5">
-                <p className="text-sm font-semibold text-gray-900 dark:text-white">{step.title}</p>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{step.title}</h3>
                 <p className="break-words text-sm leading-relaxed text-gray-500 dark:text-gray-400">{step.desc}</p>
                 {step.action}
                 {i === 2 && (
@@ -140,9 +140,9 @@ const Spending: React.FC = () => {
             aria-controls="spending-script-preview"
             className="flex items-center justify-between w-full"
           >
-            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">
+            <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400">
               스크립트 미리보기
-            </p>
+            </h2>
             <span className="text-xs text-gray-400 dark:text-gray-500">
               {showScript ? '▲' : '▼'}
             </span>


### PR DESCRIPTION
이슈 #20 의 남은 항목 4건을 처리합니다.

Closes #20

## 변경 내용

| 커밋 | 항목 | 내용 |
|---|---|---|
| `1cb3b53` | #20-3 | WebSite JSON-LD에 `SearchAction` 추가 |
| `c8da5e3` | #20-7b | 뷰포트 밖 이미지 17곳에 `loading="lazy"` |
| `a84fe20` | #20-9 | 헤딩 레벨 점프 교정 |
| `113f5e2` | #20-5 | 네이버 서치어드바이저 verification meta |
| `9367957` | #20-5 | Google Search Console verification meta |

### #20-3 SearchAction

`/character?nickname=` 쿼리 진입이 `src/pages/Character.tsx`에 이미 구현되어 있어(`useSearchParams` + URL→state 동기화) 실제 라우팅과 일치하는 URL 템플릿을 사용했습니다. 임의 URL을 만들지 않았습니다.

### #20-7b lazy loading

장비/보석/코어/악세 아이콘, 결과 테이블 아바타, 레이드 썸네일에 적용했습니다.

**제외**: `src/pages/Compare.tsx`의 `CharacterImage` — 비교 결과 화면 최상단에 노출되는 LCP 후보라 지연 로딩 대상에서 뺐습니다.

### #20-9 헤딩 레벨

- `Compare` — `SectionHeader`의 button을 `<h2>`로 감싸고 하위 `h4` → `h3`. `h1 → h2 → h3` 성립
- `Character` / `Enhancement` / `Spending` — 카드 섹션 제목 `<p>` → `<h2>`, 단계 제목 → `<h3>`

Tailwind 클래스를 그대로 옮겨 **시각적 변화는 없습니다.**

### #20-5 검색엔진 등록

`vercel.app` 서브도메인은 DNS 존 접근 권한이 없어 Google 도메인 속성을 쓸 수 없습니다. **URL 접두어 속성 + HTML 태그** 방식으로 등록했습니다.

다음(카카오)은 meta 태그 방식을 제공하지 않아 코드 변경 대상이 아니며, 네이버·Google 커버리지로 충분하다고 판단해 **폐기**했습니다.

## 검증

- `tsc --noEmit` 통과
- `App` / `Compare` / `Character` / `Enhancement` / `Spending` 테스트 28건 통과
- `src/App.test.tsx`에 SearchAction·verification meta 회귀 어서션 추가
- JSON-LD 파싱 유효성 확인

## ⚠️ 머지 후 필수 작업

verification은 **배포된 프로덕션 HTML**을 읽어야 동작합니다. 머지·배포 완료 후 진행해 주세요.

```bash
curl -s https://lokki.vercel.app/ | grep -i site-verification
```

- [ ] Google Search Console 소유확인 클릭
- [ ] 네이버 서치어드바이저 소유확인 클릭
- [ ] 양쪽 콘솔에 `sitemap.xml` 제출
- [ ] Rich Results Test로 `SearchAction` 검증 (#20-3 잔여 체크리스트)

> verification meta는 확인 완료 후에도 삭제하면 안 됩니다. `src/App.test.tsx` 어서션이 실수 삭제를 방지합니다.
