### PR TITLE
release: 빠른 메뉴 사용자 설정 배포

### DIFF
--- a/src/components/home/HomeDashboardIntro.test.tsx
+++ b/src/components/home/HomeDashboardIntro.test.tsx
@@ -1,32 +1,241 @@
-import { render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { QUICK_MENU_ORDER_STORAGE_KEY } from './quickMenuOrder';
 import HomeDashboardIntro from './HomeDashboardIntro';
 
-vi.mock(
-  'react-router-dom',
-  () => ({
-    Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
-      <a href={to} {...rest}>{children}</a>
-    ),
-  }),
-  { virtual: true },
+const defaultVisibleTitles = ['주간 골드 계산', '재련 계산', '전투력 시뮬', '시세'];
+const allTitles = [
+  ...defaultVisibleTitles,
+  '캐릭터 비교',
+  '캐릭터 검색',
+  '원정대',
+  '결제 내역',
+];
+
+const renderIntro = () => render(
+  <MemoryRouter>
+    <HomeDashboardIntro
+      activeEventCount={2}
+      calendarGroupCount={3}
+      loadingEvents={false}
+      loadingCalendar={false}
+    />
+  </MemoryRouter>,
+);
+
+const renderedTitles = () => within(screen.getByRole('navigation', { name: /빠른 메뉴/ }))
+  .getAllByRole('heading', { level: 3 })
+  .map((heading) => heading.textContent);
+
+const readStoredState = () => JSON.parse(
+  window.localStorage.getItem(QUICK_MENU_ORDER_STORAGE_KEY) ?? 'null',
 );
 
 describe('HomeDashboardIntro', () => {
-  it('groups the mobile quick menu with visible action affordances', () => {
-    render(
-      <HomeDashboardIntro
-        activeEventCount={2}
-        calendarGroupCount={3}
-        loadingEvents={false}
-        loadingCalendar={false}
-      />,
-    );
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
 
-    expect(screen.getByRole('heading', { name: '성장에 필요한 도구를 한곳에' })).toHaveClass('break-keep');
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(document, 'elementFromPoint');
+  });
+
+  it('renders only the four default visible menus in the requested order', () => {
+    renderIntro();
+
+    expect(renderedTitles()).toEqual(defaultVisibleTitles);
     const quickMenu = screen.getByRole('navigation', { name: '빠른 메뉴' });
     expect(within(quickMenu).getAllByRole('link')).toHaveLength(4);
-    const weeklyGoldLink = within(quickMenu).getByRole('link', { name: /주간 골드 계산/ });
-    expect(within(weeklyGoldLink).getByText('계산하기').parentElement).toHaveClass('opacity-100');
-    expect(within(quickMenu).getByRole('link', { name: /시세 랭킹/ })).toHaveAttribute('href', '/market');
+    expect(within(quickMenu).getByRole('link', { name: /전투력 시뮬/ })).toHaveAttribute('href', '/spec-simulator');
+  });
+
+  it('shows all menus in edit mode and distinguishes visible and hidden cards', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+
+    expect(renderedTitles()).toEqual(allTitles);
+    expect(screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' })).toHaveClass('border-la-gold/50');
+    expect(screen.getByRole('group', { name: '캐릭터 비교, 미노출, 순서 편집' })).toHaveClass('opacity-55');
+    expect(screen.getByRole('button', { name: '주간 골드 계산 미노출로 변경' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '캐릭터 비교 노출로 변경' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('restores the saved order and selected menus', () => {
+    window.localStorage.setItem(QUICK_MENU_ORDER_STORAGE_KEY, JSON.stringify({
+      order: ['/market', '/compare', '/simulation', '/enhancement', '/spec-simulator', '/character', '/expedition', '/spending'],
+      visibleIds: ['/market', '/compare', '/simulation'],
+    }));
+
+    renderIntro();
+
+    expect(renderedTitles()).toEqual(['시세', '캐릭터 비교', '주간 골드 계산']);
+  });
+
+  it.each([
+    ['invalid JSON', '["/market"'],
+    ['an invalid object', JSON.stringify({ order: ['/market'] })],
+  ])('falls back to the default settings for %s', (_label, storedValue) => {
+    window.localStorage.setItem(QUICK_MENU_ORDER_STORAGE_KEY, storedValue);
+
+    renderIntro();
+
+    expect(renderedTitles()).toEqual(defaultVisibleTitles);
+  });
+
+  it('toggles menu visibility and saves the selection', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+
+    userEvent.click(screen.getByRole('button', { name: '캐릭터 비교 노출로 변경' }));
+    userEvent.click(screen.getByRole('button', { name: '주간 골드 계산 미노출로 변경' }));
+    userEvent.click(screen.getByRole('button', { name: '편집 완료' }));
+
+    expect(renderedTitles()).toEqual(['재련 계산', '전투력 시뮬', '시세', '캐릭터 비교']);
+    expect(readStoredState().visibleIds).toEqual([
+      '/enhancement', '/spec-simulator', '/market', '/compare',
+    ]);
+  });
+
+  it('drags the card itself with a mouse pointer', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+    const sourceCard = screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' });
+    const targetCard = screen.getByRole('group', { name: '재련 계산, 노출, 순서 편집' });
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(targetCard),
+    });
+
+    fireEvent.pointerDown(sourceCard, { button: 0, pointerId: 1, pointerType: 'mouse' });
+    const editMenu = screen.getByRole('navigation', { name: '빠른 메뉴 편집' });
+    fireEvent.pointerMove(editMenu, { clientX: 10, clientY: 10, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(editMenu, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(renderedTitles().slice(0, 2)).toEqual(['재련 계산', '주간 골드 계산']);
+    expect(readStoredState().visibleIds.slice(0, 2)).toEqual(['/enhancement', '/simulation']);
+  });
+
+  it('leaves touch scrolling to the browser when movement starts before the long press', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+    const sourceCard = screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' });
+    const scrollBy = vi.spyOn(window, 'scrollBy').mockImplementation(() => {});
+    expect(sourceCard).toHaveClass('touch-pan-y');
+
+    fireEvent.pointerDown(sourceCard, {
+      button: 0, pointerId: 2, pointerType: 'touch', clientX: 10, clientY: 300,
+    });
+    const editMenu = screen.getByRole('navigation', { name: '빠른 메뉴 편집' });
+    fireEvent.pointerMove(editMenu, {
+      pointerId: 2, pointerType: 'touch', clientX: 10, clientY: 260,
+    });
+    fireEvent.pointerUp(editMenu, { pointerId: 2, pointerType: 'touch' });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+    expect(renderedTitles().slice(0, 2)).toEqual(['주간 골드 계산', '재련 계산']);
+  });
+
+  it('starts touch dragging after a long press', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+    vi.useFakeTimers();
+    const sourceCard = screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' });
+    const targetCard = screen.getByRole('group', { name: '재련 계산, 노출, 순서 편집' });
+    const elementFromPoint = vi.fn().mockReturnValue(sourceCard);
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: elementFromPoint,
+    });
+
+    fireEvent.pointerDown(sourceCard, {
+      button: 0, pointerId: 3, pointerType: 'touch', clientX: 10, clientY: 300,
+    });
+    act(() => vi.advanceTimersByTime(350));
+    elementFromPoint.mockReturnValue(targetCard);
+    const editMenu = screen.getByRole('navigation', { name: '빠른 메뉴 편집' });
+    fireEvent.pointerMove(editMenu, {
+      pointerId: 3, pointerType: 'touch', clientX: 10, clientY: 320,
+    });
+    expect(sourceCard).toHaveClass('touch-none');
+    fireEvent.pointerUp(editMenu, { pointerId: 3, pointerType: 'touch' });
+
+    expect(renderedTitles().slice(0, 2)).toEqual(['재련 계산', '주간 골드 계산']);
+    expect(readStoredState().visibleIds.slice(0, 2)).toEqual(['/enhancement', '/simulation']);
+  });
+
+  it('waits before auto-scrolling a dragged touch near the viewport edge', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+    vi.useFakeTimers();
+    const sourceCard = screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' });
+    const scrollBy = vi.spyOn(window, 'scrollBy').mockImplementation(() => {});
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(sourceCard),
+    });
+
+    fireEvent.pointerDown(sourceCard, {
+      button: 0,
+      pointerId: 4,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: window.innerHeight - 30,
+    });
+    act(() => vi.advanceTimersByTime(350));
+    expect(scrollBy).not.toHaveBeenCalled();
+
+    const editMenu = screen.getByRole('navigation', { name: '빠른 메뉴 편집' });
+    fireEvent.pointerMove(editMenu, {
+      pointerId: 4,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: window.innerHeight - 1,
+    });
+    act(() => vi.advanceTimersByTime(190));
+    expect(scrollBy).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(40));
+    fireEvent.pointerUp(editMenu, { pointerId: 4, pointerType: 'touch' });
+
+    expect(scrollBy.mock.calls.some(([, y]) => Number(y) > 0)).toBe(true);
+  });
+
+  it('supports keyboard ordering without rendering arrow buttons', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+    const card = screen.getByRole('group', { name: '주간 골드 계산, 노출, 순서 편집' });
+    card.focus();
+
+    fireEvent.keyDown(card, { key: 'ArrowRight', altKey: true });
+
+    expect(renderedTitles().slice(0, 2)).toEqual(['재련 계산', '주간 골드 계산']);
+    expect(screen.queryByRole('button', { name: /앞으로 이동|뒤로 이동/ })).not.toBeInTheDocument();
+  });
+
+  it('resets order and visibility to the default settings', () => {
+    window.localStorage.setItem(QUICK_MENU_ORDER_STORAGE_KEY, JSON.stringify({
+      order: ['/compare', '/market', '/enhancement', '/simulation'],
+      visibleIds: ['/compare'],
+    }));
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+
+    userEvent.click(screen.getByRole('button', { name: '기본 설정으로 초기화' }));
+    userEvent.click(screen.getByRole('button', { name: '편집 완료' }));
+
+    expect(renderedTitles()).toEqual(defaultVisibleTitles);
+    expect(window.localStorage.getItem(QUICK_MENU_ORDER_STORAGE_KEY)).toBeNull();
+  });
+
+  it('removes every card link while edit mode is active', () => {
+    renderIntro();
+    userEvent.click(screen.getByRole('button', { name: '순서 편집' }));
+
+    expect(within(screen.getByRole('navigation', { name: '빠른 메뉴 편집' })).queryAllByRole('link')).toHaveLength(0);
+    expect(screen.getByText(/편집 모드. 4개 메뉴 노출 중/)).toBeInTheDocument();
   });
 });

--- a/src/components/home/HomeDashboardIntro.tsx
+++ b/src/components/home/HomeDashboardIntro.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import QuickMenu from './QuickMenu';
 
 interface HomeDashboardIntroProps {
   readonly activeEventCount: number;
@@ -7,53 +7,6 @@ interface HomeDashboardIntroProps {
   readonly loadingEvents: boolean;
   readonly loadingCalendar: boolean;
 }
-
-const QUICK_ACTIONS = [
-  {
-    to: '/simulation',
-    title: '주간 골드 계산',
-    description: '주간 골드와 숙제 현황',
-    action: '계산하기',
-    iconBg: 'bg-amber-500/15',
-    iconText: 'text-amber-700 dark:text-amber-400',
-    ctaText: 'text-amber-700 dark:text-amber-400',
-    path: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-    featured: true,
-  },
-  {
-    to: '/enhancement',
-    title: '재련 계산',
-    description: '재료 시세 기반 강화 비용',
-    action: '계산하기',
-    iconBg: 'bg-emerald-500/15',
-    iconText: 'text-emerald-600 dark:text-emerald-400',
-    ctaText: 'text-emerald-600 dark:text-emerald-400',
-    path: 'M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396c.251.023.501.05.75.082M19 14.5l-2.14 3.21a2.25 2.25 0 01-1.873 1.002H9.013A2.25 2.25 0 017.14 17.71L5 14.5m14 0H5',
-    featured: false,
-  },
-  {
-    to: '/market',
-    title: '시세 랭킹',
-    description: '각인서·보석 최저가 순위',
-    action: '랭킹 보기',
-    iconBg: 'bg-la-gold/20',
-    iconText: 'text-la-gold-dark dark:text-la-gold',
-    ctaText: 'text-la-gold-dark dark:text-la-gold',
-    path: 'M3 10h18M7 15h1m4 0h1m4 0h1M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z',
-    featured: false,
-  },
-  {
-    to: '/compare',
-    title: '캐릭터 비교',
-    description: '두 캐릭터 스펙 비교',
-    action: '비교하기',
-    iconBg: 'bg-sky-500/15',
-    iconText: 'text-sky-600 dark:text-sky-400',
-    ctaText: 'text-sky-600 dark:text-sky-400',
-    path: 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3',
-    featured: false,
-  },
-] as const;
 
 const HomeDashboardIntro: React.FC<HomeDashboardIntroProps> = ({
   activeEventCount,
@@ -92,37 +45,7 @@ const HomeDashboardIntro: React.FC<HomeDashboardIntroProps> = ({
       </div>
     </section>
 
-    <section aria-labelledby="home-quick-menu-title" className="animate-fade-in">
-      <div className="mb-4">
-        <h2 id="home-quick-menu-title" className="text-xl font-bold text-gray-900 dark:text-white">빠른 메뉴</h2>
-        <p className="mt-1 break-keep text-sm text-gray-500 dark:text-gray-400">자주 쓰는 성장 도구로 바로 이동합니다.</p>
-      </div>
-      <nav aria-label="빠른 메뉴" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {QUICK_ACTIONS.map((action) => (
-          <Link
-            key={action.to}
-            to={action.to}
-            className={`glass-card group cursor-pointer p-5 text-left transition-all duration-300 hover:border-la-gold/30 hover:shadow-gold-glow dark:hover:border-la-gold/20 ${action.featured ? 'ring-1 ring-la-gold/20' : ''}`}
-          >
-            <div className="mb-3 flex items-center gap-3">
-              <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${action.iconBg}`}>
-                <svg className={`h-5 w-5 ${action.iconText}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" d={action.path} />
-                </svg>
-              </div>
-              <h3 className="text-base font-bold text-gray-900 dark:text-white">{action.title}</h3>
-            </div>
-            <p className="break-keep text-sm leading-relaxed text-gray-500 dark:text-gray-400">{action.description}</p>
-            <div className={`mt-3 flex items-center gap-1 text-sm font-medium opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 ${action.ctaText}`}>
-              <span>{action.action}</span>
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-              </svg>
-            </div>
-          </Link>
-        ))}
-      </nav>
-    </section>
+    <QuickMenu />
   </>
 );
 

--- a/src/components/home/QuickMenu.tsx
+++ b/src/components/home/QuickMenu.tsx
@@ -1,0 +1,449 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import {
+  QuickMenuState,
+  readQuickMenuState,
+  reorderQuickMenuItem,
+  resetQuickMenuState,
+  saveQuickMenuState,
+} from './quickMenuOrder';
+
+const QUICK_ACTIONS = [
+  {
+    to: '/simulation', title: '주간 골드 계산', description: '주간 골드와 숙제 현황', action: '계산하기',
+    iconBg: 'bg-amber-500/15', iconText: 'text-amber-700 dark:text-amber-400', ctaText: 'text-amber-700 dark:text-amber-400',
+    path: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', featured: true,
+  },
+  {
+    to: '/enhancement', title: '재련 계산', description: '재료 시세 기반 강화 비용', action: '계산하기',
+    iconBg: 'bg-emerald-500/15', iconText: 'text-emerald-600 dark:text-emerald-400', ctaText: 'text-emerald-600 dark:text-emerald-400',
+    path: 'M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396c.251.023.501.05.75.082M19 14.5l-2.14 3.21a2.25 2.25 0 01-1.873 1.002H9.013A2.25 2.25 0 017.14 17.71L5 14.5m14 0H5', featured: false,
+  },
+  {
+    to: '/spec-simulator', title: '전투력 시뮬', description: '장비와 세팅별 전투력 비교', action: '시뮬하기',
+    iconBg: 'bg-violet-500/15', iconText: 'text-violet-600 dark:text-violet-400', ctaText: 'text-violet-600 dark:text-violet-400',
+    path: 'M13 10V3L4 14h7v7l9-11h-7z', featured: false,
+  },
+  {
+    to: '/market', title: '시세', description: '각인서·보석 최저가 순위', action: '시세 보기',
+    iconBg: 'bg-la-gold/20', iconText: 'text-la-gold-dark dark:text-la-gold', ctaText: 'text-la-gold-dark dark:text-la-gold',
+    path: 'M3 10h18M7 15h1m4 0h1m4 0h1M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z', featured: false,
+  },
+  {
+    to: '/compare', title: '캐릭터 비교', description: '두 캐릭터 스펙 비교', action: '비교하기',
+    iconBg: 'bg-sky-500/15', iconText: 'text-sky-600 dark:text-sky-400', ctaText: 'text-sky-600 dark:text-sky-400',
+    path: 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3', featured: false,
+  },
+  {
+    to: '/character', title: '캐릭터 검색', description: '캐릭터 정보와 장비 확인', action: '검색하기',
+    iconBg: 'bg-cyan-500/15', iconText: 'text-cyan-600 dark:text-cyan-400', ctaText: 'text-cyan-600 dark:text-cyan-400',
+    path: 'M15.75 15.75L19.5 19.5m-1.5-8.25a6.75 6.75 0 11-13.5 0 6.75 6.75 0 0113.5 0z', featured: false,
+  },
+  {
+    to: '/expedition', title: '원정대', description: '원정대 캐릭터를 한눈에 확인', action: '확인하기',
+    iconBg: 'bg-rose-500/15', iconText: 'text-rose-600 dark:text-rose-400', ctaText: 'text-rose-600 dark:text-rose-400',
+    path: 'M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.941 3.198v.001c0 .504-.123.996-.36 1.432A9.056 9.056 0 0112 21c-2.1 0-4.034-.715-5.57-1.915A3 3 0 019 16.5m9 2.22a3 3 0 00-.941-3.198M15 9.75a3 3 0 11-6 0 3 3 0 016 0z', featured: false,
+  },
+  {
+    to: '/spending', title: '결제 내역', description: '결제 내역과 소비 현황 관리', action: '확인하기',
+    iconBg: 'bg-fuchsia-500/15', iconText: 'text-fuchsia-600 dark:text-fuchsia-400', ctaText: 'text-fuchsia-600 dark:text-fuchsia-400',
+    path: 'M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.75A.75.75 0 013 4.5h.75m0 0h12m0 0h.75a.75.75 0 01.75.75V6m0 0v.75a.75.75 0 01-.75.75h-.75m0-3H3.75M6 12h9', featured: false,
+  },
+] as const;
+
+type QuickAction = (typeof QUICK_ACTIONS)[number];
+const DEFAULT_ACTION_IDS = QUICK_ACTIONS.map((action) => action.to);
+const DEFAULT_VISIBLE_IDS = ['/simulation', '/enhancement', '/spec-simulator', '/market'];
+const ACTIONS_BY_ID = new Map<string, QuickAction>(QUICK_ACTIONS.map((action) => [action.to, action]));
+const TOUCH_LONG_PRESS_DELAY_MS = 350;
+const TOUCH_SCROLL_CANCEL_THRESHOLD_PX = 8;
+const TOUCH_DRAG_START_THRESHOLD_PX = 12;
+const EDGE_SCROLL_ZONE_PX = 64;
+const EDGE_SCROLL_DWELL_MS = 200;
+const MAX_EDGE_SCROLL_PX = 8;
+const REORDER_COOLDOWN_MS = 120;
+
+const CardContents: React.FC<{ readonly action: QuickAction }> = ({ action }) => (
+  <>
+    <div className="mb-3 flex items-center gap-3">
+      <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${action.iconBg}`}>
+        <svg className={`h-5 w-5 ${action.iconText}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d={action.path} />
+        </svg>
+      </div>
+      <h3 className="text-base font-bold text-gray-900 dark:text-white">{action.title}</h3>
+    </div>
+    <p className="break-keep text-sm leading-relaxed text-gray-500 dark:text-gray-400">{action.description}</p>
+    <div className={`mt-3 flex items-center gap-1 text-sm font-medium opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 ${action.ctaText}`}>
+      <span>{action.action}</span>
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </div>
+  </>
+);
+
+const QuickMenu: React.FC = () => {
+  const [menuState, setMenuState] = useState<QuickMenuState>(() =>
+    readQuickMenuState(DEFAULT_ACTION_IDS, DEFAULT_VISIBLE_IDS));
+  const [isEditing, setIsEditing] = useState(false);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const menuStateRef = useRef(menuState);
+  const draggedIdRef = useRef<string | null>(null);
+  const dragTargetIdRef = useRef<string | null>(null);
+  const touchPointerIdRef = useRef<number | null>(null);
+  const touchCandidateIdRef = useRef<string | null>(null);
+  const touchStartPointRef = useRef<{ x: number; y: number } | null>(null);
+  const touchLongPressReadyRef = useRef(false);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dragPointerRef = useRef<{ x: number; y: number } | null>(null);
+  const autoScrollFrameRef = useRef<number | null>(null);
+  const edgeScrollDirectionRef = useRef<-1 | 0 | 1>(0);
+  const edgeScrollEnteredAtRef = useRef<number | null>(null);
+  const lastReorderAtRef = useRef(Number.NEGATIVE_INFINITY);
+  const visibleSet = new Set(menuState.visibleIds);
+
+  const updateMenuState = (updater: (current: QuickMenuState) => QuickMenuState) => {
+    const next = updater(menuStateRef.current);
+    if (next === menuStateRef.current) return;
+
+    menuStateRef.current = next;
+    setMenuState(next);
+    saveQuickMenuState(next);
+  };
+
+  const moveTo = (movingId: string, targetId: string) => {
+    updateMenuState((current) => {
+      const order = reorderQuickMenuItem(current.order, movingId, targetId);
+      if (order.every((id, index) => id === current.order[index])) return current;
+      const currentVisibleSet = new Set(current.visibleIds);
+      return { order, visibleIds: order.filter((id) => currentVisibleSet.has(id)) };
+    });
+  };
+
+  const moveBy = (id: string, offset: -1 | 1) => {
+    const currentOrder = menuStateRef.current.order;
+    const currentIndex = currentOrder.indexOf(id);
+    const targetId = currentOrder[currentIndex + offset];
+    if (targetId) moveTo(id, targetId);
+  };
+
+  const toggleVisibility = (id: string) => {
+    updateMenuState((current) => {
+      const nextVisibleSet = new Set(current.visibleIds);
+      if (nextVisibleSet.has(id)) nextVisibleSet.delete(id);
+      else nextVisibleSet.add(id);
+      return { ...current, visibleIds: current.order.filter((menuId) => nextVisibleSet.has(menuId)) };
+    });
+  };
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current === null) return;
+    clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = null;
+  };
+
+  const stopAutoScroll = () => {
+    if (autoScrollFrameRef.current !== null) cancelAnimationFrame(autoScrollFrameRef.current);
+    autoScrollFrameRef.current = null;
+    edgeScrollDirectionRef.current = 0;
+    edgeScrollEnteredAtRef.current = null;
+  };
+
+  const resetTouchCandidate = () => {
+    clearLongPressTimer();
+    touchPointerIdRef.current = null;
+    touchCandidateIdRef.current = null;
+    touchStartPointRef.current = null;
+    touchLongPressReadyRef.current = false;
+  };
+
+  const stopDragging = () => {
+    resetTouchCandidate();
+    stopAutoScroll();
+    draggedIdRef.current = null;
+    dragTargetIdRef.current = null;
+    dragPointerRef.current = null;
+    setDraggedId(null);
+  };
+
+  const updateDragTarget = (clientX: number, clientY: number) => {
+    const movingId = draggedIdRef.current;
+    if (!movingId) return;
+
+    const target = document.elementFromPoint(clientX, clientY)?.closest<HTMLElement>('[data-quick-menu-id]');
+    const targetId = target?.dataset.quickMenuId;
+    if (!targetId) return;
+    if (targetId === movingId) {
+      dragTargetIdRef.current = movingId;
+      return;
+    }
+    if (targetId === dragTargetIdRef.current) return;
+
+    const now = performance.now();
+    if (now - lastReorderAtRef.current < REORDER_COOLDOWN_MS) return;
+
+    const currentOrder = menuStateRef.current.order;
+    const movingIndex = currentOrder.indexOf(movingId);
+    const targetIndex = currentOrder.indexOf(targetId);
+    if (movingIndex < 0 || targetIndex < 0) return;
+
+    const movingElement = Array.from(document.querySelectorAll<HTMLElement>('[data-quick-menu-id]'))
+      .find((element) => element.dataset.quickMenuId === movingId);
+    if (!movingElement) return;
+
+    const movingRect = movingElement.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const sameRow = Math.abs(movingRect.top - targetRect.top)
+      < Math.min(movingRect.height, targetRect.height) / 2;
+    const movingForward = movingIndex < targetIndex;
+    const crossedTargetCenter = sameRow
+      ? (movingForward
+        ? clientX >= targetRect.left + targetRect.width / 2
+        : clientX <= targetRect.left + targetRect.width / 2)
+      : (movingForward
+        ? clientY >= targetRect.top + targetRect.height / 2
+        : clientY <= targetRect.top + targetRect.height / 2);
+    if (!crossedTargetCenter) return;
+
+    dragTargetIdRef.current = targetId;
+    lastReorderAtRef.current = now;
+    moveTo(movingId, targetId);
+  };
+
+  const runAutoScroll = () => {
+    const point = dragPointerRef.current;
+    if (!point || !draggedIdRef.current) {
+      autoScrollFrameRef.current = null;
+      return;
+    }
+
+    const direction: -1 | 0 | 1 = point.y < EDGE_SCROLL_ZONE_PX
+      ? -1
+      : point.y > window.innerHeight - EDGE_SCROLL_ZONE_PX ? 1 : 0;
+    const now = performance.now();
+
+    if (direction === 0) {
+      edgeScrollDirectionRef.current = 0;
+      edgeScrollEnteredAtRef.current = null;
+    } else if (direction !== edgeScrollDirectionRef.current) {
+      edgeScrollDirectionRef.current = direction;
+      edgeScrollEnteredAtRef.current = now;
+    } else if (
+      edgeScrollEnteredAtRef.current !== null
+      && now - edgeScrollEnteredAtRef.current >= EDGE_SCROLL_DWELL_MS
+    ) {
+      const edgeDistance = direction < 0
+        ? EDGE_SCROLL_ZONE_PX - point.y
+        : point.y - (window.innerHeight - EDGE_SCROLL_ZONE_PX);
+      const speed = Math.max(1, Math.ceil(
+        MAX_EDGE_SCROLL_PX * Math.min(1, edgeDistance / EDGE_SCROLL_ZONE_PX),
+      ));
+      window.scrollBy(0, direction * speed);
+      updateDragTarget(point.x, point.y);
+    }
+
+    autoScrollFrameRef.current = requestAnimationFrame(runAutoScroll);
+  };
+
+  const beginDragging = (id: string, clientX: number, clientY: number) => {
+    clearLongPressTimer();
+    draggedIdRef.current = id;
+    dragTargetIdRef.current = id;
+    dragPointerRef.current = { x: clientX, y: clientY };
+    lastReorderAtRef.current = Number.NEGATIVE_INFINITY;
+    setDraggedId(id);
+    if (autoScrollFrameRef.current === null) {
+      autoScrollFrameRef.current = requestAnimationFrame(runAutoScroll);
+    }
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLElement>, id: string) => {
+    if (event.button !== 0 || (event.target as Element).closest('button')) return;
+
+    if (event.pointerType !== 'touch') {
+      event.preventDefault();
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      beginDragging(id, event.clientX, event.clientY);
+      return;
+    }
+
+    const pointerId = event.pointerId;
+    touchPointerIdRef.current = pointerId;
+    touchCandidateIdRef.current = id;
+    touchStartPointRef.current = { x: event.clientX, y: event.clientY };
+    touchLongPressReadyRef.current = false;
+    longPressTimerRef.current = setTimeout(() => {
+      if (touchPointerIdRef.current !== pointerId) return;
+      longPressTimerRef.current = null;
+      touchLongPressReadyRef.current = true;
+    }, TOUCH_LONG_PRESS_DELAY_MS);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLElement>) => {
+    if (touchPointerIdRef.current === event.pointerId && !draggedIdRef.current) {
+      const startPoint = touchStartPointRef.current;
+      const candidateId = touchCandidateIdRef.current;
+      if (!startPoint || !candidateId) return;
+
+      const distance = Math.hypot(event.clientX - startPoint.x, event.clientY - startPoint.y);
+      if (!touchLongPressReadyRef.current) {
+        if (distance > TOUCH_SCROLL_CANCEL_THRESHOLD_PX) resetTouchCandidate();
+        return;
+      }
+      if (distance < TOUCH_DRAG_START_THRESHOLD_PX) return;
+
+      event.preventDefault();
+      beginDragging(candidateId, event.clientX, event.clientY);
+      updateDragTarget(event.clientX, event.clientY);
+      return;
+    }
+
+    if (!draggedIdRef.current) return;
+    event.preventDefault();
+    dragPointerRef.current = { x: event.clientX, y: event.clientY };
+    updateDragTarget(event.clientX, event.clientY);
+  };
+
+  useEffect(() => {
+    const preventNativeScrollWhileDragging = (event: TouchEvent) => {
+      if (touchLongPressReadyRef.current || draggedIdRef.current) event.preventDefault();
+    };
+
+    document.addEventListener('touchmove', preventNativeScrollWhileDragging, { passive: false });
+    return () => {
+      document.removeEventListener('touchmove', preventNativeScrollWhileDragging);
+      if (longPressTimerRef.current !== null) clearTimeout(longPressTimerRef.current);
+      if (autoScrollFrameRef.current !== null) cancelAnimationFrame(autoScrollFrameRef.current);
+    };
+  }, []);
+
+  const handleReset = () => {
+    const next: QuickMenuState = {
+      order: [...DEFAULT_ACTION_IDS],
+      visibleIds: [...DEFAULT_VISIBLE_IDS],
+    };
+    resetQuickMenuState();
+    menuStateRef.current = next;
+    setMenuState(next);
+    stopDragging();
+  };
+
+  const toggleEditing = () => {
+    stopDragging();
+    setIsEditing((editing) => !editing);
+  };
+
+  const renderedIds = isEditing
+    ? menuState.order
+    : menuState.order.filter((id) => visibleSet.has(id));
+
+  return (
+    <section aria-labelledby="home-quick-menu-title" className="animate-fade-in">
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="home-quick-menu-title" className="text-xl font-bold text-gray-900 dark:text-white">빠른 메뉴</h2>
+          <p id="quick-menu-edit-instructions" className="mt-1 break-keep text-sm text-gray-500 dark:text-gray-400">
+            {isEditing
+              ? '눈 아이콘으로 노출 여부를 정하고, 카드 전체를 드래그해 순서를 바꾸세요. 터치는 카드를 길게 누른 뒤 이동하고, 키보드는 Alt와 좌우 방향키를 사용합니다.'
+              : '선택한 성장 도구로 바로 이동합니다.'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {isEditing && (
+            <button type="button" onClick={handleReset} className="rounded-lg border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-la-gold dark:border-gray-600 dark:text-gray-300 dark:hover:bg-white/10">
+              기본 설정으로 초기화
+            </button>
+          )}
+          <button type="button" aria-pressed={isEditing} onClick={toggleEditing} className="rounded-lg border border-la-gold/40 bg-la-gold/10 px-3 py-2 text-sm font-bold text-la-gold-dark hover:bg-la-gold/20 focus:outline-none focus:ring-2 focus:ring-la-gold dark:text-la-gold">
+            {isEditing ? '편집 완료' : '순서 편집'}
+          </button>
+        </div>
+      </div>
+      <nav
+        aria-label={isEditing ? '빠른 메뉴 편집' : '빠른 메뉴'}
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+        onPointerMove={handlePointerMove}
+        onPointerUp={stopDragging}
+        onPointerCancel={stopDragging}
+      >
+        {renderedIds.map((id) => {
+          const action = ACTIONS_BY_ID.get(id);
+          if (!action) return null;
+          const isVisible = visibleSet.has(id);
+          const cardClassName = `glass-card group p-5 text-left transition-all duration-300 ${action.featured ? 'ring-1 ring-la-gold/20' : ''}`;
+
+          if (!isEditing) {
+            return (
+              <Link key={id} to={action.to} className={`${cardClassName} cursor-pointer hover:border-la-gold/30 hover:shadow-gold-glow dark:hover:border-la-gold/20`}>
+                <CardContents action={action} />
+              </Link>
+            );
+          }
+
+          return (
+            <div
+              key={id}
+              data-quick-menu-id={id}
+              role="group"
+              tabIndex={0}
+              aria-label={`${action.title}, ${isVisible ? '노출' : '미노출'}, 순서 편집`}
+              aria-describedby="quick-menu-edit-instructions"
+              onKeyDown={(event) => {
+                if (!event.altKey || (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight')) return;
+                event.preventDefault();
+                moveBy(id, event.key === 'ArrowLeft' ? -1 : 1);
+              }}
+              onPointerDown={(event) => handlePointerDown(event, id)}
+              className={`${cardClassName} relative cursor-grab select-none border-dashed pr-14 focus:outline-none focus:ring-2 focus:ring-la-gold active:cursor-grabbing ${draggedId === id ? 'touch-none' : 'touch-pan-y'} ${
+                isVisible
+                  ? 'border-la-gold/50'
+                  : 'border-gray-300 opacity-55 grayscale dark:border-gray-600'
+              } ${draggedId === id ? 'scale-[1.02] shadow-gold-glow ring-2 ring-la-gold' : ''}`}
+            >
+              <div className={isVisible ? '' : 'opacity-70'}>
+                <CardContents action={action} />
+              </div>
+              <button
+                type="button"
+                aria-label={`${action.title} ${isVisible ? '미노출로 변경' : '노출로 변경'}`}
+                aria-pressed={isVisible}
+                title={isVisible ? '빠른 메뉴에서 숨기기' : '빠른 메뉴에 표시하기'}
+                onClick={() => toggleVisibility(id)}
+                className={`absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-la-gold ${
+                  isVisible
+                    ? 'border-la-gold/40 bg-la-gold/15 text-la-gold-dark dark:text-la-gold'
+                    : 'border-gray-300 bg-gray-100 text-gray-400 dark:border-gray-600 dark:bg-white/5 dark:text-gray-500'
+                }`}
+              >
+                {isVisible ? (
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12s3.75-6.75 9.75-6.75S21.75 12 21.75 12 18 18.75 12 18.75 2.25 12 2.25 12z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                ) : (
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18M10.6 10.7A2 2 0 0012 14a2 2 0 001.3-.5M9.9 5.5A10.8 10.8 0 0112 5.25c6 0 9.75 6.75 9.75 6.75a17 17 0 01-2.1 2.8M6.2 6.2C3.7 8.1 2.25 12 2.25 12S6 18.75 12 18.75a9.8 9.8 0 004.1-.9" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </nav>
+      {!isEditing && renderedIds.length === 0 && (
+        <p className="rounded-xl border border-dashed border-gray-300 p-5 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+          노출할 빠른 메뉴가 없습니다. 순서 편집에서 메뉴를 선택해 주세요.
+        </p>
+      )}
+      <p className="sr-only" aria-live="polite">
+        {isEditing
+          ? `편집 모드. ${menuState.visibleIds.length}개 메뉴 노출 중.`
+          : `일반 탐색 모드. ${menuState.visibleIds.length}개 메뉴 노출 중.`}
+      </p>
+    </section>
+  );
+};
+
+export default QuickMenu;

--- a/src/components/home/quickMenuOrder.test.ts
+++ b/src/components/home/quickMenuOrder.test.ts
@@ -1,0 +1,59 @@
+import { reconcileQuickMenuState, reorderQuickMenuItem } from './quickMenuOrder';
+
+const defaultIds = ['/simulation', '/enhancement', '/spec-simulator', '/market', '/new-menu'];
+const defaultVisibleIds = ['/simulation', '/enhancement', '/spec-simulator', '/market'];
+
+describe('quickMenuOrder', () => {
+  it('ignores deleted IDs and appends new menus to the editable order', () => {
+    const storedValue = JSON.stringify({
+      order: ['/removed-menu', '/market', '/simulation'],
+      visibleIds: ['/removed-menu', '/market'],
+    });
+
+    expect(reconcileQuickMenuState(defaultIds, defaultVisibleIds, storedValue)).toEqual({
+      order: ['/market', '/simulation', '/enhancement', '/spec-simulator', '/new-menu'],
+      visibleIds: ['/market'],
+    });
+  });
+
+  it('keeps every current menu once when storage contains duplicates and unknown values', () => {
+    const storedValue = JSON.stringify({
+      order: ['/market', '/market', '/unknown', 1],
+      visibleIds: ['/market', '/market', '/unknown'],
+    });
+
+    expect(reconcileQuickMenuState(defaultIds, defaultVisibleIds, storedValue)).toEqual({
+      order: ['/market', '/simulation', '/enhancement', '/spec-simulator', '/new-menu'],
+      visibleIds: ['/market'],
+    });
+  });
+
+  it('falls back safely when stored JSON is malformed', () => {
+    expect(reconcileQuickMenuState(defaultIds, defaultVisibleIds, '{')).toEqual({
+      order: defaultIds,
+      visibleIds: defaultVisibleIds,
+    });
+  });
+
+  it('migrates the previous array format as the visible menu selection', () => {
+    expect(reconcileQuickMenuState(defaultIds, defaultVisibleIds, JSON.stringify(['/market', '/simulation']))).toEqual({
+      order: ['/market', '/simulation', '/enhancement', '/spec-simulator', '/new-menu'],
+      visibleIds: ['/market', '/simulation'],
+    });
+  });
+
+  it('allows an intentionally empty visible selection', () => {
+    const storedValue = JSON.stringify({ order: defaultIds, visibleIds: [] });
+
+    expect(reconcileQuickMenuState(defaultIds, defaultVisibleIds, storedValue).visibleIds).toEqual([]);
+  });
+
+  it('reorders one menu relative to another without mutating the original order', () => {
+    const ids = ['/simulation', '/enhancement', '/market'];
+
+    expect(reorderQuickMenuItem(ids, '/simulation', '/enhancement')).toEqual([
+      '/enhancement', '/simulation', '/market',
+    ]);
+    expect(ids).toEqual(['/simulation', '/enhancement', '/market']);
+  });
+});

--- a/src/components/home/quickMenuOrder.ts
+++ b/src/components/home/quickMenuOrder.ts
@@ -1,0 +1,105 @@
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+export const QUICK_MENU_ORDER_STORAGE_KEY = 'homeQuickMenuOrder';
+
+export interface QuickMenuState {
+  readonly order: string[];
+  readonly visibleIds: string[];
+}
+
+const reconcileIds = (defaultIds: readonly string[], candidates: unknown): string[] => {
+  const knownIds = new Set(defaultIds);
+  const seenIds = new Set<string>();
+  const reconciledIds: string[] = [];
+
+  if (Array.isArray(candidates)) {
+    candidates.forEach((id) => {
+      if (typeof id === 'string' && knownIds.has(id) && !seenIds.has(id)) {
+        seenIds.add(id);
+        reconciledIds.push(id);
+      }
+    });
+  }
+
+  defaultIds.forEach((id) => {
+    if (!seenIds.has(id)) reconciledIds.push(id);
+  });
+
+  return reconciledIds;
+};
+
+export const reconcileQuickMenuState = (
+  defaultIds: readonly string[],
+  defaultVisibleIds: readonly string[],
+  storedValue: string | null,
+): QuickMenuState => {
+  let storedState: unknown;
+
+  try {
+    storedState = storedValue === null ? null : JSON.parse(storedValue);
+  } catch {
+    storedState = null;
+  }
+
+  if (Array.isArray(storedState)) {
+    const order = reconcileIds(defaultIds, storedState);
+    const storedVisibleIds = new Set(
+      storedState.filter((id): id is string => typeof id === 'string' && defaultIds.includes(id)),
+    );
+    return { order, visibleIds: order.filter((id) => storedVisibleIds.has(id)) };
+  }
+
+  if (!storedState || typeof storedState !== 'object') {
+    return {
+      order: [...defaultIds],
+      visibleIds: defaultIds.filter((id) => defaultVisibleIds.includes(id)),
+    };
+  }
+
+  const candidate = storedState as { order?: unknown; visibleIds?: unknown };
+  if (!Array.isArray(candidate.order) || !Array.isArray(candidate.visibleIds)) {
+    return {
+      order: [...defaultIds],
+      visibleIds: defaultIds.filter((id) => defaultVisibleIds.includes(id)),
+    };
+  }
+
+  const order = reconcileIds(defaultIds, candidate.order);
+  const visibleSet = new Set(
+    candidate.visibleIds.filter((id): id is string => typeof id === 'string' && defaultIds.includes(id)),
+  );
+
+  return { order, visibleIds: order.filter((id) => visibleSet.has(id)) };
+};
+
+export const readQuickMenuState = (
+  defaultIds: readonly string[],
+  defaultVisibleIds: readonly string[],
+): QuickMenuState => reconcileQuickMenuState(
+  defaultIds,
+  defaultVisibleIds,
+  safeLocalStorage.getItem(QUICK_MENU_ORDER_STORAGE_KEY),
+);
+
+export const saveQuickMenuState = (state: QuickMenuState): void => {
+  safeLocalStorage.setItem(QUICK_MENU_ORDER_STORAGE_KEY, JSON.stringify(state));
+};
+
+export const resetQuickMenuState = (): void => {
+  safeLocalStorage.removeItem(QUICK_MENU_ORDER_STORAGE_KEY);
+};
+
+export const reorderQuickMenuItem = (
+  ids: readonly string[],
+  movingId: string,
+  targetId: string,
+): string[] => {
+  const fromIndex = ids.indexOf(movingId);
+  const toIndex = ids.indexOf(targetId);
+  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return [...ids];
+
+  const reorderedIds = [...ids];
+  const [movedId] = reorderedIds.splice(fromIndex, 1);
+  reorderedIds.splice(toIndex, 0, movedId);
+  return reorderedIds;
+};


### PR DESCRIPTION
## 포함 변경 사항

- #58
- 메인 빠른 메뉴 노출 여부 및 순서 사용자 설정 지원
- 마우스·터치·키보드 재정렬 지원
- 모바일 롱프레스 드래그와 가장자리 자동 스크롤 지원
- `localStorage` 기반 설정 저장·복원·초기화 및 저장 데이터 병합

## 검증

- 관련 자동화 테스트 통과
- TypeScript 타입 검사 통과
- Vercel Preview 및 `test-and-build` 통과
- iPhone Chrome PWA에서 터치·스크롤·드래그 셀프 QA PASS

## 배포 범위

- base: `main`
- head: `preview`
