### PR TITLE
fix(security): React Router 7.18.2 보안 패치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@vercel/analytics": "^2.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "7.17.0",
+        "react-router-dom": "7.18.2",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.0"
       },
@@ -14023,9 +14023,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -14045,12 +14045,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@vercel/analytics": "^2.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "7.17.0",
+    "react-router-dom": "7.18.2",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,17 +7911,17 @@ react-refresh@^0.11.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-router-dom@7.17.0:
-  version "7.17.0"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz"
-  integrity sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==
+react-router-dom@7.18.2:
+  version "7.18.2"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz"
+  integrity sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==
   dependencies:
-    react-router "7.17.0"
+    react-router "7.18.2"
 
-react-router@7.17.0:
-  version "7.17.0"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz"
-  integrity sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==
+react-router@7.18.2:
+  version "7.18.2"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz"
+  integrity sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"


### PR DESCRIPTION
## 배경
`react-router-dom@7.17.0`이 의존하는 `react-router`는 현재 `npm audit`에서 다음 취약점 범위에 포함됩니다.

- Open redirect bypass
- RSC error-handler protocol validation XSS
- SSR hydration constructor injection
- 비효율적 route matching DoS
- RSC mode CSRF bypass (`<7.18.2`)

## 변경 내용
- `react-router-dom`을 `7.17.0`에서 최신 보안 패치인 `7.18.2`로 고정
- 전이 의존성 `react-router`를 `7.18.2`로 갱신
- 현재 저장소가 함께 관리하는 `package-lock.json`, `yarn.lock`을 모두 동기화

패키지 관리자 통일은 별도 #31 범위이므로 이번 PR에서는 lockfile 제거를 섞지 않았습니다.

## 보안 확인
- 설치 버전: `react-router-dom@7.18.2` / `react-router@7.18.2`
- `npm audit`의 Router 관련 finding: 없음
- 프로젝트 전체의 다른 audit finding은 이번 Issue 범위 밖이며 그대로 남아 있음

## 회귀 검증
- [x] 라우팅 관련 테스트: 3 suites, 22 tests passed
- [x] 전체 테스트: 49 suites, 384 tests passed
- [x] 프로덕션 빌드 성공
- [x] `git diff --check`

Fixes #25
