### PR TITLE
refactor(enhancement): 계산 모델과 조회 Hook 분리

### DIFF
--- a/src/components/enhancement/enhancementModel.test.ts
+++ b/src/components/enhancement/enhancementModel.test.ts
@@ -1,0 +1,48 @@
+import {
+  ARMLET_STEPS,
+  SERKA_ARMOR_STEPS,
+  AEGIR_ARMOR_STEPS,
+} from '../../data/enhancement';
+import {
+  calcStepData,
+  findCheapestAdv,
+  getStepsForSlot,
+  parseEnhLevel,
+  parseTooltipData,
+} from './enhancementModel';
+
+describe('enhancement model', () => {
+  it('parses enhancement and advanced honing state from equipment payloads', () => {
+    const tooltip = JSON.stringify({
+      Element_001: { value: { slotData: { petBorder: 6 } } },
+      Element_002: { value: '<FONT>[상급 재련] 30단계</FONT>' },
+    });
+
+    expect(parseEnhLevel('+21 운명의 전율 무기')).toBe(21);
+    expect(parseEnhLevel('강화 수치 없는 장비')).toBe(0);
+    expect(parseTooltipData(tooltip)).toEqual({ isInherited: true, advLevel: 30 });
+    expect(parseTooltipData('{invalid')).toEqual({ isInherited: false, advLevel: 0 });
+  });
+
+  it('selects step tables by slot and inheritance state', () => {
+    expect(getStepsForSlot('완갑', false)).toBe(ARMLET_STEPS);
+    expect(getStepsForSlot('투구', false)).toBe(AEGIR_ARMOR_STEPS);
+    expect(getStepsForSlot('투구', true)).toBe(SERKA_ARMOR_STEPS);
+  });
+
+  it('produces average and ceiling totals for every selected step', () => {
+    const [result] = calcStepData([AEGIR_ARMOR_STEPS[0]], false, true, {});
+
+    expect(result.totalGold).toBe(result.directGold + result.matGold);
+    expect(result.ceilingTotalGold).toBe(result.ceilingDirectGold + result.ceilingMatGold);
+    expect(result.ceiling).toBeGreaterThanOrEqual(result.exp);
+  });
+
+  it('returns the neutral advanced honing options without active slots', () => {
+    expect(findCheapestAdv([], {}, {}, {})).toEqual({
+      normalOpt: 'none',
+      ancestorOpt: 'none',
+      enhancedOpt: 'none',
+    });
+  });
+});

--- a/src/components/enhancement/enhancementModel.ts
+++ b/src/components/enhancement/enhancementModel.ts
@@ -1,0 +1,268 @@
+import type { MarketCategory } from '../../utils/api';
+import {
+  AEGIR_ARMOR_STEPS,
+  AEGIR_WEAPON_STEPS,
+  SERKA_ARMOR_STEPS,
+  SERKA_WEAPON_STEPS,
+  ARMLET_STEPS,
+  ADV_ARMOR_STAGES,
+  ADV_WEAPON_STAGES,
+  ADV_STAGE_XP,
+  calcExpectedAttempts,
+  getCeiling,
+  getAttemptMaterials,
+  calcAdvExpectedAttempts,
+  getAdvAttemptMaterials,
+  type MaterialType,
+  type AdvTurnOption,
+} from '../../data/enhancement';
+
+// ─────────────────────────────────────────────
+// 상수
+// ─────────────────────────────────────────────
+
+export const ARMOR_SLOTS = ['투구', '어깨', '상의', '하의', '장갑'] as const;
+export type ArmorSlot = (typeof ARMOR_SLOTS)[number];
+export type SlotName = '무기' | ArmorSlot | '완갑';
+
+export const ALL_SLOTS: SlotName[] = ['무기', '완갑', '투구', '어깨', '상의', '하의', '장갑'];
+export const ITEM_LEVEL_SLOTS = ['무기', ...ARMOR_SLOTS] as const;
+
+export const ITEM_LEVEL_PER_STEP = 5; // 일반 재련 1단계당 아이템 레벨 증가량
+
+export const NORMAL_BULK_TARGET_OPTIONS = Array.from({ length: 15 }, (_, i) => {
+  const level = i + 11;
+  return { value: level, label: `${level}강` };
+});
+
+export const ADV_TARGET_OPTIONS = [10, 20, 30, 40].map((level) => ({
+  value: level,
+  label: `${level}단계`,
+}));
+
+export interface MarketConfig {
+  searchName: string;
+  itemsPerUnit?: number;
+  categoryCode?: number;
+  extraParams?: Record<string, unknown>;
+  untradeable?: boolean;
+}
+
+export const MARKET_SEARCH: Record<MaterialType, MarketConfig> = {
+  // 방어구
+  '수호석':               { searchName: '운명의 수호석' },
+  '돌파석':               { searchName: '운명의 돌파석' },
+  '아비도스 융화 재료':    { searchName: '아비도스 융화 재료' },
+  '운명의 파편':           { searchName: '운명의 파편 주머니(소)', itemsPerUnit: 1000 },
+  '빙하의 숨결':           { searchName: '빙하의 숨결', categoryCode: 50020 },
+  '재봉술: 업화 [11-14]': { searchName: '재봉술 : 업화 [11-14]' },
+  '재봉술: 업화 [15-18]': { searchName: '재봉술 : 업화 [15-18]' },
+  '재봉술: 업화 [19-20]': { searchName: '재봉술 : 업화 [19-20]' },
+  // 무기
+  '파괴석':               { searchName: '운명의 파괴석' },
+  '용암의 숨결':           { searchName: '용암의 숨결', categoryCode: 50020 },
+  '야금술: 업화 [11-14]': { searchName: '야금술 : 업화 [11-14]' },
+  '야금술: 업화 [15-18]': { searchName: '야금술 : 업화 [15-18]' },
+  '야금술: 업화 [19-20]': { searchName: '야금술 : 업화 [19-20]' },
+  // 세르카 방어구
+  '운명의 수호석 결정':    { searchName: '운명의 수호석 결정' },
+  '위대한 운명의 돌파석':  { searchName: '위대한 운명의 돌파석' },
+  '상급 아비도스 융화':    { searchName: '상급 아비도스 융화' },
+  // 세르카 무기
+  '운명의 파괴석 결정':    { searchName: '운명의 파괴석 결정' },
+  // 방어구 상급 재련 책
+  '장인의 재봉술: 1단계':  { searchName: '장인의 재봉술 : 1단계' },
+  '장인의 재봉술: 2단계':  { searchName: '장인의 재봉술 : 2단계' },
+  '장인의 재봉술: 3단계':  { searchName: '장인의 재봉술 : 3단계' },
+  '장인의 재봉술: 4단계':  { searchName: '장인의 재봉술 : 4단계' },
+  // 무기 상급 재련 책
+  '장인의 야금술: 1단계':  { searchName: '장인의 야금술 : 1단계' },
+  '장인의 야금술: 2단계':  { searchName: '장인의 야금술 : 2단계' },
+  '장인의 야금술: 3단계':  { searchName: '장인의 야금술 : 3단계' },
+  '장인의 야금술: 4단계':  { searchName: '장인의 야금술 : 4단계' },
+};
+
+export const ALL_MATERIAL_TYPES = Object.keys(MARKET_SEARCH) as MaterialType[];
+
+export type PriceMap = Partial<Record<MaterialType, number>>;
+export type IconMap = Partial<Record<MaterialType, string>>;
+
+export const flattenCategories = (cats: MarketCategory[]): MarketCategory[] =>
+  cats.flatMap((c) => [c, ...(c.Subs ? flattenCategories(c.Subs) : [])]);
+
+export const MATERIAL_CATEGORY_KEYWORD: Record<MaterialType, string> = {
+  '수호석':               '재련 재료',
+  '돌파석':               '재련 재료',
+  '아비도스 융화 재료':    '재련 재료',
+  '운명의 파편':           '재련 재료',
+  '빙하의 숨결':           '추가 재료',
+  '재봉술: 업화 [11-14]': '추가 재료',
+  '재봉술: 업화 [15-18]': '추가 재료',
+  '재봉술: 업화 [19-20]': '추가 재료',
+  '운명의 수호석 결정':    '재련 재료',
+  '위대한 운명의 돌파석':  '재련 재료',
+  '상급 아비도스 융화':    '재련 재료',
+  '운명의 파괴석 결정':    '재련 재료',
+  '파괴석':               '재련 재료',
+  '용암의 숨결':           '추가 재료',
+  '야금술: 업화 [11-14]': '추가 재료',
+  '야금술: 업화 [15-18]': '추가 재료',
+  '야금술: 업화 [19-20]': '추가 재료',
+  '장인의 재봉술: 1단계':  '추가 재료',
+  '장인의 재봉술: 2단계':  '추가 재료',
+  '장인의 재봉술: 3단계':  '추가 재료',
+  '장인의 재봉술: 4단계':  '추가 재료',
+  '장인의 야금술: 1단계':  '추가 재료',
+  '장인의 야금술: 2단계':  '추가 재료',
+  '장인의 야금술: 3단계':  '추가 재료',
+  '장인의 야금술: 4단계':  '추가 재료',
+};
+
+// ─────────────────────────────────────────────
+// 유틸 함수
+// ─────────────────────────────────────────────
+
+export const parseEnhLevel = (name: string): number => {
+  const m = name.match(/^\+(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
+};
+
+export const parseTooltipData = (tooltip: string): { isInherited: boolean; advLevel: number } => {
+  try {
+    const data = JSON.parse(tooltip);
+    const isInherited = data?.Element_001?.value?.slotData?.petBorder === 6;
+    let advLevel = 0;
+    for (const key of Object.keys(data)) {
+      const el = data[key];
+      if (el?.value && typeof el.value === 'string') {
+        const stripped = el.value.replace(/<[^>]+>/g, '');
+        const m = stripped.match(/\[상급 재련\]\s*(\d+)단계/);
+        if (m) { advLevel = parseInt(m[1], 10); break; }
+      }
+    }
+    return { isInherited, advLevel };
+  } catch {
+    return { isInherited: false, advLevel: 0 };
+  }
+};
+
+export const formatGold = (g: number): string => {
+  if (g >= 100_000_000) return `${(g / 100_000_000).toFixed(2)}억G`;
+  if (g >= 10_000) return `${(g / 10_000).toFixed(1)}만G`;
+  return `${Math.round(g).toLocaleString()}G`;
+};
+
+export const formatSilver = (s: number): string => {
+  if (s >= 10_000) return `${(s / 10_000).toFixed(0)}만`;
+  return s.toLocaleString();
+};
+
+export const findCheapest = (
+  steps: typeof AEGIR_ARMOR_STEPS,
+  prices: PriceMap,
+): { useBook: boolean; useBreath: boolean } => {
+  const combos = [
+    { useBook: false, useBreath: false },
+    { useBook: false, useBreath: true },
+    { useBook: true,  useBreath: false },
+    { useBook: true,  useBreath: true },
+  ];
+  let best = combos[0];
+  let bestGold = Infinity;
+  for (const combo of combos) {
+    const gold = steps.reduce((sum, step) => {
+      const exp = calcExpectedAttempts(step, combo.useBook, combo.useBreath);
+      const mats = getAttemptMaterials(step, combo.useBook, combo.useBreath);
+      const matGold = mats.reduce((s, m) => s + m.amount * (prices[m.type] ?? 0), 0) * exp;
+      return sum + step.gold * exp + matGold;
+    }, 0);
+    if (gold < bestGold) { bestGold = gold; best = combo; }
+  }
+  return best;
+};
+
+export const ADV_TURN_OPTIONS: AdvTurnOption[] = ['none', 'book', 'breath', 'both'];
+export const ADV_TURN_OPTION_LABELS: Record<AdvTurnOption, string> = {
+  none: '-', book: '재', breath: '숨', both: '숨재',
+};
+
+export const findCheapestAdv = (
+  activeAdvSlots: SlotName[],
+  advLevelMap: Partial<Record<SlotName, number>>,
+  advTargetMap: Partial<Record<SlotName, number>>,
+  prices: PriceMap,
+): { normalOpt: AdvTurnOption; ancestorOpt: AdvTurnOption; enhancedOpt: AdvTurnOption } => {
+  const defaultCombo = { normalOpt: 'none' as AdvTurnOption, ancestorOpt: 'none' as AdvTurnOption, enhancedOpt: 'none' as AdvTurnOption };
+  if (activeAdvSlots.length === 0) return defaultCombo;
+
+  const calcSlotGold = (normalOpt: AdvTurnOption, ancestorOpt: AdvTurnOption, enhancedOpt: AdvTurnOption) => {
+    let gold = 0;
+    activeAdvSlots.forEach((slot) => {
+      const currentAdv = advLevelMap[slot] ?? 0;
+      const targetAdv = advTargetMap[slot]!;
+      const stagesData = slot === '무기' ? ADV_WEAPON_STAGES : ADV_ARMOR_STAGES;
+      for (let i = 0; i < stagesData.length; i++) {
+        const stageNum = (i + 1) as 1 | 2 | 3 | 4;
+        const stageStart = i * 10;
+        const stageEnd = stageStart + 10;
+        if (currentAdv >= stageEnd) continue;
+        if (targetAdv <= stageStart) break;
+        const stageData = stagesData[i];
+        const xpDone = currentAdv > stageStart ? (currentAdv - stageStart) * 100 : 0;
+        const xpNeeded = (Math.min(targetAdv, stageEnd) - stageStart) * 100 - xpDone;
+        if (xpNeeded <= 0) continue;
+        const attempts = calcAdvExpectedAttempts(normalOpt, ancestorOpt, enhancedOpt, stageNum) * (xpNeeded / ADV_STAGE_XP);
+        gold += attempts * stageData.gold;
+        const { main, optional } = getAdvAttemptMaterials(stageData, normalOpt, ancestorOpt, enhancedOpt);
+        for (const { type, amount } of [...main, ...optional]) {
+          gold += amount * attempts * (prices[type] ?? 0);
+        }
+      }
+    });
+    return gold;
+  };
+
+  let best = defaultCombo;
+  let bestGold = Infinity;
+  for (const normalOpt of ADV_TURN_OPTIONS) {
+    for (const ancestorOpt of ADV_TURN_OPTIONS) {
+      for (const enhancedOpt of ADV_TURN_OPTIONS) {
+        const gold = calcSlotGold(normalOpt, ancestorOpt, enhancedOpt);
+        if (gold < bestGold) { bestGold = gold; best = { normalOpt, ancestorOpt, enhancedOpt }; }
+      }
+    }
+  }
+  return best;
+};
+
+export const getStepsForSlot = (slot: SlotName, isInherited: boolean) => {
+  if (slot === '완갑') return ARMLET_STEPS;
+  if (slot === '무기') return isInherited ? SERKA_WEAPON_STEPS : AEGIR_WEAPON_STEPS;
+  return isInherited ? SERKA_ARMOR_STEPS : AEGIR_ARMOR_STEPS;
+};
+
+export const supportsAdvancedHoning = (slot: SlotName): boolean => slot !== '완갑';
+
+export const calcStepData = (
+  steps: typeof AEGIR_ARMOR_STEPS,
+  book: boolean,
+  breath: boolean,
+  priceMap: PriceMap,
+) => steps.map((step) => {
+  const exp = calcExpectedAttempts(step, book, breath);
+  const ceiling = getCeiling(step, book, breath);
+  const mats = getAttemptMaterials(step, book, breath);
+  const matGoldPerAttempt = mats.reduce((s, m) => s + m.amount * (priceMap[m.type] ?? 0), 0);
+  const matGold = matGoldPerAttempt * exp;
+  const directGold = step.gold * exp;
+  const silver = step.silver * exp;
+  // 천장(장기백) 케이스: 천장 시도수까지 모두 실패 후 마지막에 성공
+  const ceilingMatGold = matGoldPerAttempt * ceiling;
+  const ceilingDirectGold = step.gold * ceiling;
+  const ceilingSilver = step.silver * ceiling;
+  return {
+    step,
+    exp, mats, matGold, directGold, silver, totalGold: directGold + matGold,
+    ceiling, ceilingMatGold, ceilingDirectGold, ceilingSilver, ceilingTotalGold: ceilingDirectGold + ceilingMatGold,
+  };
+});

--- a/src/components/enhancement/useEnhancementCharacter.ts
+++ b/src/components/enhancement/useEnhancementCharacter.ts
@@ -1,0 +1,98 @@
+import { useCallback, useState } from 'react';
+import { fetchEquipment, fetchProfile } from '../../utils/api';
+import {
+  ARMOR_SLOTS,
+  type ArmorSlot,
+  parseEnhLevel,
+  parseTooltipData,
+  type SlotName,
+} from './enhancementModel';
+
+export const useEnhancementCharacter = () => {
+  const [armorMap, setArmorMap] = useState<Partial<Record<ArmorSlot | '완갑', number>>>({});
+  const [weaponLevel, setWeaponLevel] = useState<number | undefined>(undefined);
+  const [slotIconMap, setSlotIconMap] = useState<Partial<Record<SlotName, string>>>({});
+  const [slotInheritedMap, setSlotInheritedMap] = useState<Partial<Record<SlotName, boolean>>>({});
+  const [advLevelMap, setAdvLevelMap] = useState<Partial<Record<SlotName, number>>>({});
+  const [charItemLevel, setCharItemLevel] = useState<number | null>(null);
+  const [charLoading, setCharLoading] = useState(false);
+  const [charError, setCharError] = useState<string | null>(null);
+
+  const searchCharacter = useCallback(async (name: string) => {
+    const normalizedName = name.trim();
+    if (!normalizedName) return;
+
+    setCharLoading(true);
+    setCharError(null);
+    setArmorMap({});
+    setWeaponLevel(undefined);
+    setSlotIconMap({});
+    setSlotInheritedMap({});
+    setAdvLevelMap({});
+    setCharItemLevel(null);
+
+    try {
+      const equipment = await fetchEquipment(normalizedName);
+      const nextArmorMap: Partial<Record<ArmorSlot | '완갑', number>> = {};
+      const nextIconMap: Partial<Record<SlotName, string>> = {};
+      const nextInheritedMap: Partial<Record<SlotName, boolean>> = {};
+      const nextAdvLevelMap: Partial<Record<SlotName, number>> = {};
+
+      for (const item of equipment) {
+        if ((ARMOR_SLOTS as readonly string[]).includes(item.Type)) {
+          const slot = item.Type as ArmorSlot;
+          nextArmorMap[slot] = parseEnhLevel(item.Name);
+          if (item.Icon) nextIconMap[slot] = item.Icon;
+          const { isInherited, advLevel } = parseTooltipData(item.Tooltip);
+          if (isInherited) nextInheritedMap[slot] = true;
+          if (advLevel > 0) nextAdvLevelMap[slot] = advLevel;
+        }
+        if (item.Type === '완갑') {
+          nextArmorMap['완갑'] = parseEnhLevel(item.Name);
+          if (item.Icon) nextIconMap['완갑'] = item.Icon;
+        }
+        if (item.Type === '무기') {
+          setWeaponLevel(parseEnhLevel(item.Name));
+          if (item.Icon) nextIconMap['무기'] = item.Icon;
+          const { isInherited, advLevel } = parseTooltipData(item.Tooltip);
+          if (isInherited) nextInheritedMap['무기'] = true;
+          if (advLevel > 0) nextAdvLevelMap['무기'] = advLevel;
+        }
+      }
+
+      setArmorMap(nextArmorMap);
+      setSlotIconMap(nextIconMap);
+      setSlotInheritedMap(nextInheritedMap);
+      setAdvLevelMap(nextAdvLevelMap);
+    } catch {
+      setCharError('캐릭터를 찾을 수 없습니다');
+      setCharLoading(false);
+      return;
+    }
+
+    try {
+      const profile = await fetchProfile(normalizedName);
+      const parsedItemLevel = parseFloat(profile.ItemAvgLevel.replace(/,/g, ''));
+      if (!Number.isNaN(parsedItemLevel)) setCharItemLevel(parsedItemLevel);
+    } catch {
+      setCharItemLevel(null);
+    } finally {
+      setCharLoading(false);
+    }
+  }, []);
+
+  const clearCharacterError = useCallback(() => setCharError(null), []);
+
+  return {
+    armorMap,
+    weaponLevel,
+    slotIconMap,
+    slotInheritedMap,
+    advLevelMap,
+    charItemLevel,
+    charLoading,
+    charError,
+    clearCharacterError,
+    searchCharacter,
+  };
+};

--- a/src/components/enhancement/useEnhancementMarket.ts
+++ b/src/components/enhancement/useEnhancementMarket.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchMarketItems, fetchMarketOptions } from '../../utils/api';
+import {
+  ALL_MATERIAL_TYPES,
+  flattenCategories,
+  type IconMap,
+  MARKET_SEARCH,
+  MATERIAL_CATEGORY_KEYWORD,
+  type PriceMap,
+} from './enhancementModel';
+
+export const useEnhancementMarket = () => {
+  const [prices, setPrices] = useState<PriceMap>({});
+  const [icons, setIcons] = useState<IconMap>({});
+  const [priceLoading, setPriceLoading] = useState(true);
+  const [priceError, setPriceError] = useState<string | null>(null);
+
+  const loadPrices = useCallback(async () => {
+    setPriceLoading(true);
+    setPriceError(null);
+    try {
+      const options = await fetchMarketOptions();
+      const allCats = flattenCategories(options.Categories);
+      const findCode = (keyword: string): number => {
+        const found = allCats.find((category) => category.CodeName.includes(keyword));
+        return found?.Code ?? allCats[0]?.Code ?? 50000;
+      };
+
+      const results = await Promise.allSettled(
+        ALL_MATERIAL_TYPES.filter((type) => !MARKET_SEARCH[type].untradeable).map(async (type) => {
+          const config = MARKET_SEARCH[type];
+          const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
+          const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
+          const item = data.Items?.[0];
+          if (!item) return { type, price: 0, icon: '' };
+          const itemsPerUnit = config.itemsPerUnit ?? 1;
+          return {
+            type,
+            price: item.CurrentMinPrice / item.BundleCount / itemsPerUnit,
+            icon: item.Icon,
+          };
+        }),
+      );
+
+      const priceMap: PriceMap = {};
+      const iconMap: IconMap = {};
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          priceMap[result.value.type] = result.value.price;
+          if (result.value.icon) iconMap[result.value.type] = result.value.icon;
+        }
+      }
+      setPrices(priceMap);
+      setIcons(iconMap);
+    } catch {
+      setPriceError('가격 조회 실패');
+    } finally {
+      setPriceLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPrices();
+  }, [loadPrices]);
+
+  return { prices, icons, priceLoading, priceError, loadPrices };
+};

--- a/src/pages/Enhancement.tsx
+++ b/src/pages/Enhancement.tsx
@@ -4,284 +4,37 @@ import GlassCard from '../components/GlassCard';
 import SelectMenu from '../components/SelectMenu';
 import StateFeedback from '../components/StateFeedback';
 import {
-  fetchEquipment,
-  fetchProfile,
-  fetchMarketOptions,
-  fetchMarketItems,
-  type MarketCategory,
-} from '../utils/api';
-import {
-  AEGIR_ARMOR_STEPS,
-  AEGIR_WEAPON_STEPS,
-  SERKA_ARMOR_STEPS,
-  SERKA_WEAPON_STEPS,
-  ARMLET_STEPS,
   ADV_ARMOR_STAGES,
-  ADV_WEAPON_STAGES,
   ADV_STAGE_XP,
-  calcExpectedAttempts,
-  getCeiling,
-  getAttemptMaterials,
+  ADV_WEAPON_STAGES,
   calcAdvExpectedAttempts,
+  calcExpectedAttempts,
   getAdvAttemptMaterials,
-  type MaterialType,
+  getAttemptMaterials,
   type AdvTurnOption,
   type EnhancementStep,
+  type MaterialType,
 } from '../data/enhancement';
-
-// ─────────────────────────────────────────────
-// 상수
-// ─────────────────────────────────────────────
-
-const ARMOR_SLOTS = ['투구', '어깨', '상의', '하의', '장갑'] as const;
-type ArmorSlot = (typeof ARMOR_SLOTS)[number];
-type SlotName = '무기' | ArmorSlot | '완갑';
-
-const ALL_SLOTS: SlotName[] = ['무기', '완갑', '투구', '어깨', '상의', '하의', '장갑'];
-const ITEM_LEVEL_SLOTS = ['무기', ...ARMOR_SLOTS] as const;
-
-const ITEM_LEVEL_PER_STEP = 5; // 일반 재련 1단계당 아이템 레벨 증가량
-
-const NORMAL_BULK_TARGET_OPTIONS = Array.from({ length: 15 }, (_, i) => {
-  const level = i + 11;
-  return { value: level, label: `${level}강` };
-});
-
-const ADV_TARGET_OPTIONS = [10, 20, 30, 40].map((level) => ({
-  value: level,
-  label: `${level}단계`,
-}));
-
-interface MarketConfig {
-  searchName: string;
-  itemsPerUnit?: number;
-  categoryCode?: number;
-  extraParams?: Record<string, unknown>;
-  untradeable?: boolean;
-}
-
-const MARKET_SEARCH: Record<MaterialType, MarketConfig> = {
-  // 방어구
-  '수호석':               { searchName: '운명의 수호석' },
-  '돌파석':               { searchName: '운명의 돌파석' },
-  '아비도스 융화 재료':    { searchName: '아비도스 융화 재료' },
-  '운명의 파편':           { searchName: '운명의 파편 주머니(소)', itemsPerUnit: 1000 },
-  '빙하의 숨결':           { searchName: '빙하의 숨결', categoryCode: 50020 },
-  '재봉술: 업화 [11-14]': { searchName: '재봉술 : 업화 [11-14]' },
-  '재봉술: 업화 [15-18]': { searchName: '재봉술 : 업화 [15-18]' },
-  '재봉술: 업화 [19-20]': { searchName: '재봉술 : 업화 [19-20]' },
-  // 무기
-  '파괴석':               { searchName: '운명의 파괴석' },
-  '용암의 숨결':           { searchName: '용암의 숨결', categoryCode: 50020 },
-  '야금술: 업화 [11-14]': { searchName: '야금술 : 업화 [11-14]' },
-  '야금술: 업화 [15-18]': { searchName: '야금술 : 업화 [15-18]' },
-  '야금술: 업화 [19-20]': { searchName: '야금술 : 업화 [19-20]' },
-  // 세르카 방어구
-  '운명의 수호석 결정':    { searchName: '운명의 수호석 결정' },
-  '위대한 운명의 돌파석':  { searchName: '위대한 운명의 돌파석' },
-  '상급 아비도스 융화':    { searchName: '상급 아비도스 융화' },
-  // 세르카 무기
-  '운명의 파괴석 결정':    { searchName: '운명의 파괴석 결정' },
-  // 방어구 상급 재련 책
-  '장인의 재봉술: 1단계':  { searchName: '장인의 재봉술 : 1단계' },
-  '장인의 재봉술: 2단계':  { searchName: '장인의 재봉술 : 2단계' },
-  '장인의 재봉술: 3단계':  { searchName: '장인의 재봉술 : 3단계' },
-  '장인의 재봉술: 4단계':  { searchName: '장인의 재봉술 : 4단계' },
-  // 무기 상급 재련 책
-  '장인의 야금술: 1단계':  { searchName: '장인의 야금술 : 1단계' },
-  '장인의 야금술: 2단계':  { searchName: '장인의 야금술 : 2단계' },
-  '장인의 야금술: 3단계':  { searchName: '장인의 야금술 : 3단계' },
-  '장인의 야금술: 4단계':  { searchName: '장인의 야금술 : 4단계' },
-};
-
-const ALL_MATERIAL_TYPES = Object.keys(MARKET_SEARCH) as MaterialType[];
-
-type PriceMap = Partial<Record<MaterialType, number>>;
-type IconMap = Partial<Record<MaterialType, string>>;
-
-const flattenCategories = (cats: MarketCategory[]): MarketCategory[] =>
-  cats.flatMap((c) => [c, ...(c.Subs ? flattenCategories(c.Subs) : [])]);
-
-const MATERIAL_CATEGORY_KEYWORD: Record<MaterialType, string> = {
-  '수호석':               '재련 재료',
-  '돌파석':               '재련 재료',
-  '아비도스 융화 재료':    '재련 재료',
-  '운명의 파편':           '재련 재료',
-  '빙하의 숨결':           '추가 재료',
-  '재봉술: 업화 [11-14]': '추가 재료',
-  '재봉술: 업화 [15-18]': '추가 재료',
-  '재봉술: 업화 [19-20]': '추가 재료',
-  '운명의 수호석 결정':    '재련 재료',
-  '위대한 운명의 돌파석':  '재련 재료',
-  '상급 아비도스 융화':    '재련 재료',
-  '운명의 파괴석 결정':    '재련 재료',
-  '파괴석':               '재련 재료',
-  '용암의 숨결':           '추가 재료',
-  '야금술: 업화 [11-14]': '추가 재료',
-  '야금술: 업화 [15-18]': '추가 재료',
-  '야금술: 업화 [19-20]': '추가 재료',
-  '장인의 재봉술: 1단계':  '추가 재료',
-  '장인의 재봉술: 2단계':  '추가 재료',
-  '장인의 재봉술: 3단계':  '추가 재료',
-  '장인의 재봉술: 4단계':  '추가 재료',
-  '장인의 야금술: 1단계':  '추가 재료',
-  '장인의 야금술: 2단계':  '추가 재료',
-  '장인의 야금술: 3단계':  '추가 재료',
-  '장인의 야금술: 4단계':  '추가 재료',
-};
-
-// ─────────────────────────────────────────────
-// 유틸 함수
-// ─────────────────────────────────────────────
-
-const parseEnhLevel = (name: string): number => {
-  const m = name.match(/^\+(\d+)/);
-  return m ? parseInt(m[1], 10) : 0;
-};
-
-const parseTooltipData = (tooltip: string): { isInherited: boolean; advLevel: number } => {
-  try {
-    const data = JSON.parse(tooltip);
-    const isInherited = data?.Element_001?.value?.slotData?.petBorder === 6;
-    let advLevel = 0;
-    for (const key of Object.keys(data)) {
-      const el = data[key];
-      if (el?.value && typeof el.value === 'string') {
-        const stripped = el.value.replace(/<[^>]+>/g, '');
-        const m = stripped.match(/\[상급 재련\]\s*(\d+)단계/);
-        if (m) { advLevel = parseInt(m[1], 10); break; }
-      }
-    }
-    return { isInherited, advLevel };
-  } catch {
-    return { isInherited: false, advLevel: 0 };
-  }
-};
-
-const formatGold = (g: number): string => {
-  if (g >= 100_000_000) return `${(g / 100_000_000).toFixed(2)}억G`;
-  if (g >= 10_000) return `${(g / 10_000).toFixed(1)}만G`;
-  return `${Math.round(g).toLocaleString()}G`;
-};
-
-const formatSilver = (s: number): string => {
-  if (s >= 10_000) return `${(s / 10_000).toFixed(0)}만`;
-  return s.toLocaleString();
-};
-
-const findCheapest = (
-  steps: typeof AEGIR_ARMOR_STEPS,
-  prices: PriceMap,
-): { useBook: boolean; useBreath: boolean } => {
-  const combos = [
-    { useBook: false, useBreath: false },
-    { useBook: false, useBreath: true },
-    { useBook: true,  useBreath: false },
-    { useBook: true,  useBreath: true },
-  ];
-  let best = combos[0];
-  let bestGold = Infinity;
-  for (const combo of combos) {
-    const gold = steps.reduce((sum, step) => {
-      const exp = calcExpectedAttempts(step, combo.useBook, combo.useBreath);
-      const mats = getAttemptMaterials(step, combo.useBook, combo.useBreath);
-      const matGold = mats.reduce((s, m) => s + m.amount * (prices[m.type] ?? 0), 0) * exp;
-      return sum + step.gold * exp + matGold;
-    }, 0);
-    if (gold < bestGold) { bestGold = gold; best = combo; }
-  }
-  return best;
-};
-
-const ADV_TURN_OPTIONS: AdvTurnOption[] = ['none', 'book', 'breath', 'both'];
-const ADV_TURN_OPTION_LABELS: Record<AdvTurnOption, string> = {
-  none: '-', book: '재', breath: '숨', both: '숨재',
-};
-
-const findCheapestAdv = (
-  activeAdvSlots: SlotName[],
-  advLevelMap: Partial<Record<SlotName, number>>,
-  advTargetMap: Partial<Record<SlotName, number>>,
-  prices: PriceMap,
-): { normalOpt: AdvTurnOption; ancestorOpt: AdvTurnOption; enhancedOpt: AdvTurnOption } => {
-  const defaultCombo = { normalOpt: 'none' as AdvTurnOption, ancestorOpt: 'none' as AdvTurnOption, enhancedOpt: 'none' as AdvTurnOption };
-  if (activeAdvSlots.length === 0) return defaultCombo;
-
-  const calcSlotGold = (normalOpt: AdvTurnOption, ancestorOpt: AdvTurnOption, enhancedOpt: AdvTurnOption) => {
-    let gold = 0;
-    activeAdvSlots.forEach((slot) => {
-      const currentAdv = advLevelMap[slot] ?? 0;
-      const targetAdv = advTargetMap[slot]!;
-      const stagesData = slot === '무기' ? ADV_WEAPON_STAGES : ADV_ARMOR_STAGES;
-      for (let i = 0; i < stagesData.length; i++) {
-        const stageNum = (i + 1) as 1 | 2 | 3 | 4;
-        const stageStart = i * 10;
-        const stageEnd = stageStart + 10;
-        if (currentAdv >= stageEnd) continue;
-        if (targetAdv <= stageStart) break;
-        const stageData = stagesData[i];
-        const xpDone = currentAdv > stageStart ? (currentAdv - stageStart) * 100 : 0;
-        const xpNeeded = (Math.min(targetAdv, stageEnd) - stageStart) * 100 - xpDone;
-        if (xpNeeded <= 0) continue;
-        const attempts = calcAdvExpectedAttempts(normalOpt, ancestorOpt, enhancedOpt, stageNum) * (xpNeeded / ADV_STAGE_XP);
-        gold += attempts * stageData.gold;
-        const { main, optional } = getAdvAttemptMaterials(stageData, normalOpt, ancestorOpt, enhancedOpt);
-        for (const { type, amount } of [...main, ...optional]) {
-          gold += amount * attempts * (prices[type] ?? 0);
-        }
-      }
-    });
-    return gold;
-  };
-
-  let best = defaultCombo;
-  let bestGold = Infinity;
-  for (const normalOpt of ADV_TURN_OPTIONS) {
-    for (const ancestorOpt of ADV_TURN_OPTIONS) {
-      for (const enhancedOpt of ADV_TURN_OPTIONS) {
-        const gold = calcSlotGold(normalOpt, ancestorOpt, enhancedOpt);
-        if (gold < bestGold) { bestGold = gold; best = { normalOpt, ancestorOpt, enhancedOpt }; }
-      }
-    }
-  }
-  return best;
-};
-
-const getStepsForSlot = (slot: SlotName, isInherited: boolean) => {
-  if (slot === '완갑') return ARMLET_STEPS;
-  if (slot === '무기') return isInherited ? SERKA_WEAPON_STEPS : AEGIR_WEAPON_STEPS;
-  return isInherited ? SERKA_ARMOR_STEPS : AEGIR_ARMOR_STEPS;
-};
-
-const supportsAdvancedHoning = (slot: SlotName): boolean => slot !== '완갑';
-
-const calcStepData = (
-  steps: typeof AEGIR_ARMOR_STEPS,
-  book: boolean,
-  breath: boolean,
-  priceMap: PriceMap,
-) => steps.map((step) => {
-  const exp = calcExpectedAttempts(step, book, breath);
-  const ceiling = getCeiling(step, book, breath);
-  const mats = getAttemptMaterials(step, book, breath);
-  const matGoldPerAttempt = mats.reduce((s, m) => s + m.amount * (priceMap[m.type] ?? 0), 0);
-  const matGold = matGoldPerAttempt * exp;
-  const directGold = step.gold * exp;
-  const silver = step.silver * exp;
-  // 천장(장기백) 케이스: 천장 시도수까지 모두 실패 후 마지막에 성공
-  const ceilingMatGold = matGoldPerAttempt * ceiling;
-  const ceilingDirectGold = step.gold * ceiling;
-  const ceilingSilver = step.silver * ceiling;
-  return {
-    step,
-    exp, mats, matGold, directGold, silver, totalGold: directGold + matGold,
-    ceiling, ceilingMatGold, ceilingDirectGold, ceilingSilver, ceilingTotalGold: ceilingDirectGold + ceilingMatGold,
-  };
-});
-
-// ─────────────────────────────────────────────
-// 서브 컴포넌트
-// ─────────────────────────────────────────────
+import {
+  ADV_TARGET_OPTIONS,
+  ADV_TURN_OPTION_LABELS,
+  ADV_TURN_OPTIONS,
+  ALL_SLOTS,
+  calcStepData,
+  findCheapest,
+  findCheapestAdv,
+  formatGold,
+  formatSilver,
+  getStepsForSlot,
+  ITEM_LEVEL_PER_STEP,
+  ITEM_LEVEL_SLOTS,
+  MARKET_SEARCH,
+  NORMAL_BULK_TARGET_OPTIONS,
+  supportsAdvancedHoning,
+  type SlotName,
+} from '../components/enhancement/enhancementModel';
+import { useEnhancementCharacter } from '../components/enhancement/useEnhancementCharacter';
+import { useEnhancementMarket } from '../components/enhancement/useEnhancementMarket';
 
 const Toggle: React.FC<{
   label: string;
@@ -320,16 +73,20 @@ const Toggle: React.FC<{
 const Enhancement: React.FC = () => {
   // ── 캐릭터 검색 ─────────────────────────────
   const [charInput, setCharInput] = useState('');
-  const [armorMap, setArmorMap] = useState<Partial<Record<ArmorSlot | '완갑', number>>>({});
-  const [weaponLevel, setWeaponLevel] = useState<number | undefined>(undefined);
-  const [slotIconMap, setSlotIconMap] = useState<Partial<Record<SlotName, string>>>({});
-  const [slotInheritedMap, setSlotInheritedMap] = useState<Partial<Record<SlotName, boolean>>>({});
-  const [advLevelMap, setAdvLevelMap] = useState<Partial<Record<SlotName, number>>>({});
-  const [advTargetMap, setAdvTargetMap] = useState<Partial<Record<SlotName, number>>>({});
-  const [charItemLevel, setCharItemLevel] = useState<number | null>(null);
-  const [charLoading, setCharLoading] = useState(false);
-  const [charError, setCharError] = useState<string | null>(null);
   const charInputRef = useRef<HTMLInputElement>(null);
+  const {
+    armorMap,
+    weaponLevel,
+    slotIconMap,
+    slotInheritedMap,
+    advLevelMap,
+    charItemLevel,
+    charLoading,
+    charError,
+    clearCharacterError,
+    searchCharacter: fetchCharacterEnhancement,
+  } = useEnhancementCharacter();
+  const [advTargetMap, setAdvTargetMap] = useState<Partial<Record<SlotName, number>>>({});
 
   // ── 슬롯별 목표 강 ───────────────────────────
   const [targetMap, setTargetMap] = useState<Partial<Record<SlotName, number>>>({});
@@ -345,60 +102,13 @@ const Enhancement: React.FC = () => {
   const [advEnhancedOpt, setAdvEnhancedOpt] = useState<AdvTurnOption>('none');
 
   // ── 거래소 가격 ──────────────────────────────
-  const [prices, setPrices] = useState<PriceMap>({});
-  const [icons, setIcons] = useState<IconMap>({});
-  const [priceLoading, setPriceLoading] = useState(true);
-  const [priceError, setPriceError] = useState<string | null>(null);
+  const { prices, icons, priceLoading, priceError, loadPrices } = useEnhancementMarket();
   const autoApplied = useRef(false);
   const autoAppliedAdv = useRef(false);
 
   // ── 보유 재료 ────────────────────────────────
   const [ownedMaterials, setOwnedMaterials] = useState<Partial<Record<MaterialType, number>>>({});
   const [showOwnedSection, setShowOwnedSection] = useState(false);
-
-  // ── 거래소 가격 조회 (마운트 시 1회 + 실패 시 재시도) ──
-  const loadPrices = useCallback(async () => {
-    setPriceLoading(true);
-    setPriceError(null);
-    try {
-      const options = await fetchMarketOptions();
-      const allCats = flattenCategories(options.Categories);
-      const findCode = (keyword: string): number => {
-        const found = allCats.find((c) => c.CodeName.includes(keyword));
-        return found?.Code ?? allCats[0]?.Code ?? 50000;
-      };
-
-      const results = await Promise.allSettled(
-        ALL_MATERIAL_TYPES.filter((type) => !MARKET_SEARCH[type].untradeable).map(async (type) => {
-          const config = MARKET_SEARCH[type];
-          const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
-          const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
-          const item = data.Items?.[0];
-          if (!item) return { type, price: 0, icon: '' };
-          const itemsPerUnit = config.itemsPerUnit ?? 1;
-          return { type, price: item.CurrentMinPrice / item.BundleCount / itemsPerUnit, icon: item.Icon };
-        })
-      );
-      const priceMap: PriceMap = {};
-      const iconMap: IconMap = {};
-      for (const r of results) {
-        if (r.status === 'fulfilled') {
-          priceMap[r.value.type] = r.value.price;
-          if (r.value.icon) iconMap[r.value.type] = r.value.icon;
-        }
-      }
-      setPrices(priceMap);
-      setIcons(iconMap);
-    } catch {
-      setPriceError('가격 조회 실패');
-    } finally {
-      setPriceLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadPrices();
-  }, [loadPrices]);
 
   // ── 슬롯별 현재 레벨 ─────────────────────────
   const slotCurrentLevel = useMemo<Record<SlotName, number>>(() => ({
@@ -462,67 +172,15 @@ const Enhancement: React.FC = () => {
   // ── 캐릭터 장비 조회 ─────────────────────────
   const searchCharacter = useCallback(async (name: string) => {
     if (!name.trim()) return;
-    setCharLoading(true);
-    setCharError(null);
-    setArmorMap({});
-    setWeaponLevel(undefined);
-    setSlotIconMap({});
-    setSlotInheritedMap({});
-    setAdvLevelMap({});
     setAdvTargetMap({});
-    setCharItemLevel(null);
     setTargetMap({});
-    try {
-      const equipment = await fetchEquipment(name.trim());
-      const map: Partial<Record<ArmorSlot | '완갑', number>> = {};
-      const iconMap: Partial<Record<SlotName, string>> = {};
-      const inheritedMap: Partial<Record<SlotName, boolean>> = {};
-      const advMap: Partial<Record<SlotName, number>> = {};
-      for (const item of equipment) {
-        if ((ARMOR_SLOTS as readonly string[]).includes(item.Type)) {
-          map[item.Type as ArmorSlot] = parseEnhLevel(item.Name);
-          if (item.Icon) iconMap[item.Type as ArmorSlot] = item.Icon;
-          const { isInherited, advLevel } = parseTooltipData(item.Tooltip);
-          if (isInherited) inheritedMap[item.Type as ArmorSlot] = true;
-          if (advLevel > 0) advMap[item.Type as ArmorSlot] = advLevel;
-        }
-        if (item.Type === '완갑') {
-          map['완갑'] = parseEnhLevel(item.Name);
-          if (item.Icon) iconMap['완갑'] = item.Icon;
-        }
-        if (item.Type === '무기') {
-          setWeaponLevel(parseEnhLevel(item.Name));
-          if (item.Icon) iconMap['무기'] = item.Icon;
-          const { isInherited, advLevel } = parseTooltipData(item.Tooltip);
-          if (isInherited) inheritedMap['무기'] = true;
-          if (advLevel > 0) advMap['무기'] = advLevel;
-        }
-      }
-      setArmorMap(map);
-      setSlotIconMap(iconMap);
-      setSlotInheritedMap(inheritedMap);
-      setAdvLevelMap(advMap);
-    } catch {
-      setCharError('캐릭터를 찾을 수 없습니다');
-      setCharLoading(false);
-      return;
-    }
-
-    try {
-      const profile = await fetchProfile(name.trim());
-      const parsed = parseFloat(profile.ItemAvgLevel.replace(/,/g, ''));
-      if (!isNaN(parsed)) setCharItemLevel(parsed);
-    } catch {
-      // 프로필 조회 실패 시 아이템 레벨 미표시 (장비 데이터는 유지)
-    } finally {
-      setCharLoading(false);
-    }
-  }, []);
+    await fetchCharacterEnhancement(name);
+  }, [fetchCharacterEnhancement]);
 
   const handleSearch = () => searchCharacter(charInput);
 
   const handleResetCharSearch = (): void => {
-    setCharError(null);
+    clearCharacterError();
     charInputRef.current?.focus();
     charInputRef.current?.select();
   };


### PR DESCRIPTION
## 변경 사항
- Enhancement 상수, 장비 Tooltip parser, 일반/상급 재련 계산 helper를 feature model로 이동
- 캐릭터 장비/프로필 조회 상태를 `useEnhancementCharacter`로 분리
- 거래소 시세 조회 상태를 `useEnhancementMarket`으로 분리
- model 단위 테스트 추가
- `Enhancement.tsx`를 1,596줄에서 1,254줄로 축소

## 범위 제한
- 결과 및 설정 UI 컴포넌트는 이번 PR에서 이동하지 않음
- 재련 공식, API 요청 순서, UI 및 문구를 변경하지 않음

## 테스트
- `CI=true yarn test --watchAll=false --runTestsByPath src/pages/Enhancement.test.tsx src/components/enhancement/enhancementModel.test.ts`
- 2 suites / 9 tests passed
- 변경 파일 TypeScript diagnostics 없음

## 후속 작업
- Enhancement 설정/결과/재료 UI 컴포넌트 분리

Closes #44
Related to #29