### PR TITLE
fix(security): Lost Ark API 프록시 보호 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Run tests
+      - name: Run proxy security tests
+        run: yarn test:proxy
+
+      - name: Run frontend tests
         run: yarn test --watchAll=false
         env:
           CI: true

--- a/API_KEY_MITIGATION.md
+++ b/API_KEY_MITIGATION.md
@@ -45,5 +45,6 @@ Do not rename the function back to `api/lostark/[...path].js`; that shape previo
 ## Notes
 
 - This does not require changing page-level UI code.
-- The current proxy includes an endpoint allowlist and a lightweight per-instance rate limit. For higher traffic, move rate limiting to a durable store or platform firewall.
+- The proxy keeps its endpoint and method allowlists, but rate limiting is enforced by a production Vercel WAF rule instead of ephemeral function memory. Configure the rule before deploying a version containing this change; see `docs/vercel-waf-rate-limit.md`.
+- The proxy aborts Lost Ark upstream requests after 10 seconds and returns sanitized `502`/`504` responses for upstream failures.
 - See `docs/troubleshooting/vercel-lostark-api-route-404.md` for the production routing failure that led to the current splat function shape.

--- a/API_KEY_MITIGATION.md
+++ b/API_KEY_MITIGATION.md
@@ -36,7 +36,7 @@ Do not rename the function back to `api/lostark/[...path].js`; that shape previo
 
 ## Deployment Checklist
 
-1. Set `LOSTARK_API_KEY` in Vercel project environment variables.
+1. Set `LOSTARK_API_KEY` in the Vercel Production environment only. If Preview deployments need the key, protect them separately before enabling it.
 2. Do not set or use `REACT_APP_API_KEY` for production builds.
 3. Rotate any Lost Ark API key that may have been exposed through a previous client build.
 4. Confirm browser network requests go to `/api/lostark/...`, not directly to `developer-lostark.game.onstove.com`.

--- a/api/lostark/[...].js
+++ b/api/lostark/[...].js
@@ -1,8 +1,6 @@
 const LOSTARK_API_BASE_URL = 'https://developer-lostark.game.onstove.com';
 const ALLOWED_METHODS = new Set(['GET', 'POST']);
-const WINDOW_MS = 60 * 1000;
-const MAX_REQUESTS_PER_WINDOW = 120;
-const rateLimitStore = new Map();
+const UPSTREAM_TIMEOUT_MS = 10 * 1000;
 const ALLOWED_GET_PATHS = [
   /^characters\/[^/]+\/siblings$/,
   /^armories\/characters\/[^/]+\/(profiles|arkgrid|equipment|gems|engravings|arkpassive|cards)$/,
@@ -11,28 +9,6 @@ const ALLOWED_GET_PATHS = [
   /^markets\/options$/,
 ];
 const ALLOWED_POST_PATHS = new Set(['markets/items', 'auctions/items']);
-
-function getClientIp(req) {
-  const forwardedFor = req.headers['x-forwarded-for'];
-  if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
-    return forwardedFor.split(',')[0].trim();
-  }
-  return req.socket?.remoteAddress || 'unknown';
-}
-
-function isRateLimited(req) {
-  const now = Date.now();
-  const ip = getClientIp(req);
-  const current = rateLimitStore.get(ip);
-
-  if (!current || current.resetAt <= now) {
-    rateLimitStore.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-    return false;
-  }
-
-  current.count += 1;
-  return current.count > MAX_REQUESTS_PER_WINDOW;
-}
 
 function resolvePath(pathQuery) {
   if (Array.isArray(pathQuery)) return pathQuery.join('/');
@@ -47,9 +23,9 @@ function buildTargetUrl(req) {
   for (const [key, value] of Object.entries(req.query)) {
     if (key === 'path') continue;
     if (Array.isArray(value)) {
-      value.forEach((item) => url.searchParams.append(key, item));
+      value.forEach((item) => url.searchParams.append(key, String(item)));
     } else if (value != null) {
-      url.searchParams.set(key, value);
+      url.searchParams.set(key, String(value));
     }
   }
 
@@ -67,43 +43,66 @@ function resolveBody(req) {
   return typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
 }
 
-module.exports = async function handler(req, res) {
-  const apiKey = process.env.LOSTARK_API_KEY;
+function createProxyHandler({
+  fetchImpl = globalThis.fetch,
+  upstreamTimeoutMs = UPSTREAM_TIMEOUT_MS,
+  logger = console,
+} = {}) {
+  return async function handler(req, res) {
+    const apiKey = process.env.LOSTARK_API_KEY;
 
-  if (!apiKey) {
-    res.status(500).json({ message: 'Lost Ark API key is not configured.' });
-    return;
-  }
+    res.setHeader('cache-control', 'no-store');
+    res.setHeader('x-content-type-options', 'nosniff');
 
-  if (!ALLOWED_METHODS.has(req.method)) {
-    res.setHeader('Allow', Array.from(ALLOWED_METHODS).join(', '));
-    res.status(405).json({ message: 'Method not allowed.' });
-    return;
-  }
+    if (!apiKey) {
+      res.status(500).json({ message: 'Lost Ark API key is not configured.' });
+      return;
+    }
 
-  const path = resolvePath(req.query.path);
-  if (!isAllowedPath(req.method, path)) {
-    res.status(403).json({ message: 'Endpoint is not allowed.' });
-    return;
-  }
+    if (!ALLOWED_METHODS.has(req.method)) {
+      res.setHeader('Allow', Array.from(ALLOWED_METHODS).join(', '));
+      res.status(405).json({ message: 'Method not allowed.' });
+      return;
+    }
 
-  if (isRateLimited(req)) {
-    res.status(429).json({ message: 'Too many requests.' });
-    return;
-  }
+    const path = resolvePath(req.query.path);
+    if (!isAllowedPath(req.method, path)) {
+      res.status(403).json({ message: 'Endpoint is not allowed.' });
+      return;
+    }
 
-  const response = await fetch(buildTargetUrl(req), {
-    method: req.method,
-    headers: {
-      accept: 'application/json',
-      authorization: `bearer ${apiKey}`,
-      ...(req.method === 'POST' ? { 'content-type': 'application/json' } : {}),
-    },
-    body: resolveBody(req),
-  });
+    const timeoutSignal = AbortSignal.timeout(upstreamTimeoutMs);
 
-  const contentType = response.headers.get('content-type') || 'application/json';
-  res.status(response.status);
-  res.setHeader('content-type', contentType);
-  res.send(await response.text());
-};
+    try {
+      const response = await fetchImpl(buildTargetUrl(req), {
+        method: req.method,
+        headers: {
+          accept: 'application/json',
+          authorization: `bearer ${apiKey}`,
+          ...(req.method === 'POST' ? { 'content-type': 'application/json' } : {}),
+        },
+        body: resolveBody(req),
+        signal: timeoutSignal,
+      });
+
+      const contentType = response.headers.get('content-type') || 'application/json';
+      res.status(response.status);
+      res.setHeader('content-type', contentType);
+      res.send(await response.text());
+    } catch (error) {
+      const timedOut = timeoutSignal.aborted || error?.name === 'TimeoutError';
+      const status = timedOut ? 504 : 502;
+      const message = timedOut
+        ? 'Lost Ark API request timed out.'
+        : 'Lost Ark API is temporarily unavailable.';
+
+      logger.error(message, { errorName: error?.name || 'UnknownError' });
+      res.status(status).json({ message });
+    }
+  };
+}
+
+const handler = createProxyHandler();
+
+module.exports = handler;
+module.exports.createProxyHandler = createProxyHandler;

--- a/api/lostark/proxy.test.js
+++ b/api/lostark/proxy.test.js
@@ -1,0 +1,217 @@
+const assert = require('node:assert/strict');
+const {
+  afterEach: nodeAfterEach,
+  beforeEach: nodeBeforeEach,
+  describe: nodeDescribe,
+  test: nodeTest,
+} = require('node:test');
+
+const { createProxyHandler } = require('./[...].js');
+
+const TEST_API_KEY = 'unit-test-api-key';
+
+function createRequest(overrides = {}) {
+  return {
+    method: 'GET',
+    headers: {},
+    query: { path: ['news', 'events'] },
+    body: undefined,
+    ...overrides,
+  };
+}
+
+function createResponse() {
+  return {
+    headers: new Map(),
+    statusCode: null,
+    payload: undefined,
+    setHeader(name, value) {
+      this.headers.set(name.toLowerCase(), value);
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+    send(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+}
+
+function createUpstreamResponse({
+  status = 200,
+  contentType = 'application/json; charset=utf-8',
+  body = '{}',
+} = {}) {
+  return {
+    status,
+    headers: { get: (name) => (name === 'content-type' ? contentType : null) },
+    text: async () => body,
+  };
+}
+
+function createHandler(options = {}) {
+  return createProxyHandler({
+    logger: { error() {} },
+    ...options,
+  });
+}
+
+nodeDescribe('Lost Ark API proxy', () => {
+  nodeBeforeEach(() => {
+    process.env.LOSTARK_API_KEY = TEST_API_KEY;
+  });
+
+  nodeAfterEach(() => {
+    delete process.env.LOSTARK_API_KEY;
+  });
+
+  nodeTest('rejects requests when the server-side API key is missing', async () => {
+    delete process.env.LOSTARK_API_KEY;
+    let fetchCalled = false;
+    const handler = createHandler({
+      fetchImpl: async () => {
+        fetchCalled = true;
+      },
+    });
+    const res = createResponse();
+
+    await handler(createRequest(), res);
+
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.payload, { message: 'Lost Ark API key is not configured.' });
+    assert.equal(fetchCalled, false);
+  });
+
+  nodeTest('rejects methods and endpoints outside the allowlist', async (t) => {
+    const handler = createHandler({
+      fetchImpl: async () => assert.fail('The upstream must not be called.'),
+    });
+
+    await t.test('method', async () => {
+      const res = createResponse();
+      await handler(createRequest({ method: 'DELETE' }), res);
+      assert.equal(res.statusCode, 405);
+      assert.equal(res.headers.get('allow'), 'GET, POST');
+    });
+
+    await t.test('endpoint', async () => {
+      const res = createResponse();
+      await handler(createRequest({ query: { path: ['admin', 'secrets'] } }), res);
+      assert.equal(res.statusCode, 403);
+    });
+  });
+
+  nodeTest('forwards only controlled headers to an allowed upstream endpoint', async () => {
+    let capturedUrl;
+    let capturedOptions;
+    const handler = createHandler({
+      fetchImpl: async (url, options) => {
+        capturedUrl = url;
+        capturedOptions = options;
+        return createUpstreamResponse({ body: '{"events":[]}' });
+      },
+    });
+    const req = createRequest({
+      headers: { authorization: 'bearer attacker-token', cookie: 'session=value' },
+      query: { path: ['news', 'events'], locale: 'ko-KR' },
+    });
+    const res = createResponse();
+
+    await handler(req, res);
+
+    assert.equal(capturedUrl.toString(), 'https://developer-lostark.game.onstove.com/news/events?locale=ko-KR');
+    assert.deepEqual(capturedOptions.headers, {
+      accept: 'application/json',
+      authorization: `bearer ${TEST_API_KEY}`,
+    });
+    assert.ok(capturedOptions.signal instanceof AbortSignal);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.payload, '{"events":[]}');
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(res.headers.get('x-content-type-options'), 'nosniff');
+  });
+
+  nodeTest('serializes allowed POST bodies as JSON', async () => {
+    let capturedOptions;
+    const handler = createHandler({
+      fetchImpl: async (_url, options) => {
+        capturedOptions = options;
+        return createUpstreamResponse();
+      },
+    });
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        method: 'POST',
+        query: { path: ['markets', 'items'] },
+        body: { CategoryCode: 20000 },
+      }),
+      res
+    );
+
+    assert.equal(capturedOptions.body, '{"CategoryCode":20000}');
+    assert.equal(capturedOptions.headers['content-type'], 'application/json');
+  });
+
+  nodeTest('returns a sanitized 504 response when the upstream times out', async () => {
+    const handler = createHandler({
+      upstreamTimeoutMs: 5,
+      fetchImpl: async (_url, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+    });
+    const res = createResponse();
+    const keepEventLoopAlive = setTimeout(() => {}, 50);
+
+    try {
+      await handler(createRequest(), res);
+    } finally {
+      clearTimeout(keepEventLoopAlive);
+    }
+
+    assert.equal(res.statusCode, 504);
+    assert.deepEqual(res.payload, { message: 'Lost Ark API request timed out.' });
+    assert.equal(JSON.stringify(res.payload).includes(TEST_API_KEY), false);
+  });
+
+  nodeTest('returns a sanitized 502 response for other upstream failures', async () => {
+    const handler = createHandler({
+      fetchImpl: async () => {
+        throw new Error(`upstream failed with ${TEST_API_KEY}`);
+      },
+    });
+    const res = createResponse();
+
+    await handler(createRequest(), res);
+
+    assert.equal(res.statusCode, 502);
+    assert.deepEqual(res.payload, { message: 'Lost Ark API is temporarily unavailable.' });
+    assert.equal(JSON.stringify(res.payload).includes(TEST_API_KEY), false);
+  });
+
+  nodeTest('preserves upstream status and content type without exposing response caching', async () => {
+    const handler = createHandler({
+      fetchImpl: async () =>
+        createUpstreamResponse({
+          status: 429,
+          contentType: 'application/problem+json',
+          body: '{"message":"rate limited"}',
+        }),
+    });
+    const res = createResponse();
+
+    await handler(createRequest(), res);
+
+    assert.equal(res.statusCode, 429);
+    assert.equal(res.headers.get('content-type'), 'application/problem+json');
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+  });
+});

--- a/docs/vercel-waf-rate-limit.md
+++ b/docs/vercel-waf-rate-limit.md
@@ -1,0 +1,63 @@
+# Lost Ark API proxy: Vercel WAF rate limit
+
+The production Lost Ark proxy relies on Vercel WAF for a serverless-safe rate limit. Function-local memory is not a durable counter because Vercel can reuse, create, and retire function instances as traffic changes.
+
+## Production rule
+
+Configure this rule in the Vercel project before deploying the proxy hardening change:
+
+| Setting | Value |
+| --- | --- |
+| Rule name | `Lost Ark API proxy rate limit` |
+| If | Request path starts with `/api/lostark/` |
+| Then | Rate Limit |
+| Strategy | Fixed Window |
+| Time window | 60 seconds |
+| Request limit | 120 |
+| Counting key | IP |
+
+1. Open the project in the Vercel Dashboard.
+2. Open **Firewall**, select **Configure**, and add a new rule.
+3. Enter the condition and rate-limit values above.
+4. Review the change and select **Publish**. Vercel applies published firewall changes to the production deployment without a redeployment.
+
+The application uses Vercel's default WAF response when the limit is exceeded. No Redis or rate-limit environment variables are required.
+
+## Hobby-plan constraints
+
+At the time this rule was documented, Vercel provides fixed-window WAF rate limiting on Hobby with one rate-limit rule per project and 1,000,000 included allowed requests. Check that the project does not already use its single rate-limit rule; if it does, consolidate the conditions instead of creating a second rule. Counters are maintained per region, so a future multi-region deployment must reassess the effective global limit.
+
+See Vercel's current documentation before changing the rule:
+
+- [WAF Rate Limiting](https://vercel.com/docs/vercel-firewall/vercel-waf/rate-limiting)
+- [WAF Custom Rules](https://vercel.com/docs/vercel-firewall/vercel-waf/custom-rules)
+- [Vercel Functions](https://vercel.com/docs/functions)
+
+## Safe rollout
+
+1. Publish the WAF rule.
+2. Confirm the production request path condition is `/api/lostark/`.
+3. Merge and deploy the proxy hardening change.
+4. Verify normal allowed requests still succeed.
+5. Verify blocked and failed requests do not expose `LOSTARK_API_KEY` or upstream exception details.
+
+Do not disable the WAF rule while this proxy is publicly reachable unless another distributed rate limiter is already active.
+
+## Production verification
+
+Use a disallowed proxy path so verification does not call the Lost Ark upstream API. From Git Bash, replace the host if the production domain changes:
+
+```bash
+for i in $(seq 1 121); do
+  curl -sS -o /dev/null -w '%{http_code}\n' \
+    https://lokki.vercel.app/api/lostark/not-allowed
+done
+```
+
+Expected result within one 60-second window:
+
+- Initial requests reach the function and return `403` from the endpoint allowlist.
+- A request after the configured threshold returns the WAF rate-limit response (`429`).
+- After the window expires, the endpoint returns `403` again.
+
+Run this check only once per deployment verification window; it intentionally exercises the production firewall counter.

--- a/docs/vercel-waf-rate-limit.md
+++ b/docs/vercel-waf-rate-limit.md
@@ -35,13 +35,14 @@ See Vercel's current documentation before changing the rule:
 
 ## Safe rollout
 
-1. Publish the WAF rule.
-2. Confirm the production request path condition is `/api/lostark/`.
-3. Merge and deploy the proxy hardening change.
-4. Verify normal allowed requests still succeed.
-5. Verify blocked and failed requests do not expose `LOSTARK_API_KEY` or upstream exception details.
+1. Confirm `LOSTARK_API_KEY` is scoped to the Vercel Production environment only. Production WAF rules do not protect a Preview deployment that has separately been given the key.
+2. Publish the WAF rule.
+3. Confirm the production request path condition is `/api/lostark/`.
+4. Merge and deploy the proxy hardening change.
+5. Verify normal allowed requests still succeed.
+6. Verify blocked and failed requests do not expose `LOSTARK_API_KEY` or upstream exception details.
 
-Do not disable the WAF rule while this proxy is publicly reachable unless another distributed rate limiter is already active.
+Do not disable the WAF rule while this proxy is publicly reachable unless another distributed rate limiter is already active. If Preview deployments later require Lost Ark API access, add equivalent protection before enabling the key there.
 
 ## Production verification
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "react-scripts build",
     "postbuild": "node scripts/generateStaticSeo.js",
     "test": "react-scripts test",
+    "test:proxy": "node --test api/lostark/proxy.test.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
## 변경 사항
- 서버리스 인스턴스별 `Map` rate limit을 제거하고 Production Vercel WAF fixed-window 정책으로 전환
- Lost Ark upstream 호출에 10초 timeout 적용
- timeout은 sanitized `504`, 기타 네트워크 예외는 sanitized `502`로 처리
- 응답에 `Cache-Control: no-store`, `X-Content-Type-Options: nosniff` 적용
- 메서드/endpoint allowlist와 통제된 upstream header 전달을 포함한 프록시 보안 테스트 추가
- 프록시 테스트를 CI에 추가
- Hobby 플랜용 WAF 설정 및 안전한 배포/검증 절차 문서화

## 배포 전 필수 작업
이 변경은 로컬 메모리 limiter를 제거하므로 **배포 전에** Vercel Dashboard에서 다음 Production WAF 규칙을 먼저 Publish해야 합니다.

- Request path starts with `/api/lostark/`
- Fixed Window
- IP당 60초 120회

상세 절차: `docs/vercel-waf-rate-limit.md`

## 검증
- `yarn test:proxy` — 9 passed
- `CI=true yarn test --watchAll=false` — 49 suites, 384 tests passed
- `CI=true yarn build` — compiled successfully
- 변경된 JavaScript 파일 diagnostics — errors 없음

Closes #27