### PR TITLE
ci: GitHub Actions 런타임 업데이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
           cache: yarn


### PR DESCRIPTION
## 변경 사항
- 첫 CI 실행에서 확인된 Node.js 20 기반 Action deprecation 경고 제거
- `actions/checkout`과 `actions/setup-node`를 최신 major v7으로 업데이트

## 참고
- 후속 정리: #26
- Epic: #33