### PR TITLE
fix: React Hook 의존성 예외 제거

### DIFF
--- a/src/components/simulation/useSimulationPage.ts
+++ b/src/components/simulation/useSimulationPage.ts
@@ -131,20 +131,21 @@ export const useSimulationPage = () => {
             setSelectedNames(new Set());
             setError(null);
         }
-    }, [urlNickname]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [urlNickname, nickname]);
 
     // 닉네임 변경 시 siblings API 호출 + 서버 자동 감지.
-    // cancelled 플래그로 race 방지: 닉네임을 빠르게 바꾸면 이전 요청의 응답이 늦게 도착해도 무시.
+    // 이전 요청을 취소해 늦게 도착한 응답이 최신 상태를 덮지 않게 한다.
     useEffect(() => {
         if (!nickname) return;
-        let cancelled = false;
+
+        const controller = new AbortController();
         safeLocalStorage.setItem(LS_NICKNAME, nickname);
         setLoading(true);
         setError(null);
 
-        fetchSiblings(nickname)
+        fetchSiblings(nickname, { signal: controller.signal })
             .then((data) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 if (Array.isArray(data) && data.length > 0) {
                     const serverCounts = new Map<string, number>();
                     data.forEach((c) => {
@@ -166,19 +167,18 @@ export const useSimulationPage = () => {
                 setLoading(false);
             })
             .catch((err: unknown) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 console.error(err);
                 setError('캐릭터 정보를 불러오는 데 실패했습니다.');
                 setLoading(false);
             });
 
-        return () => { cancelled = true; };
+        return () => controller.abort();
     }, [nickname]);
 
 
     const handleNicknameSubmit = (name: string): void => {
         setSearchParams({ nickname: name });
-        setNickname(name);
         setServer(null);
         setCharacterNames([]);
         setCharacterInfo([]);
@@ -188,31 +188,31 @@ export const useSimulationPage = () => {
     };
 
     const fetchCharacterInfo = useCallback(
-        async (characterName: string): Promise<CharacterProfile | null> => {
+        async (characterName: string, signal: AbortSignal): Promise<CharacterProfile | null> => {
             try {
-                const data = await fetchProfile(characterName);
+                const data = await fetchProfile(characterName, { signal });
                 if (data && data.CharacterName) {
                     return data;
                 }
                 return null;
             } catch (err) {
-                console.error(err);
+                if (!signal.aborted) console.error(err);
                 return null;
             }
         },
         []
     );
 
-    // characterNames 팬아웃 fetchProfile. 동일 race 방지 패턴.
-    // fetchCharacterInfo는 내부 try/catch로 null을 리턴하지만 시그니처 변경 회귀 방지 위해 .catch 가드.
+    // characterNames 팬아웃 fetchProfile. 이전 팬아웃 요청은 모두 취소한다.
     useEffect(() => {
         if (characterNames.length === 0) return;
-        let cancelled = false;
+
+        const controller = new AbortController();
         setLoading(true);
 
-        Promise.all(characterNames.map((c) => fetchCharacterInfo(c.CharacterName)))
+        Promise.all(characterNames.map((c) => fetchCharacterInfo(c.CharacterName, controller.signal)))
             .then((results) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 results.sort((a, b) => {
                     const lvA = a ? parseFloat(a.ItemAvgLevel.replace(/,/g, '')) : 0;
                     const lvB = b ? parseFloat(b.ItemAvgLevel.replace(/,/g, '')) : 0;
@@ -222,12 +222,12 @@ export const useSimulationPage = () => {
                 setLoading(false);
             })
             .catch((err) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 console.error(err);
                 setLoading(false);
             });
 
-        return () => { cancelled = true; };
+        return () => controller.abort();
     }, [characterNames, fetchCharacterInfo]);
 
     const allResults: CharacterGoldResult[] = useMemo(() => {

--- a/src/pages/Character.test.tsx
+++ b/src/pages/Character.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Character from './Character';
 import type { CharacterProfile, EquipmentItem } from '../types/lostark';
@@ -136,5 +136,28 @@ describe('Character route state affordances', () => {
     expect(await screen.findByRole('status', { name: '캐릭터 정보가 없습니다' })).toHaveTextContent(
       '닉네임을 확인한 뒤 다시 검색해 주세요',
     );
+  });
+
+  it('aborts an outdated request and ignores its late response', async () => {
+    let resolveFirst!: (value: CharacterProfile) => void;
+    let firstSignal: AbortSignal | undefined;
+    mockedFetchProfile
+      .mockImplementationOnce((_nickname, options) => {
+        firstSignal = options?.signal ?? undefined;
+        return new Promise<CharacterProfile>((resolve) => { resolveFirst = resolve; });
+      })
+      .mockResolvedValueOnce({ ...profile, CharacterName: '최신캐릭터' });
+
+    const { rerender } = render(<Character />);
+    await waitFor(() => expect(mockedFetchProfile).toHaveBeenCalledTimes(1));
+
+    mockCurrentSearchParams = new URLSearchParams('nickname=최신캐릭터');
+    rerender(<Character />);
+
+    expect(await screen.findByRole('img', { name: '최신캐릭터' })).toBeInTheDocument();
+    expect(firstSignal?.aborted).toBe(true);
+
+    await act(async () => { resolveFirst(profile); });
+    expect(screen.queryByRole('img', { name: '테스트캐릭터' })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -50,7 +50,7 @@ const Character: React.FC = () => {
       setArkGrid(null);
       setError(null);
     }
-  }, [urlNickname]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [urlNickname, nickname]);
 
   // AbortController로 이전 요청을 취소해 늦게 도착한 응답이 최신 상태를 덮지 않게 한다.
   useEffect(() => {
@@ -94,7 +94,6 @@ const Character: React.FC = () => {
 
   const handleSearch = (name: string) => {
     setSearchParams({ nickname: name });
-    setNickname(name);
   };
 
   const handleResetSearch = (): void => {

--- a/src/pages/Simulation.test.tsx
+++ b/src/pages/Simulation.test.tsx
@@ -11,7 +11,11 @@ vi.mock('../components/NicknameInput', () => ({
     <button onClick={() => onSubmit('테스트캐릭터')}>골드 계산 시작</button>
   ),
 }));
-vi.mock('../components/NicknameSearchBar', () => ({ default: () => <div>NicknameSearchBar</div> }));
+vi.mock('../components/NicknameSearchBar', () => ({
+  default: ({ onSearch }: { onSearch: (name: string) => void }) => (
+    <button onClick={() => onSearch('최신캐릭터')}>다른 캐릭터 검색</button>
+  ),
+}));
 vi.mock('../components/simulation/GoldLoadingSkeleton', () => ({ default: () => <div>Loading</div> }));
 vi.mock('../components/simulation/CharacterRaidCard', () => ({
   default: ({ result }: { result: { characterName: string } }) => (
@@ -77,11 +81,37 @@ describe('Simulation page orchestration', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '골드 계산 시작' }));
 
-    await waitFor(() => expect(mockedFetchSiblings).toHaveBeenCalledWith('테스트캐릭터'));
-    await waitFor(() => expect(mockedFetchProfile).toHaveBeenCalledWith('테스트캐릭터'));
+    await waitFor(() => expect(mockedFetchSiblings).toHaveBeenCalledWith(
+      '테스트캐릭터',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    ));
+    await waitFor(() => expect(mockedFetchProfile).toHaveBeenCalledWith(
+      '테스트캐릭터',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    ));
     expect(await screen.findByRole('heading', { name: /테스트캐릭터.*주간 골드/ })).toBeInTheDocument();
     expect(screen.getByText((_, element) =>
       element?.tagName === 'P' && element.textContent?.includes('루페온 서버 | 1 캐릭터') === true,
     )).toBeInTheDocument();
+  });
+
+  it('aborts an outdated expedition request when the nickname changes', async () => {
+    let firstSignal: AbortSignal | undefined;
+    mockedFetchSiblings
+      .mockImplementationOnce((_nickname, options) => {
+        firstSignal = options?.signal ?? undefined;
+        return new Promise(() => undefined);
+      })
+      .mockResolvedValueOnce([{ ...sibling, CharacterName: '최신캐릭터' }]);
+    mockedFetchProfile.mockResolvedValue({ ...profile, CharacterName: '최신캐릭터' });
+
+    render(<MemoryRouter><Simulation /></MemoryRouter>);
+    fireEvent.click(screen.getByRole('button', { name: '골드 계산 시작' }));
+    await waitFor(() => expect(mockedFetchSiblings).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: '다른 캐릭터 검색' }));
+
+    await waitFor(() => expect(firstSignal?.aborted).toBe(true));
+    expect(await screen.findByRole('heading', { name: /최신캐릭터.*주간 골드/ })).toBeInTheDocument();
   });
 });

--- a/src/pages/SpecSimulator.test.tsx
+++ b/src/pages/SpecSimulator.test.tsx
@@ -1,14 +1,16 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import SpecSimulator from './SpecSimulator';
+import type { CharacterProfile } from '../types/lostark';
 import { fetchProfile } from '../utils/api';
 
 const longNickname = '모바일에서도아주긴캐릭터닉네임이잘리는일없이표시되어야합니다';
+let mockCurrentSearchParams = new URLSearchParams(`nickname=${longNickname}`);
 
 vi.mock(
   'react-router-dom',
   () => ({
     Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    useSearchParams: () => [new URLSearchParams(`nickname=${longNickname}`), vi.fn()],
+    useSearchParams: () => [mockCurrentSearchParams, vi.fn()],
   }),
   { virtual: true },
 );
@@ -25,6 +27,11 @@ vi.mock('../utils/api', () => ({
 const mockedFetchProfile = vi.mocked(fetchProfile);
 
 describe('SpecSimulator route error guidance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentSearchParams = new URLSearchParams(`nickname=${longNickname}`);
+  });
+
   it('keeps the searched nickname in a wrapping-friendly error heading', async () => {
     mockedFetchProfile.mockRejectedValue(new Error('rate limited'));
 
@@ -44,5 +51,30 @@ describe('SpecSimulator route error guidance', () => {
     expect(await screen.findByRole('status', { name: `${longNickname} 프로필을 찾을 수 없습니다` })).toHaveTextContent(
       '닉네임을 확인한 뒤 다른 캐릭터를 다시 검색해 주세요',
     );
+  });
+
+  it('aborts an outdated profile request and ignores its late response', async () => {
+    let resolveFirst!: (value: CharacterProfile) => void;
+    let firstSignal: AbortSignal | undefined;
+    const oldProfile = { CharacterName: longNickname } as CharacterProfile;
+    const latestProfile = { CharacterName: '최신캐릭터' } as CharacterProfile;
+    mockedFetchProfile
+      .mockImplementationOnce((_nickname, options) => {
+        firstSignal = options?.signal ?? undefined;
+        return new Promise<CharacterProfile>((resolve) => { resolveFirst = resolve; });
+      })
+      .mockResolvedValueOnce(latestProfile);
+
+    const { rerender } = render(<SpecSimulator />);
+    await waitFor(() => expect(mockedFetchProfile).toHaveBeenCalledTimes(1));
+
+    mockCurrentSearchParams = new URLSearchParams('nickname=최신캐릭터');
+    rerender(<SpecSimulator />);
+
+    expect(await screen.findByRole('heading', { name: '최신캐릭터' })).toBeInTheDocument();
+    expect(firstSignal?.aborted).toBe(true);
+
+    await act(async () => { resolveFirst(oldProfile); });
+    expect(screen.queryByRole('heading', { name: longNickname })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/SpecSimulator.tsx
+++ b/src/pages/SpecSimulator.tsx
@@ -41,7 +41,7 @@ const SpecSimulator: React.FC = () => {
       setProfile(null);
       setError(null);
     }
-  }, [urlNickname]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [urlNickname, nickname]);
 
   useEffect(() => {
     if (!nickname) return;
@@ -79,7 +79,6 @@ const SpecSimulator: React.FC = () => {
 
   const handleSearch = (name: string): void => {
     setSearchParams({ nickname: name });
-    setNickname(name);
   };
 
   if (!nickname) {


### PR DESCRIPTION
## 변경 사항
- Character 및 SpecSimulator의 Hook 의존성 예외를 제거했습니다.
- URL 쿼리를 닉네임 변경의 단일 진입점으로 정리했습니다.
- Simulation의 원정대 및 프로필 요청에 AbortController를 적용했습니다.
- 닉네임 변경 시 이전 요청 취소와 늦은 응답 무시를 검증하는 테스트를 추가했습니다.

## 검증
- `yarn test src/pages/Character.test.tsx src/pages/SpecSimulator.test.tsx src/pages/Simulation.test.tsx`
- `yarn typecheck`
- `git diff --check`

Closes #32