### PR TITLE
feat: 공통 Footer 및 개인정보처리방침 추가

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -60,4 +60,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://lokki.vercel.app/policy</loc>
+    <lastmod>2026-08-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -28,6 +28,7 @@ vi.mock('./pages/Enhancement', () => ({ default: () => <div>Enhancement Page</di
 vi.mock('./pages/Market', () => ({ default: () => <div>Market Page</div> }));
 vi.mock('./pages/Spending', () => ({ default: () => <div>Spending Page</div> }));
 vi.mock('./pages/Changelog', () => ({ default: () => <div>Changelog Page</div> }));
+vi.mock('./pages/Policy', () => ({ default: () => <div>Policy Page</div> }));
 vi.mock('./pages/NotFound', () => ({ default: () => <div>Not Found Page</div> }));
 
 import App from './App';
@@ -65,6 +66,15 @@ test('matches the changelog route to the changelog page', async () => {
 
   expect(await screen.findByText('Changelog Page')).toBeInTheDocument();
   expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
+});
+
+test('matches the policy route and renders the common footer', async () => {
+  mockPathname = '/policy';
+
+  render(<App />);
+
+  expect(await screen.findByText('Policy Page')).toBeInTheDocument();
+  expect(screen.getByRole('contentinfo')).toHaveTextContent('© 2026 로아끼욧. All rights reserved.');
 });
 
 test('falls back to the not found page for unmatched routes', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Footer from './components/Footer';
 import { LoadingIndicator } from './components/Loading';
 import { RouteSeo } from './components/RouteSeo';
 import { ROUTES } from './utils/routes';
@@ -16,6 +17,7 @@ const Enhancement = React.lazy(() => import(/* webpackChunkName: "route-enhancem
 const Spending = React.lazy(() => import(/* webpackChunkName: "route-spending" */ './pages/Spending'));
 const Market = React.lazy(() => import(/* webpackChunkName: "route-market" */ './pages/Market'));
 const Changelog = React.lazy(() => import(/* webpackChunkName: "route-changelog" */ './pages/Changelog'));
+const Policy = React.lazy(() => import(/* webpackChunkName: "route-policy" */ './pages/Policy'));
 const NotFound = React.lazy(() => import(/* webpackChunkName: "route-not-found" */ './pages/NotFound'));
 
 const ChunkErrorBanner: React.FC = () => {
@@ -46,31 +48,35 @@ const ChunkErrorBanner: React.FC = () => {
 const AppContent: React.FC = () => {
   return (
     <Router>
-      <div className="min-h-screen font-[Pretendard,sans-serif] bg-gray-50 dark:bg-la-dark transition-colors duration-300">
+      <div className="flex min-h-screen flex-col bg-gray-50 font-[Pretendard,sans-serif] transition-colors duration-300 dark:bg-la-dark">
         <RouteSeo />
         <ChunkErrorBanner />
-        <React.Suspense
-          fallback={
-            <LoadingIndicator
-              message="페이지 불러오는 중..."
-              className="mx-auto mt-8 max-w-7xl"
-            />
-          }
-        >
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/character" element={<Character />} />
-            <Route path="/simulation" element={<Simulation />} />
-            <Route path="/spec-simulator" element={<SpecSimulator />} />
-            <Route path="/expedition" element={<Expedition />} />
-            <Route path="/compare" element={<Compare />} />
-            <Route path="/enhancement" element={<Enhancement />} />
-            <Route path="/market" element={<Market />} />
-            <Route path="/spending" element={<Spending />} />
-            <Route path={ROUTES.changelog} element={<Changelog />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </React.Suspense>
+        <div className="flex flex-1 flex-col [&>div]:min-h-0 [&>div]:flex-1">
+          <React.Suspense
+            fallback={
+              <LoadingIndicator
+                message="페이지 불러오는 중..."
+                className="mx-auto mt-8 max-w-7xl"
+              />
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/character" element={<Character />} />
+              <Route path="/simulation" element={<Simulation />} />
+              <Route path="/spec-simulator" element={<SpecSimulator />} />
+              <Route path="/expedition" element={<Expedition />} />
+              <Route path="/compare" element={<Compare />} />
+              <Route path="/enhancement" element={<Enhancement />} />
+              <Route path="/market" element={<Market />} />
+              <Route path="/spending" element={<Spending />} />
+              <Route path={ROUTES.changelog} element={<Changelog />} />
+              <Route path={ROUTES.policy} element={<Policy />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </React.Suspense>
+        </div>
+        <Footer />
       </div>
     </Router>
   );

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Footer from './Footer';
+
+const renderFooter = () =>
+  render(
+    <MemoryRouter>
+      <Footer />
+    </MemoryRouter>,
+  );
+
+test('renders the service notices and policy link', () => {
+  renderFooter();
+
+  expect(screen.getByText('© 2026 로아끼욧. All rights reserved.')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: '개인정보처리방침' })).toHaveAttribute('href', '/policy');
+  expect(screen.getByText('본 사이트는 Smilegate RPG 및 STOVE의 공식 서비스가 아닙니다.')).toBeInTheDocument();
+  expect(screen.getByText('게임 데이터는 LOST ARK Open API를 기반으로 제공됩니다.')).toBeInTheDocument();
+});
+
+test('opens the Discord invitation in a new tab', () => {
+  renderFooter();
+
+  const discordLink = screen.getByRole('link', { name: 'Discord' });
+  expect(discordLink).toHaveAttribute('href', 'https://discord.gg/xRgvcwt6W');
+  expect(discordLink).toHaveAttribute('target', '_blank');
+  expect(discordLink).toHaveAttribute('rel', 'noopener noreferrer');
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ROUTES } from '../utils/routes';
+
+const Footer: React.FC = () => (
+  <footer className="border-t border-gray-200/70 bg-white/70 px-4 py-6 text-gray-500 transition-colors duration-300 dark:border-white/10 dark:bg-la-dark/70 dark:text-gray-400">
+    <div className="mx-auto flex max-w-7xl flex-col gap-4 text-center text-xs leading-relaxed sm:text-left">
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+        <p className="font-medium text-gray-700 dark:text-gray-300">
+          © 2026 로아끼욧. All rights reserved.
+        </p>
+        <nav aria-label="푸터 링크" className="flex items-center justify-center gap-4 sm:justify-end">
+          <Link
+            to={ROUTES.policy}
+            className="font-medium text-gray-600 transition-colors hover:text-la-gold-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-300 dark:hover:text-la-gold"
+          >
+            개인정보처리방침
+          </Link>
+          <a
+            href="https://discord.gg/xRgvcwt6W"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-gray-600 transition-colors hover:text-la-gold-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-300 dark:hover:text-la-gold"
+          >
+            Discord
+          </a>
+        </nav>
+      </div>
+      <div className="space-y-1 border-t border-gray-200/60 pt-4 dark:border-white/5">
+        <p>본 사이트는 Smilegate RPG 및 STOVE의 공식 서비스가 아닙니다.</p>
+        <p>게임 데이터는 LOST ARK Open API를 기반으로 제공됩니다.</p>
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/constants/routeSeo.json
+++ b/src/constants/routeSeo.json
@@ -86,5 +86,13 @@
     "robots": "index, follow",
     "lastmod": "2026-08-18",
     "priority": "0.6"
+  },
+  {
+    "path": "/policy",
+    "title": "개인정보처리방침 - 로아끼욧",
+    "description": "로아끼욧의 개인정보 처리 항목, 이용 목적, 보관 기준과 이용자 권리를 확인하세요.",
+    "robots": "index, follow",
+    "lastmod": "2026-08-25",
+    "priority": "0.3"
   }
 ]

--- a/src/pages/Policy.test.tsx
+++ b/src/pages/Policy.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Policy from './Policy';
+
+vi.mock('../components/NavBar', () => ({ default: () => <nav>Navigation</nav> }));
+
+test('describes the information handled by the service', () => {
+  render(<Policy />);
+
+  expect(screen.getByRole('heading', { level: 1, name: '개인정보처리방침' })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: '1. 처리하는 정보와 이용 목적' })).toBeInTheDocument();
+  expect(screen.getByText(/캐릭터 닉네임을 처리합니다/)).toBeInTheDocument();
+  expect(screen.getByText(/Vercel Analytics를 통해 처리될 수 있습니다/)).toBeInTheDocument();
+  expect(screen.getByText('시행일: 2026년 8월 25일')).toBeInTheDocument();
+});

--- a/src/pages/Policy.tsx
+++ b/src/pages/Policy.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+import GlassCard from '../components/GlassCard';
+
+const Policy: React.FC = () => (
+  <div className="bg-gray-50 transition-colors duration-300 dark:bg-la-dark">
+    <NavBar />
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">개인정보처리방침</h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          로아끼욧은 이용자의 정보를 안전하게 다루기 위해 다음과 같이 개인정보 처리 기준을 안내합니다.
+        </p>
+        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">시행일: 2026년 8월 25일</p>
+      </header>
+
+      <GlassCard className="space-y-8 p-5 text-sm leading-7 text-gray-700 sm:p-8 dark:text-gray-300">
+        <section aria-labelledby="policy-purpose">
+          <h2 id="policy-purpose" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            1. 처리하는 정보와 이용 목적
+          </h2>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>캐릭터 검색과 서비스 기능 제공을 위해 이용자가 입력한 캐릭터 닉네임을 처리합니다.</li>
+            <li>
+              서비스 품질 개선과 오류 분석을 위해 방문 페이지, 접속 환경, 대략적인 지역 등의 이용 정보가
+              Vercel Analytics를 통해 처리될 수 있습니다.
+            </li>
+            <li>회원가입, 실명, 연락처 또는 결제 정보를 직접 수집하지 않습니다.</li>
+          </ul>
+        </section>
+
+        <section aria-labelledby="policy-storage">
+          <h2 id="policy-storage" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            2. 브라우저 저장 정보
+          </h2>
+          <p>
+            최근 검색한 캐릭터 닉네임, 테마 설정, 시뮬레이션 및 숙제 관리 상태 등은 편의 기능 제공을 위해
+            이용자의 브라우저 저장소에 저장됩니다. 해당 정보는 브라우저의 사이트 데이터 삭제 기능으로
+            언제든지 삭제할 수 있습니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="policy-retention">
+          <h2 id="policy-retention" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            3. 보유 및 파기
+          </h2>
+          <p>
+            캐릭터 조회 정보는 기능 제공 과정에서만 사용하며 별도의 회원 데이터베이스에 저장하지 않습니다.
+            브라우저 저장 정보는 이용자가 삭제할 때까지 보관되며, 분석 정보는 Vercel의 정책에 따라 보관 및
+            삭제됩니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="policy-third-party">
+          <h2 id="policy-third-party" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            4. 외부 서비스 이용
+          </h2>
+          <p>
+            로아끼욧은 캐릭터 및 게임 정보 제공을 위해 LOST ARK Open API를 이용하고, 서비스 배포와 이용 현황
+            분석을 위해 Vercel을 이용합니다. 각 외부 서비스에서 처리되는 정보에는 해당 서비스의 개인정보
+            처리방침이 적용됩니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="policy-rights">
+          <h2 id="policy-rights" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            5. 이용자의 권리
+          </h2>
+          <p>
+            이용자는 브라우저에 저장된 정보를 직접 확인하거나 삭제할 수 있으며, 브라우저 설정 또는 콘텐츠
+            차단 기능을 통해 분석 정보 처리를 제한할 수 있습니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="policy-changes">
+          <h2 id="policy-changes" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            6. 방침 변경
+          </h2>
+          <p>
+            이 방침의 내용이 변경되는 경우 시행 전에 서비스 내 공지 또는 이 페이지를 통해 안내합니다.
+          </p>
+        </section>
+      </GlassCard>
+    </main>
+  </div>
+);
+
+export default Policy;

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -4,6 +4,7 @@
 
 export const ROUTES = {
   changelog: '/changelog',
+  policy: '/policy',
 } as const;
 
 /** 뒤따르는 슬래시를 제거한 경로. 루트('/', '//')는 항상 '/'로 수렴한다. */

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,7 @@
     { "source": "/market", "destination": "/market/index.html" },
     { "source": "/spending", "destination": "/spending/index.html" },
     { "source": "/changelog", "destination": "/changelog/index.html" },
+    { "source": "/policy", "destination": "/policy/index.html" },
     { "source": "/:path*", "destination": "/404.html" }
   ]
 }


### PR DESCRIPTION
## 변경 사항
- 모든 페이지에 공통 Footer를 추가했습니다.
- 서비스 고지 문구와 개인정보처리방침 링크를 추가했습니다.
- Discord 초대 링크를 새 탭으로 연결했습니다.
- `/policy` 개인정보처리방침 페이지와 SEO 정보를 추가했습니다.
- 짧은 페이지에서도 Footer가 화면 하단에 자연스럽게 배치되도록 레이아웃을 조정했습니다.
- `/policy`를 sitemap에 추가했습니다.

## 테스트
- `yarn typecheck`
- `yarn test src/components/Footer.test.tsx src/pages/Policy.test.tsx src/App.test.tsx --run`

Closes #54