### PR TITLE
fix(simulation): LOPEC 장비 강화 계산 기준 일치

### DIFF
--- a/src/utils/lopecEquipmentDelta.ts
+++ b/src/utils/lopecEquipmentDelta.ts
@@ -188,7 +188,9 @@ export const calcNormalHoningBaseStatDelta = ({
   const rawDeltas = sumNormalHoningRawDeltas({ slots, currentEquip, modifiedEquip });
   const currentBaseAttackFlatSum = charStats.baseAttackFlatSum ?? 0;
   const currentBaseAttackPercentSum = charStats.baseAttackPercentSum ?? 0;
-  const currentBaseAttack = charStats.pureBaseAttack ?? (
+  // 분모와 분자는 동일하게 선택된 주스탯/무기 공격력 기준으로 재구성한다.
+  // pureBaseAttack만 분모에 사용하면 displayedMainStat fallback과 기준이 갈려 가짜 배율이 생긴다.
+  const currentBaseAttack = (
     Math.sqrt((currentMainStat * currentWeaponAttack) / 6) + currentBaseAttackFlatSum
   ) * (1 + currentBaseAttackPercentSum / 100);
   if (currentBaseAttack <= 0) return 1;

--- a/src/utils/lopecSimulator.invenFormula.test.ts
+++ b/src/utils/lopecSimulator.invenFormula.test.ts
@@ -12,7 +12,20 @@ describe('calcLopecDelta Inven combat-power formula changes', () => {
       tier: '전율',
     });
     const modified = { ...current, normalLevel: 17 };
+    const charStats = { W: 200_000, baseAttack: 150_000, pureBaseAttack: 140_000, displayedMainStat };
 
+    const unchangedResult = calcLopecDelta(
+      currentScore,
+      engravings([]),
+      engravings([]),
+      emptyGems,
+      emptyGems,
+      { helmet: current },
+      { helmet: current },
+      undefined,
+      undefined,
+      charStats,
+    );
     const result = calcLopecDelta(
       currentScore,
       engravings([]),
@@ -23,9 +36,10 @@ describe('calcLopecDelta Inven combat-power formula changes', () => {
       { helmet: modified },
       undefined,
       undefined,
-      { W: 200_000, baseAttack: 150_000, pureBaseAttack: 140_000, displayedMainStat },
+      charStats,
     );
 
+    expect(unchangedResult).toBeCloseTo(currentScore, 6);
     expect(result).toBeCloseTo(currentScore * Math.sqrt((displayedMainStat + 2793) / displayedMainStat), 6);
   });
 


### PR DESCRIPTION
## 원인
`calcNormalHoningBaseStatDelta`가 현재 기본 공격력 분모에는 전달받은 `pureBaseAttack`을 우선 사용하면서, 변경 후 기본 공격력 분자에는 `displayedMainStat` fallback과 `W`로 재구성한 값을 사용했습니다. 두 입력이 같은 기준이 아닐 때 강화 델타와 무관한 배율이 포함되었습니다.

이 불일치는 완갑 보정을 추가한 `e869572`에서 전후 비율의 분모 계산만 변경되며 발생했습니다.

## 계산 기준에 대한 결정
현재와 변경 후 기본 공격력을 모두 동일하게 선택된 `currentMainStat`, `currentWeaponAttack`, flat/percent bucket으로 재구성합니다.

- 기본 공격력 역산이 가능한 경로에서는 기존 표시 기본 공격력을 다시 재현합니다.
- `displayedMainStat` fallback 경로에서는 분모와 분자가 같은 기준을 사용합니다.
- 공개 함수 시그니처와 재련 델타 공식은 유지합니다.

## 변경 내용
- LOPEC 일반 재련 ratio의 현재 기본 공격력 분모를 일관된 입력 기준으로 재구성
- 기준 불일치가 가짜 배율을 만들 수 있는 이유를 인라인 주석으로 기록

## 테스트
`uses displayed main stat as the Serka armor denominator when supplied` 테스트를 보강했습니다.

- 장비가 변하지 않으면 입력 기준이 불일치해도 현재 점수를 그대로 유지하는지 검증
- 실제 강화 시 `displayedMainStat` 기준의 기대 배율을 유지하는지 검증
- 실패 기대값은 변경하지 않음

## 검증 결과
- [x] `CI=true npm test -- --watchAll=false --runInBand src/utils/lopecSimulator.invenFormula.test.ts` (3 passed)
- [x] `CI=true npm test -- --watchAll=false --runInBand src/utils/lopec` (90 passed)
- [x] `CI=true npm test -- --watchAll=false --runInBand` (384 passed)
- [x] `npm run build` (성공)
- [x] `git diff --check`

Fixes #24
