### PR TITLE
test: limit Vitest worker concurrency

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,5 +8,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/setupTests.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx,js,jsx}'],
+    // Keep parallelism bounded so UI-heavy jsdom tests do not compete for CPU in CI.
+    maxWorkers: 4,
   },
 });


### PR DESCRIPTION
## Summary
- Limit Vitest parallel workers to 4
- Reduce CPU contention for UI-heavy jsdom tests without removing coverage

## Verification
- `CI=true yarn test` — 54 files, 402 tests passed

Related to #33.