### PR TITLE
ci: 테스트 및 프로덕션 빌드 자동화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+          cache: yarn
+
+      - name: Enable Yarn
+        run: corepack enable && corepack prepare yarn@1.22.22 --activate
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test --watchAll=false
+        env:
+          CI: true
+
+      - name: Build production bundle
+        run: yarn build
+        env:
+          CI: true


### PR DESCRIPTION
## 변경 사항
- `main` push 및 pull request에서 실행되는 GitHub Actions CI 추가
- Node.js `22.19.0`과 Yarn `1.22.22` 버전 고정
- frozen lockfile 의존성 설치, 전체 테스트, 프로덕션 빌드 자동화
- 최소 권한, 중복 실행 취소, 15분 timeout 적용

## 검증
- `yarn install --frozen-lockfile`
- `CI=true yarn test --watchAll=false` (49 suites, 384 tests passed)
- `CI=true yarn build`

Closes #26
Related to #33