### PR TITLE
perf: 페이지 라우트 단위 코드 분할

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { CHUNK_ERROR_EVENT, CHUNK_ERROR_KEY } from './context/PwaChunkContext';
 import routeSeoEntries from './constants/routeSeo.json';
 
 let mockPathname = '/';
@@ -33,33 +34,48 @@ import App from './App';
 
 beforeEach(() => {
   mockPathname = '/';
+  window.sessionStorage.removeItem(CHUNK_ERROR_KEY);
 });
 
-test('renders the home route', () => {
+test('renders the loading state before the home route', async () => {
   render(<App />);
 
-  expect(screen.getByText('Home Page')).toBeInTheDocument();
+  expect(screen.getByText('페이지 불러오는 중...')).toBeInTheDocument();
+  expect(await screen.findByText('Home Page')).toBeInTheDocument();
   expect(document.title).toBe('로아끼욧 - 로스트아크 캐릭터 조회·주간 골드 계산기');
 });
 
-test('matches the changelog route to the changelog page', () => {
+test('shows the existing chunk error banner when the chunk error event fires', async () => {
+  render(<App />);
+  await screen.findByText('Home Page');
+
+  act(() => {
+    window.dispatchEvent(new CustomEvent(CHUNK_ERROR_EVENT));
+  });
+
+  expect(
+    screen.getByText('새 버전이 배포되었습니다. 안정적인 사용을 위해 새로고침해 주세요.'),
+  ).toBeInTheDocument();
+});
+
+test('matches the changelog route to the changelog page', async () => {
   mockPathname = '/changelog';
 
   render(<App />);
 
-  expect(screen.getByText('Changelog Page')).toBeInTheDocument();
+  expect(await screen.findByText('Changelog Page')).toBeInTheDocument();
   expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
 });
 
-test('falls back to the not found page for unmatched routes', () => {
+test('falls back to the not found page for unmatched routes', async () => {
   mockPathname = '/missing-route';
 
   render(<App />);
 
-  expect(screen.getByText('Not Found Page')).toBeInTheDocument();
+  expect(await screen.findByText('Not Found Page')).toBeInTheDocument();
 });
 
-test('updates SEO metadata for the current route', () => {
+test('updates SEO metadata for the current route', async () => {
   mockPathname = '/market';
 
   render(<App />);
@@ -73,9 +89,10 @@ test('updates SEO metadata for the current route', () => {
     'href',
     'https://lokki.vercel.app/market',
   );
+  expect(await screen.findByText('Market Page')).toBeInTheDocument();
 });
 
-test('marks unknown routes as noindex with the home canonical', () => {
+test('marks unknown routes as noindex with the home canonical', async () => {
   mockPathname = '/missing-route';
 
   render(<App />);
@@ -83,9 +100,10 @@ test('marks unknown routes as noindex with the home canonical', () => {
   expect(document.title).toBe('페이지를 찾을 수 없습니다 - 로아끼욧');
   expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
   expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute('href', 'https://lokki.vercel.app/');
+  expect(await screen.findByText('Not Found Page')).toBeInTheDocument();
 });
 
-test('normalizes the changelog trailing slash for metadata and canonical URL', () => {
+test('normalizes the changelog trailing slash for metadata and canonical URL', async () => {
   mockPathname = '/changelog/';
 
   render(<App />);
@@ -100,11 +118,12 @@ test('normalizes the changelog trailing slash for metadata and canonical URL', (
     'href',
     'https://lokki.vercel.app/changelog',
   );
+  expect(await screen.findByText('Changelog Page')).toBeInTheDocument();
 });
 
 // trailing slash 정규화는 /changelog 전용이 아니라 모든 라우트에 적용된다.
 // 이전에는 /market/ 이 NOT_FOUND_SEO(noindex)로 폴백됐으므로 회귀 지점을 함께 고정한다.
-test('normalizes the trailing slash for pre-existing routes as well', () => {
+test('normalizes the trailing slash for pre-existing routes as well', async () => {
   mockPathname = '/market/';
 
   render(<App />);
@@ -115,6 +134,7 @@ test('normalizes the trailing slash for pre-existing routes as well', () => {
     'href',
     'https://lokki.vercel.app/market',
   );
+  expect(await screen.findByText('Market Page')).toBeInTheDocument();
 });
 
 test('lists every indexable route in the sitemap', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Home from './pages/Home';
-import Character from './pages/Character';
-import Simulation from './pages/Simulation';
-import SpecSimulator from './pages/SpecSimulator';
-import Expedition from './pages/Expedition';
-import Compare from './pages/Compare';
-import Enhancement from './pages/Enhancement';
-import Spending from './pages/Spending';
-import Market from './pages/Market';
-import Changelog from './pages/Changelog';
-import NotFound from './pages/NotFound';
+import { LoadingIndicator } from './components/Loading';
 import { RouteSeo } from './components/RouteSeo';
 import { ROUTES } from './utils/routes';
 import { PwaChunkProvider, usePwaChunk } from './context/PwaChunkContext';
 import { ThemeProvider } from './context/ThemeContext';
+
+const Home = React.lazy(() => import(/* webpackChunkName: "route-home" */ './pages/Home'));
+const Character = React.lazy(() => import(/* webpackChunkName: "route-character" */ './pages/Character'));
+const Simulation = React.lazy(() => import(/* webpackChunkName: "route-simulation" */ './pages/Simulation'));
+const SpecSimulator = React.lazy(() => import(/* webpackChunkName: "route-spec-simulator" */ './pages/SpecSimulator'));
+const Expedition = React.lazy(() => import(/* webpackChunkName: "route-expedition" */ './pages/Expedition'));
+const Compare = React.lazy(() => import(/* webpackChunkName: "route-compare" */ './pages/Compare'));
+const Enhancement = React.lazy(() => import(/* webpackChunkName: "route-enhancement" */ './pages/Enhancement'));
+const Spending = React.lazy(() => import(/* webpackChunkName: "route-spending" */ './pages/Spending'));
+const Market = React.lazy(() => import(/* webpackChunkName: "route-market" */ './pages/Market'));
+const Changelog = React.lazy(() => import(/* webpackChunkName: "route-changelog" */ './pages/Changelog'));
+const NotFound = React.lazy(() => import(/* webpackChunkName: "route-not-found" */ './pages/NotFound'));
 
 const ChunkErrorBanner: React.FC = () => {
   const { chunkErrorOccurred, clearChunkError } = usePwaChunk();
@@ -47,19 +49,28 @@ const AppContent: React.FC = () => {
       <div className="min-h-screen font-[Pretendard,sans-serif] bg-gray-50 dark:bg-la-dark transition-colors duration-300">
         <RouteSeo />
         <ChunkErrorBanner />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/character" element={<Character />} />
-          <Route path="/simulation" element={<Simulation />} />
-          <Route path="/spec-simulator" element={<SpecSimulator />} />
-          <Route path="/expedition" element={<Expedition />} />
-          <Route path="/compare" element={<Compare />} />
-          <Route path="/enhancement" element={<Enhancement />} />
-          <Route path="/market" element={<Market />} />
-          <Route path="/spending" element={<Spending />} />
-          <Route path={ROUTES.changelog} element={<Changelog />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <React.Suspense
+          fallback={
+            <LoadingIndicator
+              message="페이지 불러오는 중..."
+              className="mx-auto mt-8 max-w-7xl"
+            />
+          }
+        >
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/character" element={<Character />} />
+            <Route path="/simulation" element={<Simulation />} />
+            <Route path="/spec-simulator" element={<SpecSimulator />} />
+            <Route path="/expedition" element={<Expedition />} />
+            <Route path="/compare" element={<Compare />} />
+            <Route path="/enhancement" element={<Enhancement />} />
+            <Route path="/market" element={<Market />} />
+            <Route path="/spending" element={<Spending />} />
+            <Route path={ROUTES.changelog} element={<Changelog />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </React.Suspense>
       </div>
     </Router>
   );


### PR DESCRIPTION
## 요약
- 모든 페이지 라우트를 `React.lazy` 동적 import로 전환했습니다.
- 기존 `LoadingIndicator`를 사용하는 `Suspense` fallback을 추가했습니다.
- `PwaChunkProvider`를 Suspense 바깥에 유지하고 chunk 오류 이벤트 배너 회귀 테스트를 추가했습니다.
- 기존 라우팅/SEO 테스트를 lazy 렌더링에 맞게 비동기화했습니다.

## 검증
- `CI=true yarn test --watchAll=false --runTestsByPath src/App.test.tsx` (10/10 통과)
- `yarn build` 성공
- 프로덕션 산출물에서 `route-home` 등 11개 route chunk 생성 및 누락 없음 확인

Closes #28