### PR TITLE
feat: 화면 인식 기반 보유 재료 입력 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "node": "24.x"
   },
   "dependencies": {
+    "@techstark/opencv-js": "5.0.0-release.1",
     "@vercel/analytics": "^2.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "7.18.2",
+    "tesseract.js": "7.0.0",
     "web-vitals": "^2.1.0"
   },
   "scripts": {

--- a/src/components/enhancement/EnhancementMaterialsSection.tsx
+++ b/src/components/enhancement/EnhancementMaterialsSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import GlassCard from '../GlassCard';
 import StateFeedback from '../StateFeedback';
 import { formatGold, MARKET_SEARCH } from './enhancementModel';
+import MaterialScreenCapture from './material-recognition/MaterialScreenCapture';
 import type { EnhancementPageModel } from './useEnhancementPage';
 
 const EnhancementMaterialsSection: React.FC<{ model: EnhancementPageModel }> = ({ model }) => {
@@ -41,6 +42,13 @@ const EnhancementMaterialsSection: React.FC<{ model: EnhancementPageModel }> = (
             </button>
             {showOwnedSection && (
               <div className="mt-3 space-y-3 overflow-hidden">
+                <MaterialScreenCapture
+                  icons={icons}
+                  targetMaterials={Array.from(shortfallData.keys())}
+                  onApply={(recognized) => {
+                    setOwnedMaterials((previous) => ({ ...previous, ...recognized }));
+                  }}
+                />
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2">
                   {Array.from(shortfallData.keys()).map((type) => (
                     <div key={type} className="flex items-center gap-2">

--- a/src/components/enhancement/EnhancementResultsSection.tsx
+++ b/src/components/enhancement/EnhancementResultsSection.tsx
@@ -1,9 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import GlassCard from '../GlassCard';
 import { formatGold, formatSilver } from './enhancementModel';
 import type { EnhancementPageModel } from './useEnhancementPage';
 
-const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ model }) => {
+interface EnhancementResultsSectionProps {
+  model: EnhancementPageModel;
+  section?: 'all' | 'summary' | 'details';
+}
+
+const EnhancementResultsSection: React.FC<EnhancementResultsSectionProps> = ({
+  model,
+  section = 'all',
+}) => {
+  const [isStepCostsOpen, setIsStepCostsOpen] = useState(true);
+  const showSummary = section !== 'details';
+  const showDetails = section !== 'summary';
   const {
     advLevelMap,
     advTargetMap,
@@ -30,7 +41,7 @@ const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ 
         {hasAnyResult && (
           <>
             {/* ── 합산 견적 ── */}
-            <GlassCard className="p-4 border border-la-gold/20">
+            {showSummary && <GlassCard className="p-4 border border-la-gold/20">
               <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
                 강화 견적 합계{hasOwnedInput && hasPrices && <span className="ml-1 font-normal text-orange-500 dark:text-orange-400">(추가 구매 기준)</span>}
               </h2>
@@ -69,11 +80,53 @@ const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ 
                   )}
                 </div>
               </div>
-            </GlassCard>
+            </GlassCard>}
 
+            {showDetails && <>
             {/* ── 일반 재련 섹션 ── */}
             {hasResult && (
               <>
+            {/* ── 예상 총 비용 요약 ── */}
+            <GlassCard className="p-4">
+              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
+                예상 총 비용{activeSlots.length >= 2 ? ' (전체)' : ''}
+              </h2>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">총 기대 시도</p>
+                  <p className="text-xl font-bold text-gray-900 dark:text-white">
+                    {totals.exp.toFixed(1)}
+                    <span className="text-sm font-normal text-gray-400 ml-0.5">트</span>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">직접 골드</p>
+                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
+                    {formatGold(totals.directGold)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">
+                    {hasOwnedInput ? '추가 재료비' : '재료 비용'}
+                  </p>
+                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
+                    {hasPrices ? formatGold(hasOwnedInput ? normalShortfallMatGold : totals.matGold) : '—'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">합계</p>
+                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
+                    {hasPrices ? formatGold(totals.directGold + (hasOwnedInput ? normalShortfallMatGold : totals.matGold)) : '—'}
+                  </p>
+                  {totals.silver > 0 && (
+                    <p className="text-[11px] text-gray-400 mt-0.5">
+                      실링 {formatSilver(Math.round(totals.silver))}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </GlassCard>
+
             {/* ── 슬롯별 소계 (2개 이상 선택 시) ── */}
             {activeSlots.length >= 2 && (
               <GlassCard className="p-4">
@@ -121,50 +174,20 @@ const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ 
               </GlassCard>
             )}
 
-            {/* ── 예상 총 비용 요약 ── */}
-            <GlassCard className="p-4">
-              <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-3">
-                예상 총 비용{activeSlots.length >= 2 ? ' (전체)' : ''}
-              </h2>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                <div>
-                  <p className="text-xs text-gray-400 mb-0.5">총 기대 시도</p>
-                  <p className="text-xl font-bold text-gray-900 dark:text-white">
-                    {totals.exp.toFixed(1)}
-                    <span className="text-sm font-normal text-gray-400 ml-0.5">트</span>
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-gray-400 mb-0.5">직접 골드</p>
-                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
-                    {formatGold(totals.directGold)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-gray-400 mb-0.5">
-                    {hasOwnedInput ? '추가 재료비' : '재료 비용'}
-                  </p>
-                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
-                    {hasPrices ? formatGold(hasOwnedInput ? normalShortfallMatGold : totals.matGold) : '—'}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-gray-400 mb-0.5">합계</p>
-                  <p className="text-xl font-bold text-la-gold-dark dark:text-la-gold">
-                    {hasPrices ? formatGold(totals.directGold + (hasOwnedInput ? normalShortfallMatGold : totals.matGold)) : '—'}
-                  </p>
-                  {totals.silver > 0 && (
-                    <p className="text-[11px] text-gray-400 mt-0.5">
-                      실링 {formatSilver(Math.round(totals.silver))}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </GlassCard>
-
             {/* ── 단계별 테이블 ── */}
             <GlassCard className="overflow-hidden p-0">
-              <div className="overflow-x-auto">
+              <button
+                type="button"
+                onClick={() => setIsStepCostsOpen((current) => !current)}
+                aria-expanded={isStepCostsOpen}
+                className="flex w-full items-center justify-between px-4 py-3 text-left"
+              >
+                <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">단계 별 비용</span>
+                <span aria-hidden="true" className="text-xs text-gray-400 dark:text-gray-500">
+                  {isStepCostsOpen ? '▲' : '▼'}
+                </span>
+              </button>
+              {isStepCostsOpen && <div className="overflow-x-auto border-t border-gray-200/50 dark:border-white/8">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-gray-200/50 dark:border-white/8">
@@ -217,7 +240,7 @@ const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ 
                     })}
                   </tbody>
                 </table>
-              </div>
+              </div>}
             </GlassCard>
               </>
             )}
@@ -291,6 +314,7 @@ const EnhancementResultsSection: React.FC<{ model: EnhancementPageModel }> = ({ 
                 </GlassCard>
               </>
             )}
+            </>}
           </>
         )}
     </>

--- a/src/components/enhancement/EnhancementView.tsx
+++ b/src/components/enhancement/EnhancementView.tsx
@@ -12,8 +12,9 @@ const EnhancementView: React.FC<{ model: EnhancementPageModel }> = ({ model }) =
     <main className="enhancement-page max-w-4xl mx-auto px-4 py-6 space-y-5">
       <EnhancementCharacterSection model={model} />
       <EnhancementSettingsSection model={model} />
-      <EnhancementResultsSection model={model} />
+      <EnhancementResultsSection model={model} section="summary" />
       <EnhancementMaterialsSection model={model} />
+      <EnhancementResultsSection model={model} section="details" />
     </main>
   </div>
 );

--- a/src/components/enhancement/enhancementModel.ts
+++ b/src/components/enhancement/enhancementModel.ts
@@ -42,6 +42,7 @@ export const ADV_TARGET_OPTIONS = [10, 20, 30, 40].map((level) => ({
 
 export interface MarketConfig {
   searchName: string;
+  itemName?: string;
   itemsPerUnit?: number;
   categoryCode?: number;
   extraParams?: Record<string, unknown>;
@@ -67,7 +68,7 @@ export const MARKET_SEARCH: Record<MaterialType, MarketConfig> = {
   // 세르카 방어구
   '운명의 수호석 결정':    { searchName: '운명의 수호석 결정' },
   '위대한 운명의 돌파석':  { searchName: '위대한 운명의 돌파석' },
-  '상급 아비도스 융화':    { searchName: '상급 아비도스 융화' },
+  '상급 아비도스 융화':    { searchName: '상급 아비도스 융화', itemName: '상급 아비도스 융화 재료' },
   // 세르카 무기
   '운명의 파괴석 결정':    { searchName: '운명의 파괴석 결정' },
   // 방어구 상급 재련 책

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
@@ -146,7 +146,7 @@ describe('MaterialScreenCapture', () => {
     expect(screen.getByRole('button', { name: '보유 재료에 적용' })).toBeDisabled();
   });
 
-  it('allows review and applies only accepted corrected results', () => {
+  it('applies corrected results and preserves a recognized zero quantity', () => {
     const onApply = vi.fn();
     mockedUseMaterialScreenCapture.mockReturnValue({
       status: 'review',
@@ -165,7 +165,7 @@ describe('MaterialScreenCapture', () => {
     fireEvent.change(screen.getByLabelText('수호석 인식 수량'), { target: { value: '1500' } });
     fireEvent.click(screen.getByRole('button', { name: '보유 재료에 적용' }));
 
-    expect(onApply).toHaveBeenCalledWith({ 수호석: 1500 });
+    expect(onApply).toHaveBeenCalledWith({ 수호석: 1500, 파괴석: 0 });
     expect(reset).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { MaterialType } from '../../../data/enhancement';
+import MaterialScreenCapture from './MaterialScreenCapture';
+import { useMaterialScreenCapture } from './useMaterialScreenCapture';
+
+vi.mock('./useMaterialScreenCapture', () => ({
+  useMaterialScreenCapture: vi.fn(),
+}));
+
+const mockedUseMaterialScreenCapture = vi.mocked(useMaterialScreenCapture);
+const start = vi.fn();
+const stop = vi.fn();
+const reset = vi.fn();
+
+const renderCapture = (onApply = vi.fn()) => render(
+  <MaterialScreenCapture
+    icons={{ 수호석: '/guardian.png' }}
+    targetMaterials={['수호석']}
+    onApply={onApply}
+  />,
+);
+
+describe('MaterialScreenCapture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseMaterialScreenCapture.mockReturnValue({
+      status: 'idle',
+      error: null,
+      results: [],
+      scanCount: 0,
+      start,
+      stop,
+      reset,
+    });
+  });
+
+  it('starts screen capture without offering a file upload', () => {
+    renderCapture();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Lost Ark 화면에서 자동 불러오기' }));
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(screen.queryByLabelText(/파일/)).not.toBeInTheDocument();
+  });
+
+  it('includes fate shards for top-bar or honing-window recognition', () => {
+    render(
+      <MaterialScreenCapture
+        icons={{ 수호석: '/guardian.png' }}
+        targetMaterials={['수호석', '운명의 파편']}
+        onApply={vi.fn()}
+      />,
+    );
+
+    expect(mockedUseMaterialScreenCapture).toHaveBeenCalledWith(expect.objectContaining({
+      targetMaterials: ['수호석', '운명의 파편'],
+    }));
+    expect(screen.getByText(/운명의 파편은 게임 상단 바를 먼저 확인하고.*소지 금액 첫 번째 값을 읽습니다/)).toBeInTheDocument();
+  });
+
+  it('shows recognized materials while sharing and lets the user stop', () => {
+    mockedUseMaterialScreenCapture.mockReturnValue({
+      status: 'sharing',
+      error: null,
+      results: [
+        {
+          material: '운명의 파괴석 결정' as MaterialType,
+          quantity: 950870,
+          confidence: 0.65,
+          needsReview: true,
+        },
+      ],
+      scanCount: 2,
+      start,
+      stop,
+      reset,
+    });
+    renderCapture();
+
+    expect(screen.getByText('인식 결과 확인')).toBeInTheDocument();
+    expect(screen.getByText('운명의 파괴석 결정')).toHaveTextContent('확인 필요');
+    expect(screen.getByText('950,870')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '화면 공유 중지' }));
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('does not apply a capped honing value unless the user accepts it', () => {
+    const onApply = vi.fn();
+    mockedUseMaterialScreenCapture.mockReturnValue({
+      status: 'review',
+      error: null,
+      results: [
+        {
+          material: '파괴석' as MaterialType,
+          quantity: 9999,
+          confidence: 0.95,
+          needsReview: true,
+          needsTooltip: true,
+          source: 'honing',
+        },
+        {
+          material: '돌파석' as MaterialType,
+          quantity: 879,
+          confidence: 0.9,
+          needsReview: false,
+          source: 'honing',
+        },
+      ],
+      scanCount: 1,
+      start,
+      stop,
+      reset,
+    });
+    renderCapture(onApply);
+
+    expect(screen.getByText('파괴석')).toHaveTextContent('툴팁 확인 필요');
+    fireEvent.click(screen.getByRole('button', { name: '보유 재료에 적용' }));
+
+    expect(onApply).toHaveBeenCalledWith({ 돌파석: 879 });
+  });
+
+  it('does not allow an unchanged capped value to be applied after re-including it', () => {
+    mockedUseMaterialScreenCapture.mockReturnValue({
+      status: 'review',
+      error: null,
+      results: [{
+        material: '파괴석' as MaterialType,
+        quantity: 9999,
+        confidence: 0.95,
+        needsReview: true,
+        needsTooltip: true,
+        source: 'honing',
+      }],
+      scanCount: 1,
+      start,
+      stop,
+      reset,
+    });
+    renderCapture();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: '보유 재료에 적용' })).toBeDisabled();
+  });
+
+  it('allows review and applies only accepted corrected results', () => {
+    const onApply = vi.fn();
+    mockedUseMaterialScreenCapture.mockReturnValue({
+      status: 'review',
+      error: null,
+      results: [
+        { material: '수호석' as MaterialType, quantity: 1200, confidence: 0.92, needsReview: false },
+        { material: '파괴석' as MaterialType, quantity: 0, confidence: 0.4, needsReview: true },
+      ],
+      scanCount: 3,
+      start,
+      stop,
+      reset,
+    });
+    renderCapture(onApply);
+
+    fireEvent.change(screen.getByLabelText('수호석 인식 수량'), { target: { value: '1500' } });
+    fireEvent.click(screen.getByRole('button', { name: '보유 재료에 적용' }));
+
+    expect(onApply).toHaveBeenCalledWith({ 수호석: 1500 });
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx
@@ -141,6 +141,8 @@ describe('MaterialScreenCapture', () => {
 
     fireEvent.click(screen.getByRole('checkbox'));
 
+    expect(screen.getByText('9999로 잘려 표시된 재료는 실제 수량을 입력하거나 적용 대상에서 제외해 주세요.')).toBeInTheDocument();
+    expect(screen.queryByText(/수량은 0 이상/)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '보유 재료에 적용' })).toBeDisabled();
   });
 

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
@@ -39,6 +39,13 @@ const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
     return value == null || !Number.isInteger(value) || value < 0 || value > MAX_OWNED_QUANTITY;
   }), [excluded, quantities, results]);
 
+  const hasUnconfirmedCappedMaterial = invalidMaterials.some((result) => (
+    result.needsTooltip && quantities[result.material] === result.quantity
+  ));
+  const hasInvalidQuantity = invalidMaterials.some((result) => (
+    !result.needsTooltip || quantities[result.material] !== result.quantity
+  ));
+
   const apply = () => {
     if (invalidMaterials.length > 0) return;
     const accepted: Partial<Record<MaterialType, number>> = {};
@@ -187,7 +194,12 @@ const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
           </div>
         )}
 
-        {invalidMaterials.length > 0 && (
+        {hasUnconfirmedCappedMaterial && (
+          <p className="text-xs text-red-500">
+            9999로 잘려 표시된 재료는 실제 수량을 입력하거나 적용 대상에서 제외해 주세요.
+          </p>
+        )}
+        {hasInvalidQuantity && (
           <p className="text-xs text-red-500">수량은 0 이상 {MAX_OWNED_QUANTITY.toLocaleString()} 이하의 정수여야 합니다.</p>
         )}
         {error && <p className="text-xs text-red-500">{error}</p>}

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { MaterialType } from '../../../data/enhancement';
+import { useMaterialScreenCapture } from './useMaterialScreenCapture';
+import type { MaterialIconMap } from './types';
+
+const MAX_OWNED_QUANTITY = 999_999_999;
+
+interface MaterialScreenCaptureProps {
+  icons: MaterialIconMap;
+  targetMaterials: MaterialType[];
+  onApply: (materials: Partial<Record<MaterialType, number>>) => void;
+}
+
+const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
+  icons,
+  targetMaterials,
+  onApply,
+}) => {
+  const includesFateShard = targetMaterials.includes('운명의 파편');
+  const { status, error, results, scanCount, start, stop, reset } = useMaterialScreenCapture({
+    icons,
+    targetMaterials,
+  });
+  const [quantities, setQuantities] = useState<Partial<Record<MaterialType, number>>>({});
+  const [excluded, setExcluded] = useState<Set<MaterialType>>(new Set());
+
+  useEffect(() => {
+    if (status !== 'review') return;
+    setQuantities(Object.fromEntries(results.map((result) => [result.material, result.quantity])));
+    setExcluded(new Set(results.filter((result) => (
+      result.quantity <= 0 || result.needsTooltip
+    )).map((result) => result.material)));
+  }, [results, status]);
+
+  const invalidMaterials = useMemo(() => results.filter((result) => {
+    if (excluded.has(result.material)) return false;
+    const value = quantities[result.material];
+    if (result.needsTooltip && value === result.quantity) return true;
+    return value == null || !Number.isInteger(value) || value < 0 || value > MAX_OWNED_QUANTITY;
+  }), [excluded, quantities, results]);
+
+  const apply = () => {
+    if (invalidMaterials.length > 0) return;
+    const accepted: Partial<Record<MaterialType, number>> = {};
+    results.forEach(({ material }) => {
+      if (!excluded.has(material)) accepted[material] = quantities[material];
+    });
+    onApply(accepted);
+    reset();
+  };
+
+  if (status === 'sharing' || status === 'requesting') {
+    return (
+      <div className="rounded-lg border border-la-gold/30 bg-la-gold/5 p-3" aria-live="polite">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold text-gray-700 dark:text-gray-200">
+              {status === 'requesting' ? 'Lost Ark 창을 선택해 주세요' : 'Lost Ark 화면을 인식하고 있습니다'}
+            </p>
+            <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+              강화창 재료를 먼저 읽으며, 툴팁 확인 필요 항목은 아이콘에 마우스를 올려 주세요.
+              {scanCount > 0 && ` ${results.length}종 감지 · ${scanCount}회 분석`}
+            </p>
+          </div>
+          {status === 'sharing' && (
+            <button
+              type="button"
+              onClick={() => { void stop(); }}
+              className="rounded-md bg-red-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-600"
+            >
+              화면 공유 중지
+            </button>
+          )}
+        </div>
+        {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
+
+        {status === 'sharing' && (
+          <div className="mt-3 border-t border-la-gold/20 pt-3">
+            <p className="text-xs font-semibold text-gray-700 dark:text-gray-200">인식 결과 확인</p>
+            <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+              확인한 항목만 기존 보유 재료에 덮어쓰며, 실패하거나 제외한 항목은 유지됩니다.
+            </p>
+            {results.length === 0 ? (
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                재료에 마우스를 올리면 인식된 항목이 여기에 표시됩니다.
+              </p>
+            ) : (
+              <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {results.map((result) => (
+                  <div
+                    key={result.material}
+                    className={`flex items-center gap-2 rounded-md border p-2 ${
+                      result.needsReview
+                        ? 'border-orange-400/60 bg-orange-500/5'
+                        : 'border-gray-200 dark:border-white/10'
+                    }`}
+                  >
+                    {icons[result.material] && (
+                      <img src={icons[result.material]} alt="" className="h-7 w-7 rounded" />
+                    )}
+                    <span className="min-w-0 flex-1 truncate text-xs text-gray-700 dark:text-gray-300">
+                      {result.material}
+                      {result.needsTooltip
+                        ? <span className="ml-1 text-orange-500">툴팁 확인 필요</span>
+                        : result.needsReview && <span className="ml-1 text-orange-500">확인 필요</span>}
+                    </span>
+                    <span className="text-xs tabular-nums text-gray-700 dark:text-gray-300">
+                      {result.quantity.toLocaleString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (status === 'review') {
+    return (
+      <div className="space-y-3 rounded-lg border border-gray-200/60 bg-gray-50/70 p-3 dark:border-white/10 dark:bg-white/5">
+        <div>
+          <p className="text-xs font-semibold text-gray-700 dark:text-gray-200">인식 결과 확인</p>
+          <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+            확인한 항목만 기존 보유 재료에 덮어쓰며, 실패하거나 제외한 항목은 유지됩니다.
+          </p>
+        </div>
+
+        {results.length === 0 ? (
+          <p className="rounded-md bg-orange-500/10 p-2 text-xs text-orange-600 dark:text-orange-300">
+            재료 툴팁을 찾지 못했습니다. 소지품에서 재료에 마우스를 충분히 오래 올린 뒤 다시 시도해 주세요.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {results.map((result) => {
+              const isExcluded = excluded.has(result.material);
+              return (
+                <label
+                  key={result.material}
+                  className={`flex items-center gap-2 rounded-md border p-2 ${
+                    isExcluded
+                      ? 'border-gray-200 opacity-50 dark:border-white/10'
+                      : result.needsReview
+                        ? 'border-orange-400/60 bg-orange-500/5'
+                        : 'border-gray-200 dark:border-white/10'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!isExcluded}
+                    onChange={(event) => {
+                      setExcluded((current) => {
+                        const next = new Set(current);
+                        if (event.target.checked) next.delete(result.material);
+                        else next.add(result.material);
+                        return next;
+                      });
+                    }}
+                  />
+                  {icons[result.material] && (
+                    <img src={icons[result.material]} alt="" className="h-7 w-7 rounded" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-xs text-gray-700 dark:text-gray-300">
+                    {result.material}
+                    {result.needsTooltip
+                      ? <span className="ml-1 text-orange-500">툴팁 확인 필요</span>
+                      : result.needsReview && <span className="ml-1 text-orange-500">확인 필요</span>}
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={MAX_OWNED_QUANTITY}
+                    step={1}
+                    disabled={isExcluded}
+                    value={quantities[result.material] ?? ''}
+                    onChange={(event) => {
+                      const value = event.target.value === '' ? undefined : Number(event.target.value);
+                      setQuantities((current) => ({ ...current, [result.material]: value }));
+                    }}
+                    aria-label={`${result.material} 인식 수량`}
+                    className="w-24 rounded bg-white px-2 py-1 text-right text-xs tabular-nums outline-none focus:ring-1 focus:ring-la-gold/50 disabled:bg-transparent dark:bg-white/10"
+                  />
+                </label>
+              );
+            })}
+          </div>
+        )}
+
+        {invalidMaterials.length > 0 && (
+          <p className="text-xs text-red-500">수량은 0 이상 {MAX_OWNED_QUANTITY.toLocaleString()} 이하의 정수여야 합니다.</p>
+        )}
+        {error && <p className="text-xs text-red-500">{error}</p>}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={apply}
+            disabled={results.length === 0 || invalidMaterials.length > 0 || excluded.size === results.length}
+            className="rounded-md bg-la-gold px-3 py-1.5 text-xs font-semibold text-gray-950 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            보유 재료에 적용
+          </button>
+          <button
+            type="button"
+            onClick={() => { reset(); void start(); }}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-100 dark:border-white/15 dark:text-gray-300 dark:hover:bg-white/5"
+          >
+            다시 인식
+          </button>
+          <button
+            type="button"
+            onClick={reset}
+            className="px-2 py-1.5 text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => { void start(); }}
+        className="inline-flex items-center rounded-md border border-la-gold/40 bg-la-gold/10 px-3 py-2 text-xs font-semibold text-la-gold-dark transition-colors hover:bg-la-gold/20 dark:text-la-gold"
+      >
+        Lost Ark 화면에서 자동 불러오기
+      </button>
+      <div className="space-y-1.5 text-[11px] leading-relaxed text-gray-400 dark:text-gray-500">
+        <p className="font-medium text-gray-500 dark:text-gray-400">이렇게 사용해 주세요</p>
+        <ol className="list-decimal space-y-1 pl-4">
+          <li>Lost Ark 창을 공유한 뒤 <strong className="font-semibold">장비 재련 화면</strong>을 열어 두세요.</li>
+          <li>강화창에 보이는 재료 종류와 <strong className="font-semibold">보유 수량</strong>을 자동으로 읽습니다.</li>
+          <li>
+            수량이 <strong className="font-semibold text-orange-500">9999</strong>로 표시된 재료는 실제 보유량이 잘린 값입니다.
+            해당 재료 아이콘에 마우스를 올리고 툴팁이 보이도록 잠시 기다려 주세요.
+          </li>
+          {includesFateShard && (
+            <li>운명의 파편은 게임 상단 바를 먼저 확인하고, 인식되지 않으면 강화창의 소지 금액 첫 번째 값을 읽습니다.</li>
+          )}
+        </ol>
+        <p>공유 화면은 사용자의 브라우저에서만 분석하며 서버로 전송하거나 저장하지 않습니다.</p>
+      </div>
+      {error && (
+        <div className="flex items-start justify-between gap-2 rounded-md bg-red-500/10 p-2" role="alert">
+          <p className="text-xs text-red-500">{error}</p>
+          <button type="button" onClick={reset} className="shrink-0 text-xs text-gray-400 underline">닫기</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MaterialScreenCapture;

--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
@@ -28,7 +28,7 @@ const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
     if (status !== 'review') return;
     setQuantities(Object.fromEntries(results.map((result) => [result.material, result.quantity])));
     setExcluded(new Set(results.filter((result) => (
-      result.quantity <= 0 || result.needsTooltip
+      result.needsTooltip
     )).map((result) => result.material)));
   }, [results, status]);
 

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createHoningObservation,
+  parseHoningFateShardQuantity,
+  parseHoningOwnedQuantity,
+  parseTooltipQuantity,
+  parseTooltipTitleQuantity,
+  parseTopBarFateShardQuantity,
+} from './recognizeMaterialFrame';
+
+describe('parseTooltipTitleQuantity', () => {
+  it.each([
+    ['[X 7440)', 7440],
+    ['[X 950870]', 950_870],
+    ['[ 5400]', 5400],
+  ])('reads tooltip title OCR variations from %s', (text, expected) => {
+    expect(parseTooltipTitleQuantity(text)).toBe(expected);
+  });
+});
+
+describe('honing material quantity parsing', () => {
+  it.each([
+    ['879 / 44', { quantity: 879, needsTooltip: false }],
+    ['659 / 47', { quantity: 659, needsTooltip: false }],
+    ['0 / 16', { quantity: 0, needsTooltip: false }],
+    ['1745 22', { quantity: 1745, needsTooltip: false }],
+    ['9999 / 4260', { quantity: 9999, needsTooltip: true }],
+  ])('reads only the owned value from %s', (text, expected) => {
+    expect(parseHoningOwnedQuantity(text)).toEqual(expected);
+  });
+
+  it('processes every visible weapon, armor, and armlet material without a fixed slot count', () => {
+    const weapon = ['파괴석', '돌파석', '아비도스 융화 재료'];
+    const armor = ['수호석', '돌파석', '아비도스 융화 재료'];
+    const armletSlots = ['파괴석', '수호석', '돌파석', '아비도스 융화 재료'];
+    const observe = (materials: string[]) => materials.map((material, index) => (
+      createHoningObservation(material as Parameters<typeof createHoningObservation>[0], {
+        quantity: index + 1,
+        needsTooltip: false,
+      })
+    ));
+
+    expect(observe(weapon).map(({ material }) => material)).toEqual(weapon);
+    expect(observe(armor).map(({ material }) => material)).toEqual(armor);
+    expect([...observe(armletSlots).map(({ material }) => material), '운명의 파편']).toEqual([
+      '파괴석', '수호석', '돌파석', '아비도스 융화 재료', '운명의 파편',
+    ]);
+  });
+});
+
+describe('fate shard quantity parsing', () => {
+  it('reads the first owned currency from the honing window', () => {
+    expect(parseHoningFateShardQuantity(
+      '소지 금액 10,977,353 # 83,359,124 @ 13,655 @',
+    )).toBe(10_977_353);
+  });
+
+  it('uses the first grouped amount on the owned-amount row when OCR misses the label', () => {
+    expect(parseHoningFateShardQuantity(
+      '39.840 # 60.000 @ 10,150\n3.068.727 # 17,610,805 @ 413615 @',
+    )).toBe(3_068_727);
+  });
+
+  it('reads the last grouped quantity from the top-bar crop', () => {
+    expect(parseTopBarFateShardQuantity('121,365 1,226,295')).toBe(1_226_295);
+  });
+
+  it('does not use capped material counts from the honing window', () => {
+    expect(parseHoningFateShardQuantity('9999 / 780 1745 / 22 0 / 16')).toBeNull();
+  });
+});
+
+describe('parseTooltipQuantity', () => {
+  it('prefers the total owned quantity in a tooltip', () => {
+    expect(parseTooltipQuantity('겹침 수량: 100개\n전체 보유 수량: 950,870개', 100)).toBe(950_870);
+  });
+
+  it('uses the title quantity when the tooltip has no total', () => {
+    expect(parseTooltipQuantity('거래 불가\n분해불가', 7440)).toBe(7440);
+  });
+
+  it('caps an abnormally large quantity', () => {
+    expect(parseTooltipQuantity('전체 보유 수량: 1,000,000,000개', 1)).toBe(999_999_999);
+  });
+});

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -1,0 +1,665 @@
+import type { Mat } from '@techstark/opencv-js';
+import type { MaterialType } from '../../../data/enhancement';
+import type {
+  MaterialIconMap,
+  MaterialObservation,
+  RecognitionFrame,
+  RecognitionMetrics,
+} from './types';
+
+const TEMPLATE_SIZES = [38, 42, 46, 50, 64, 80, 96, 112, 128];
+const MATCH_THRESHOLD = 0.72;
+const COARSE_MATCH_THRESHOLD = 0.5;
+const COARSE_SCALE = 0.25;
+const MAX_MATCHES_PER_SCALE = 4;
+const MAX_OWNED_QUANTITY = 999_999_999;
+
+type OpenCv = typeof import('@techstark/opencv-js') & {
+  onRuntimeInitialized?: () => void;
+};
+type OpenCvMat = Mat;
+type OcrWorker = Awaited<ReturnType<typeof import('tesseract.js')['createWorker']>>;
+
+let openCvPromise: Promise<OpenCv> | null = null;
+let numericOcrWorkerPromise: Promise<OcrWorker> | null = null;
+let tooltipOcrWorkerPromise: Promise<OcrWorker> | null = null;
+const templateCanvasCache = new Map<string, HTMLCanvasElement>();
+
+const getOpenCv = (): Promise<OpenCv> => {
+  if (openCvPromise) return openCvPromise;
+  openCvPromise = import('@techstark/opencv-js').then(async (module) => {
+    const candidate = ('default' in module ? module.default : module) as unknown;
+    const cv = await Promise.resolve(candidate) as OpenCv;
+    if (cv.Mat) return cv;
+    await new Promise<void>((resolve) => {
+      cv.onRuntimeInitialized = resolve;
+    });
+    return cv;
+  });
+  return openCvPromise;
+};
+
+const getNumericOcrWorker = (): Promise<OcrWorker> => {
+  if (numericOcrWorkerPromise) return numericOcrWorkerPromise;
+  numericOcrWorkerPromise = import('tesseract.js').then(async ({ createWorker, PSM }) => {
+    const worker = await createWorker('eng');
+    await worker.setParameters({
+      tessedit_char_whitelist: '0123456789,/Xx[] ',
+      tessedit_pageseg_mode: PSM.SINGLE_LINE,
+      preserve_interword_spaces: '0',
+    });
+    return worker;
+  });
+  return numericOcrWorkerPromise;
+};
+
+const getTooltipOcrWorker = (): Promise<OcrWorker> => {
+  if (tooltipOcrWorkerPromise) return tooltipOcrWorkerPromise;
+  tooltipOcrWorkerPromise = import('tesseract.js').then(async ({ createWorker, PSM }) => {
+    const worker = await createWorker('kor+eng');
+    await worker.setParameters({ tessedit_pageseg_mode: PSM.SINGLE_BLOCK });
+    return worker;
+  });
+  return tooltipOcrWorkerPromise;
+};
+
+const loadTemplateCanvas = async (url: string): Promise<HTMLCanvasElement> => {
+  const cached = templateCanvasCache.get(url);
+  if (cached) return cached;
+
+  const response = await fetch(url, { mode: 'cors', credentials: 'omit' });
+  if (!response.ok) throw new Error('재료 아이콘을 불러오지 못했습니다.');
+  const bitmap = await createImageBitmap(await response.blob());
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  try {
+    if (!context) throw new Error('이미지 분석을 시작할 수 없습니다.');
+    context.drawImage(bitmap, 0, 0);
+  } finally {
+    bitmap.close();
+  }
+  templateCanvasCache.set(url, canvas);
+  return canvas;
+};
+
+interface Match {
+  x: number;
+  y: number;
+  slotSize: number;
+  score: number;
+}
+
+interface TemplateMatchTiming {
+  coarseMs: number;
+  refineMs: number;
+}
+
+const findTemplateMatches = (
+  cv: OpenCv,
+  source: OpenCvMat,
+  templateCanvas: HTMLCanvasElement,
+  templateSizes = TEMPLATE_SIZES,
+  timing?: TemplateMatchTiming,
+): Match[] => {
+  const templateSource = cv.imread(templateCanvas);
+  const templateRgb = new cv.Mat();
+  const coarseSource = new cv.Mat();
+  const mask = new cv.Mat();
+  cv.cvtColor(templateSource, templateRgb, cv.COLOR_RGBA2RGB);
+  cv.resize(
+    source,
+    coarseSource,
+    new cv.Size(Math.round(source.cols * COARSE_SCALE), Math.round(source.rows * COARSE_SCALE)),
+    0,
+    0,
+    cv.INTER_AREA,
+  );
+  const matches: Match[] = [];
+
+  try {
+    for (const slotSize of templateSizes) {
+      const resized = new cv.Mat();
+      const coarseTemplate = new cv.Mat();
+      const coarseResult = new cv.Mat();
+      const cropX = Math.round(slotSize * 0.05);
+      const cropY = Math.round(slotSize * 0.2);
+      const cropWidth = Math.round(slotSize * 0.68);
+      const cropHeight = Math.round(slotSize * 0.68);
+      const coarseSlotSize = Math.max(10, Math.round(slotSize * COARSE_SCALE));
+      const coarseCropX = Math.round(coarseSlotSize * 0.05);
+      const coarseCropY = Math.round(coarseSlotSize * 0.2);
+      const coarseCropWidth = Math.round(coarseSlotSize * 0.68);
+      const coarseCropHeight = Math.round(coarseSlotSize * 0.68);
+      let templateCrop: OpenCvMat | null = null;
+      let coarseTemplateCrop: OpenCvMat | null = null;
+
+      try {
+        cv.resize(templateRgb, resized, new cv.Size(slotSize, slotSize), 0, 0, cv.INTER_AREA);
+        templateCrop = resized.roi(new cv.Rect(cropX, cropY, cropWidth, cropHeight));
+        cv.resize(
+          templateRgb,
+          coarseTemplate,
+          new cv.Size(coarseSlotSize, coarseSlotSize),
+          0,
+          0,
+          cv.INTER_AREA,
+        );
+        coarseTemplateCrop = coarseTemplate.roi(new cv.Rect(
+          coarseCropX,
+          coarseCropY,
+          coarseCropWidth,
+          coarseCropHeight,
+        ));
+        const coarseStarted = performance.now();
+        cv.matchTemplate(coarseSource, coarseTemplateCrop, coarseResult, cv.TM_CCOEFF_NORMED);
+        if (timing) timing.coarseMs += performance.now() - coarseStarted;
+
+        for (let count = 0; count < MAX_MATCHES_PER_SCALE; count += 1) {
+          const { maxVal: coarseScore, maxLoc: coarseLoc } = cv.minMaxLoc(coarseResult, mask);
+          if (coarseScore < COARSE_MATCH_THRESHOLD) break;
+
+          const expectedCropX = Math.round(coarseLoc.x / COARSE_SCALE);
+          const expectedCropY = Math.round(coarseLoc.y / COARSE_SCALE);
+          const margin = Math.round(slotSize * 0.4);
+          const left = Math.max(0, expectedCropX - margin);
+          const top = Math.max(0, expectedCropY - margin);
+          const right = Math.min(source.cols, expectedCropX + cropWidth + margin);
+          const bottom = Math.min(source.rows, expectedCropY + cropHeight + margin);
+          const sourceRoi = source.roi(new cv.Rect(left, top, right - left, bottom - top));
+          const refinedResult = new cv.Mat();
+
+          try {
+            const refineStarted = performance.now();
+            cv.matchTemplate(sourceRoi, templateCrop, refinedResult, cv.TM_CCOEFF_NORMED);
+            const { maxVal, maxLoc } = cv.minMaxLoc(refinedResult, mask);
+            if (timing) timing.refineMs += performance.now() - refineStarted;
+            if (maxVal >= MATCH_THRESHOLD) {
+              const x = left + maxLoc.x - cropX;
+              const y = top + maxLoc.y - cropY;
+              const duplicate = matches.some((match) => (
+                Math.hypot(match.x - x, match.y - y) < Math.min(match.slotSize, slotSize) * 0.55
+              ));
+              if (!duplicate) matches.push({ x, y, slotSize, score: maxVal });
+            }
+          } finally {
+            sourceRoi.delete();
+            refinedResult.delete();
+          }
+
+          const suppressLeft = Math.max(0, coarseLoc.x - coarseSlotSize);
+          const suppressTop = Math.max(0, coarseLoc.y - coarseSlotSize);
+          const suppressWidth = Math.min(coarseResult.cols - suppressLeft, coarseSlotSize * 2);
+          const suppressHeight = Math.min(coarseResult.rows - suppressTop, coarseSlotSize * 2);
+          const suppressed = coarseResult.roi(new cv.Rect(
+            suppressLeft,
+            suppressTop,
+            suppressWidth,
+            suppressHeight,
+          ));
+          suppressed.setTo(new cv.Scalar(-1));
+          suppressed.delete();
+        }
+      } finally {
+        templateCrop?.delete();
+        coarseTemplateCrop?.delete();
+        resized.delete();
+        coarseTemplate.delete();
+        coarseResult.delete();
+      }
+    }
+  } finally {
+    templateSource.delete();
+    templateRgb.delete();
+    coarseSource.delete();
+    mask.delete();
+  }
+
+  return matches;
+};
+
+interface OcrRegion {
+  canvas: HTMLCanvasElement;
+  hasTextPixels: boolean;
+}
+
+const createOcrRegion = (
+  frame: HTMLCanvasElement,
+  sourceX: number,
+  sourceY: number,
+  sourceWidth: number,
+  sourceHeight: number,
+  scale: number,
+  threshold: boolean,
+  includeColoredText = false,
+): OcrRegion => {
+  const x = Math.max(0, Math.round(sourceX));
+  const y = Math.max(0, Math.round(sourceY));
+  const width = Math.max(0, Math.min(frame.width - x, Math.round(sourceWidth)));
+  const height = Math.max(0, Math.min(frame.height - y, Math.round(sourceHeight)));
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, width * scale);
+  canvas.height = Math.max(1, height * scale);
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context || width === 0 || height === 0) return { canvas, hasTextPixels: false };
+
+  context.imageSmoothingEnabled = false;
+  context.drawImage(frame, x, y, width, height, 0, 0, canvas.width, canvas.height);
+  if (!threshold) return { canvas, hasTextPixels: true };
+
+  const image = context.getImageData(0, 0, canvas.width, canvas.height);
+  let textPixels = 0;
+  for (let index = 0; index < image.data.length; index += 4) {
+    const red = image.data[index];
+    const green = image.data[index + 1];
+    const blue = image.data[index + 2];
+    const brightness = (red + green + blue) / 3;
+    const neutral = Math.max(red, green, blue) - Math.min(red, green, blue) < 65;
+    const coloredQuantity = green > red * 1.2 || red > green * 1.2;
+    const isText = (neutral && brightness > 145)
+      || (includeColoredText && coloredQuantity && Math.max(red, green, blue) > 120);
+    const value = isText ? 0 : 255;
+    if (isText) textPixels += 1;
+    image.data[index] = value;
+    image.data[index + 1] = value;
+    image.data[index + 2] = value;
+    image.data[index + 3] = 255;
+  }
+  context.putImageData(image, 0, 0);
+  return { canvas, hasTextPixels: textPixels > scale * scale * 4 };
+};
+
+export const parseTooltipTitleQuantity = (text: string): number | null => {
+  const normalized = text.replace(/\s/g, '');
+  const bracketMatch = normalized.match(/[\[(][Xx]?([\d,]+)(?:\]|\))/);
+  const xMatch = normalized.match(/[Xx]([\d,]+)/);
+  const rawQuantity = bracketMatch?.[1] ?? xMatch?.[1];
+  if (!rawQuantity) return null;
+  const quantity = Number(rawQuantity.replace(/,/g, ''));
+  return Number.isSafeInteger(quantity) ? quantity : null;
+};
+
+export const parseTooltipQuantity = (text: string, fallback: number): number => {
+  const totalMatch = text.match(/전체\s*보유\s*수량[ \t]*[:：]?[ \t]*([\d, ]+)/);
+  const rawQuantity = totalMatch?.[1] ?? String(fallback);
+  const quantity = Number(rawQuantity.replace(/[^\d]/g, ''));
+  return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : fallback;
+};
+
+export const parseHoningFateShardQuantity = (text: string): number | null => {
+  const ownedAmount = text.match(/소지\s*금액[ \t]*(\d{1,3}(?:[,.]\d{3})+)/)?.[1];
+  const amountLines = text.split(/\r?\n/).filter((line) => /\d{1,3}(?:[,.]\d{3})+/.test(line));
+  const firstGroupedOnLastLine = amountLines.at(-1)?.match(/\d{1,3}(?:[,.]\d{3})+/)?.[0];
+  const rawQuantity = ownedAmount ?? firstGroupedOnLastLine;
+  if (!rawQuantity) return null;
+  const quantity = Number(rawQuantity.replace(/[^\d]/g, ''));
+  return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : null;
+};
+
+export const parseTopBarFateShardQuantity = (text: string): number | null => {
+  const groupedNumbers = Array.from(text.matchAll(/\d{1,3}(?:,\d{3})+/g));
+  const rawQuantity = groupedNumbers.at(-1)?.[0];
+  if (!rawQuantity) return null;
+  const quantity = Number(rawQuantity.replace(/,/g, ''));
+  return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : null;
+};
+
+export interface HoningOwnedQuantity {
+  quantity: number;
+  needsTooltip: boolean;
+}
+
+export const parseHoningOwnedQuantity = (text: string): HoningOwnedQuantity | null => {
+  const divided = text.match(/([\d, ]+)\s*[/|]\s*[\d, ]+/);
+  const separated = text.trim().match(/^([\d,]{2,})\s+[\d,]+/);
+  const rawOwned = divided?.[1] ?? separated?.[1];
+  if (!rawOwned) return null;
+  const quantity = Number(rawOwned.replace(/[^\d]/g, ''));
+  if (!Number.isSafeInteger(quantity)) return null;
+  return { quantity, needsTooltip: quantity === 9999 };
+};
+
+export const createHoningObservation = (
+  material: MaterialType,
+  reading: HoningOwnedQuantity,
+  confidence = 0.9,
+): MaterialObservation => ({
+  material,
+  quantity: reading.quantity,
+  confidence,
+  x: 0,
+  y: 0,
+  slotSize: 0,
+  needsReview: reading.needsTooltip || confidence < 0.8,
+  needsTooltip: reading.needsTooltip,
+  source: 'honing',
+});
+
+interface HoningRecognition {
+  observations: MaterialObservation[];
+  detected: boolean;
+  cappedMaterials: MaterialType[];
+  rowY: number;
+  leftmostSlotX: number;
+  slotSize: number;
+  region: { x: number; y: number; width: number; height: number };
+}
+
+const recognizeHoningMaterials = async (
+  frame: HTMLCanvasElement,
+  cv: OpenCv,
+  source: OpenCvMat,
+  icons: MaterialIconMap,
+  materials: MaterialType[],
+  metrics: RecognitionMetrics,
+): Promise<HoningRecognition> => {
+  const candidateStarted = performance.now();
+  // Both compact and full-screen samples place the honing material row in this
+  // central-lower band. Icon matches plus a `owned / required` line are still
+  // required, so this band alone never declares a honing window.
+  const region = {
+    x: Math.round(frame.width * 0.15),
+    y: Math.round(frame.height * 0.48),
+    width: Math.round(frame.width * 0.7),
+    height: Math.round(frame.height * 0.36),
+  };
+  const sourceRoi = source.roi(new cv.Rect(region.x, region.y, region.width, region.height));
+  metrics.honingCandidateMs += performance.now() - candidateStarted;
+  const observations: MaterialObservation[] = [];
+  const cappedMaterials: MaterialType[] = [];
+  const numericWorker = await getNumericOcrWorker();
+  const slotPositions = new Set<string>();
+  let detected = false;
+  let rowY = frame.height;
+  let leftmostSlotX = frame.width;
+  let largestSlot = 0;
+
+  try {
+    for (const material of materials) {
+      const iconUrl = icons[material];
+      if (!iconUrl) continue;
+      const template = await loadTemplateCanvas(iconUrl);
+      const matchTiming = { coarseMs: 0, refineMs: 0 };
+      const matches = findTemplateMatches(cv, sourceRoi, template, TEMPLATE_SIZES, matchTiming)
+        .sort((left, right) => right.score - left.score);
+      metrics.slotDetectionMs += matchTiming.coarseMs;
+      metrics.iconClassificationMs += matchTiming.refineMs;
+      if (matches.length > 0) detected = true;
+
+      for (const relativeMatch of matches.slice(0, 1)) {
+        const match = {
+          ...relativeMatch,
+          x: relativeMatch.x + region.x,
+          y: relativeMatch.y + region.y,
+        };
+        const quantityCrop = {
+          x: match.x - match.slotSize * 0.45,
+          y: match.y + match.slotSize * (match.slotSize < 50 ? 0.95 : 1.1),
+          width: match.slotSize * 1.9,
+          height: match.slotSize * 0.58,
+          scale: 5,
+        };
+        const quantityRegion = createOcrRegion(
+          frame,
+          quantityCrop.x,
+          quantityCrop.y,
+          quantityCrop.width,
+          quantityCrop.height,
+          quantityCrop.scale,
+          false,
+        );
+        if (!quantityRegion.hasTextPixels) continue;
+        const ocrStarted = performance.now();
+        await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,/Xx[] ' });
+        const { data } = await numericWorker.recognize(quantityRegion.canvas);
+        metrics.slotOcrMs += performance.now() - ocrStarted;
+        let reading = parseHoningOwnedQuantity(data.text);
+        if (!reading && match.slotSize < 50) {
+          const compactRetry = createOcrRegion(
+            frame,
+            match.x - match.slotSize * 0.63,
+            match.y + match.slotSize * 0.82,
+            match.slotSize * 2.37,
+            match.slotSize * 0.79,
+            4,
+            false,
+          );
+          const retryStarted = performance.now();
+          await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,/' });
+          const { data: retryData } = await numericWorker.recognize(compactRetry.canvas);
+          metrics.slotOcrMs += performance.now() - retryStarted;
+          reading = parseHoningOwnedQuantity(retryData.text);
+        }
+        if (!reading) continue;
+
+        const observation = createHoningObservation(
+          material,
+          reading,
+          Math.min(match.score, Math.max(0, data.confidence / 100)),
+        );
+        observations.push({ ...observation, x: match.x, y: match.y, slotSize: match.slotSize });
+        if (reading.needsTooltip) cappedMaterials.push(material);
+        rowY = Math.min(rowY, match.y);
+        leftmostSlotX = Math.min(leftmostSlotX, match.x);
+        largestSlot = Math.max(largestSlot, match.slotSize);
+        slotPositions.add(`${Math.round(match.x / 8)}:${Math.round(match.y / 8)}`);
+        break;
+      }
+    }
+  } finally {
+    sourceRoi.delete();
+  }
+
+  metrics.slotCount = slotPositions.size;
+  return {
+    observations,
+    detected: detected && observations.length > 0,
+    cappedMaterials,
+    rowY,
+    leftmostSlotX,
+    slotSize: largestSlot,
+    region,
+  };
+};
+
+const recognizeTooltipQuantity = async (
+  frame: HTMLCanvasElement,
+  match: Match,
+): Promise<{ quantity: number; confidence: number; needsReview: boolean } | null> => {
+  const title = createOcrRegion(
+    frame,
+    match.x - match.slotSize * 0.3,
+    match.y - match.slotSize * 1.2,
+    match.slotSize * 6.8,
+    match.slotSize * 0.9,
+    4,
+    true,
+  );
+  if (!title.hasTextPixels) return null;
+
+  const numericWorker = await getNumericOcrWorker();
+  await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,Xx[] ' });
+  const { data: titleData } = await numericWorker.recognize(title.canvas);
+  const titleQuantity = parseTooltipTitleQuantity(titleData.text);
+  if (titleQuantity === null) return null;
+
+  const tooltip = createOcrRegion(
+    frame,
+    match.x - match.slotSize * 0.3,
+    match.y + match.slotSize * 1.4,
+    match.slotSize * 6.8,
+    match.slotSize * 3.4,
+    2,
+    false,
+  );
+  const tooltipWorker = await getTooltipOcrWorker();
+  const { data: tooltipData } = await tooltipWorker.recognize(tooltip.canvas);
+  const quantity = parseTooltipQuantity(tooltipData.text, titleQuantity);
+  const capped = quantity > MAX_OWNED_QUANTITY;
+  const confidence = Math.max(0, Math.min(1, titleData.confidence / 100));
+
+  return {
+    quantity: capped ? MAX_OWNED_QUANTITY : quantity,
+    confidence,
+    needsReview: capped || titleData.confidence < 70,
+  };
+};
+
+const recognizeFateShard = async (
+  frame: HTMLCanvasElement,
+  honing?: HoningRecognition,
+): Promise<MaterialObservation | null> => {
+  const topBar = createOcrRegion(
+    frame,
+    frame.width * 0.47,
+    0,
+    frame.width * 0.07,
+    Math.max(36, frame.height * 0.045),
+    3,
+    true,
+  );
+  const numericWorker = await getNumericOcrWorker();
+  await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,' });
+  const { data: topBarData } = await numericWorker.recognize(topBar.canvas);
+  const topBarQuantity = parseTopBarFateShardQuantity(topBarData.text);
+  if (topBarQuantity !== null) {
+    return {
+      material: '운명의 파편',
+      quantity: topBarQuantity,
+      confidence: Math.max(0, Math.min(1, topBarData.confidence / 100)),
+      x: 0,
+      y: 0,
+      slotSize: 0,
+      needsReview: topBarData.confidence < 70,
+      source: 'fate-shard',
+    };
+  }
+
+  const hasHoningRow = honing?.detected && honing.slotSize > 0;
+  if (!hasHoningRow || !honing) return null;
+  // The first value below the leftmost material slot is fate shards. Limiting
+  // this crop prevents the following silver and gold values from being used.
+  const honingCosts = createOcrRegion(
+    frame,
+    honing.leftmostSlotX - honing.slotSize * 1.3,
+    honing.rowY + honing.slotSize * 1.75,
+    honing.slotSize * 2.7,
+    honing.slotSize * 1.8,
+    4,
+    false,
+  );
+  const tooltipWorker = await getTooltipOcrWorker();
+  const { data: honingData } = await tooltipWorker.recognize(honingCosts.canvas);
+  const honingQuantity = parseHoningFateShardQuantity(honingData.text);
+  if (honingQuantity === null) return null;
+
+  return {
+    material: '운명의 파편',
+    quantity: honingQuantity,
+    confidence: Math.max(0, Math.min(1, honingData.confidence / 100)),
+    x: 0,
+    y: 0,
+    slotSize: 0,
+    needsReview: honingData.confidence < 70,
+    source: 'fate-shard',
+  };
+};
+
+const validateFrame = (frame: HTMLCanvasElement): void => {
+  if (frame.width < 800 || frame.height < 450) {
+    throw new Error(`공유 화면 해상도가 너무 낮습니다. 감지된 화면: ${frame.width}×${frame.height}`);
+  }
+};
+
+export const recognizeMaterialFrame = async (
+  frame: HTMLCanvasElement,
+  icons: MaterialIconMap,
+  targetMaterials: MaterialType[],
+): Promise<RecognitionFrame> => {
+  validateFrame(frame);
+  const totalStarted = performance.now();
+  const observations: MaterialObservation[] = [];
+  const materialTargets = targetMaterials.filter((material) => material !== '운명의 파편');
+  const metrics: RecognitionMetrics = {
+    honingCandidateMs: 0,
+    slotDetectionMs: 0,
+    iconClassificationMs: 0,
+    slotOcrMs: 0,
+    fateShardOcrMs: 0,
+    tooltipOcrMs: 0,
+    slotCount: 0,
+    targetCount: materialTargets.length,
+    totalMs: 0,
+  };
+
+  let honing: HoningRecognition | undefined;
+  let cv: OpenCv | undefined;
+  let sourceRgba: OpenCvMat | undefined;
+  let sourceRgb: OpenCvMat | undefined;
+
+  try {
+    if (materialTargets.length > 0) {
+      cv = await getOpenCv();
+      sourceRgba = cv.imread(frame);
+      sourceRgb = new cv.Mat();
+      cv.cvtColor(sourceRgba, sourceRgb, cv.COLOR_RGBA2RGB);
+      honing = await recognizeHoningMaterials(frame, cv, sourceRgb, icons, materialTargets, metrics);
+      observations.push(...honing.observations);
+    }
+
+    if (targetMaterials.includes('운명의 파편')) {
+      const fateStarted = performance.now();
+      const fateShard = await recognizeFateShard(frame, honing);
+      metrics.fateShardOcrMs += performance.now() - fateStarted;
+      if (fateShard) observations.push(fateShard);
+    }
+
+    const tooltipMaterials = honing?.detected ? honing.cappedMaterials : materialTargets;
+    if (tooltipMaterials.length > 0 && cv && sourceRgb) {
+      for (const material of tooltipMaterials) {
+        const iconUrl = icons[material];
+        if (!iconUrl) continue;
+        const template = await loadTemplateCanvas(iconUrl);
+        const matches = findTemplateMatches(cv, sourceRgb, template)
+          .sort((left, right) => right.slotSize - left.slotSize || right.score - left.score);
+
+        for (const match of matches) {
+          const tooltipStarted = performance.now();
+          const quantity = await recognizeTooltipQuantity(frame, match);
+          metrics.tooltipOcrMs += performance.now() - tooltipStarted;
+          if (!quantity) continue;
+          observations.push({
+            material,
+            quantity: quantity.quantity,
+            confidence: Math.min(match.score, quantity.confidence),
+            x: match.x,
+            y: match.y,
+            slotSize: match.slotSize,
+            needsReview: quantity.needsReview || match.score < 0.8,
+            needsTooltip: false,
+            source: 'tooltip',
+          });
+          break;
+        }
+      }
+    }
+  } finally {
+    sourceRgba?.delete();
+    sourceRgb?.delete();
+  }
+
+  metrics.totalMs = performance.now() - totalStarted;
+  return { observations, frameWidth: frame.width, frameHeight: frame.height, metrics };
+};
+
+export const disposeMaterialRecognizer = async (): Promise<void> => {
+  const workerPromises = [numericOcrWorkerPromise, tooltipOcrWorkerPromise];
+  numericOcrWorkerPromise = null;
+  tooltipOcrWorkerPromise = null;
+  await Promise.all(workerPromises.map(async (workerPromise) => {
+    if (!workerPromise) return;
+    const worker = await workerPromise;
+    await worker.terminate();
+  }));
+};

--- a/src/components/enhancement/material-recognition/sessionResults.test.ts
+++ b/src/components/enhancement/material-recognition/sessionResults.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { MaterialType } from '../../../data/enhancement';
+import {
+  addRecognitionFrame,
+  createRecognitionSessionResults,
+  summarizeRecognitionSession,
+} from './sessionResults';
+import type { MaterialObservation } from './types';
+
+const observation = (
+  material: MaterialType,
+  quantity: number,
+  x: number,
+  y: number,
+  confidence = 0.9,
+): MaterialObservation => ({
+  material,
+  quantity,
+  x,
+  y,
+  confidence,
+  slotSize: 46,
+  needsReview: confidence < 0.8,
+});
+
+describe('material recognition session results', () => {
+  it('does not count a stack again when the same screen is scanned repeatedly', () => {
+    const frame = [observation('수호석', 1200, 100, 200)];
+    let session = addRecognitionFrame(createRecognitionSessionResults(), frame);
+    session = addRecognitionFrame(session, frame);
+
+    expect(summarizeRecognitionSession(session)).toEqual([
+      expect.objectContaining({ material: '수호석', quantity: 1200 }),
+    ]);
+  });
+
+  it('does not add the same tooltip again when its screen position changes', () => {
+    let session = addRecognitionFrame(createRecognitionSessionResults(), [
+      observation('파괴석', 7501, 100, 200),
+    ]);
+    session = addRecognitionFrame(session, [
+      observation('파괴석', 7501, 300, 400),
+    ]);
+
+    expect(summarizeRecognitionSession(session)[0]).toEqual(
+      expect.objectContaining({ material: '파괴석', quantity: 7501 }),
+    );
+  });
+
+  it('keeps the more confident reading for the same slot', () => {
+    let session = addRecognitionFrame(createRecognitionSessionResults(), [
+      observation('돌파석', 41, 100, 200, 0.6),
+    ]);
+    session = addRecognitionFrame(session, [
+      observation('돌파석', 47, 102, 201, 0.95),
+    ]);
+
+    expect(summarizeRecognitionSession(session)[0]).toEqual(
+      expect.objectContaining({ quantity: 47, confidence: 0.95, needsReview: false }),
+    );
+  });
+
+  it('does not let a capped honing value replace a confirmed quantity', () => {
+    let session = addRecognitionFrame(createRecognitionSessionResults(), [{
+      ...observation('파괴석', 12_345, 100, 200, 0.9),
+      source: 'honing',
+    }]);
+    session = addRecognitionFrame(session, [{
+      ...observation('파괴석', 9999, 100, 200, 0.99),
+      source: 'honing',
+      needsTooltip: true,
+      needsReview: true,
+    }]);
+
+    expect(summarizeRecognitionSession(session)[0].quantity).toBe(12_345);
+  });
+
+  it('replaces a capped honing value with the tooltip quantity without summing frames', () => {
+    let session = addRecognitionFrame(createRecognitionSessionResults(), [{
+      ...observation('수호석', 9999, 100, 200, 0.95),
+      source: 'honing',
+      needsTooltip: true,
+      needsReview: true,
+    }]);
+    session = addRecognitionFrame(session, [{
+      ...observation('수호석', 950_870, 300, 400, 0.8),
+      source: 'tooltip',
+    }]);
+    session = addRecognitionFrame(session, [{
+      ...observation('수호석', 950_870, 300, 400, 0.8),
+      source: 'tooltip',
+    }]);
+
+    expect(summarizeRecognitionSession(session)[0]).toEqual(expect.objectContaining({
+      quantity: 950_870,
+      needsTooltip: undefined,
+      source: 'tooltip',
+    }));
+  });
+});

--- a/src/components/enhancement/material-recognition/sessionResults.ts
+++ b/src/components/enhancement/material-recognition/sessionResults.ts
@@ -1,0 +1,75 @@
+import type { MaterialType } from '../../../data/enhancement';
+import type { MaterialObservation, RecognizedMaterial } from './types';
+
+interface StoredObservation extends MaterialObservation {
+  key: string;
+}
+
+export interface RecognitionSessionResults {
+  observations: Map<string, StoredObservation>;
+}
+
+export const createRecognitionSessionResults = (): RecognitionSessionResults => ({
+  observations: new Map(),
+});
+
+const observationKey = (observation: MaterialObservation): string => observation.material;
+
+const sourcePriority = (observation: MaterialObservation): number => {
+  if (observation.source === 'tooltip' || observation.source === 'fate-shard') return 3;
+  if (observation.source === 'honing' && !observation.needsTooltip) return 2;
+  return 1;
+};
+
+export const addRecognitionFrame = (
+  session: RecognitionSessionResults,
+  observations: MaterialObservation[],
+): RecognitionSessionResults => {
+  if (observations.length === 0) return session;
+
+  const stored = new Map(session.observations);
+  observations.forEach((observation) => {
+    const key = observationKey(observation);
+    const current = stored.get(key);
+    const incomingPriority = sourcePriority(observation);
+    const currentPriority = current ? sourcePriority(current) : -1;
+    if (!current
+      || incomingPriority > currentPriority
+      || (incomingPriority === currentPriority && observation.confidence >= current.confidence)) {
+      stored.set(key, { ...observation, key });
+    }
+  });
+  return { observations: stored };
+};
+
+export const summarizeRecognitionSession = (
+  session: RecognitionSessionResults,
+): RecognizedMaterial[] => {
+  const totals = new Map<MaterialType, RecognizedMaterial>();
+
+  session.observations.forEach((observation) => {
+    const current = totals.get(observation.material);
+    if (!current) {
+      totals.set(observation.material, {
+        material: observation.material,
+        quantity: observation.quantity,
+        confidence: observation.confidence,
+        needsReview: observation.needsReview,
+        needsTooltip: observation.needsTooltip,
+        source: observation.source,
+      });
+      return;
+    }
+
+    totals.set(observation.material, {
+      material: observation.material,
+      quantity: current.quantity + observation.quantity,
+      confidence: Math.min(current.confidence, observation.confidence),
+      needsReview: current.needsReview || observation.needsReview,
+      needsTooltip: current.needsTooltip || observation.needsTooltip,
+      source: current.source,
+    });
+  });
+
+  return Array.from(totals.values());
+};

--- a/src/components/enhancement/material-recognition/types.ts
+++ b/src/components/enhancement/material-recognition/types.ts
@@ -1,0 +1,47 @@
+import type { MaterialType } from '../../../data/enhancement';
+
+export type CaptureStatus = 'idle' | 'requesting' | 'sharing' | 'review' | 'error';
+
+export type RecognitionSource = 'honing' | 'tooltip' | 'fate-shard';
+
+export interface MaterialObservation {
+  material: MaterialType;
+  quantity: number;
+  confidence: number;
+  x: number;
+  y: number;
+  slotSize: number;
+  needsReview: boolean;
+  needsTooltip?: boolean;
+  source?: RecognitionSource;
+}
+
+export interface RecognizedMaterial {
+  material: MaterialType;
+  quantity: number;
+  confidence: number;
+  needsReview: boolean;
+  needsTooltip?: boolean;
+  source?: RecognitionSource;
+}
+
+export interface RecognitionMetrics {
+  honingCandidateMs: number;
+  slotDetectionMs: number;
+  iconClassificationMs: number;
+  slotOcrMs: number;
+  fateShardOcrMs: number;
+  tooltipOcrMs: number;
+  slotCount: number;
+  targetCount: number;
+  totalMs: number;
+}
+
+export interface RecognitionFrame {
+  observations: MaterialObservation[];
+  frameWidth: number;
+  frameHeight: number;
+  metrics?: RecognitionMetrics;
+}
+
+export type MaterialIconMap = Partial<Record<MaterialType, string>>;

--- a/src/components/enhancement/material-recognition/useMaterialScreenCapture.test.ts
+++ b/src/components/enhancement/material-recognition/useMaterialScreenCapture.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+import type { RecognitionFrame } from './types';
+import { disposeMaterialRecognizer, recognizeMaterialFrame } from './recognizeMaterialFrame';
+import { useMaterialScreenCapture } from './useMaterialScreenCapture';
+
+vi.mock('./recognizeMaterialFrame', () => ({
+  disposeMaterialRecognizer: vi.fn().mockResolvedValue(undefined),
+  recognizeMaterialFrame: vi.fn(),
+}));
+
+const emptyFrame: RecognitionFrame = {
+  observations: [],
+  frameWidth: 1920,
+  frameHeight: 1080,
+};
+
+describe('useMaterialScreenCapture', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(disposeMaterialRecognizer).mockResolvedValue(undefined);
+    Object.defineProperty(HTMLMediaElement.prototype, 'readyState', {
+      configurable: true,
+      get: () => HTMLMediaElement.HAVE_CURRENT_DATA,
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, 'videoWidth', {
+      configurable: true,
+      get: () => 1920,
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, 'videoHeight', {
+      configurable: true,
+      get: () => 1080,
+    });
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('does not leave an interval when sharing ends during the initial scan', async () => {
+    let resolveRecognition!: (frame: RecognitionFrame) => void;
+    vi.mocked(recognizeMaterialFrame).mockReturnValue(new Promise((resolve) => {
+      resolveRecognition = resolve;
+    }));
+
+    const stopTrack = vi.fn();
+    const track = {
+      stop: stopTrack,
+      addEventListener: vi.fn(),
+    };
+    const stream = {
+      getTracks: () => [track],
+      getVideoTracks: () => [track],
+    } as unknown as MediaStream;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getDisplayMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    const { result, unmount } = renderHook(() => useMaterialScreenCapture({
+      icons: { 수호석: '/guardian.png' },
+      targetMaterials: ['수호석'],
+    }));
+
+    let startPromise!: Promise<void>;
+    act(() => {
+      startPromise = result.current.start();
+    });
+    await act(async () => {
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    });
+    expect(recognizeMaterialFrame).toHaveBeenCalledOnce();
+
+    let stopPromise!: Promise<void>;
+    act(() => {
+      stopPromise = result.current.stop();
+    });
+    await act(async () => {
+      resolveRecognition(emptyFrame);
+      await startPromise;
+      await vi.runAllTimersAsync();
+      await stopPromise;
+    });
+
+    expect(result.current.status).toBe('review');
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    unmount();
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+  });
+});

--- a/src/components/enhancement/material-recognition/useMaterialScreenCapture.ts
+++ b/src/components/enhancement/material-recognition/useMaterialScreenCapture.ts
@@ -36,7 +36,8 @@ export const useMaterialScreenCapture = ({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const timerRef = useRef<number | null>(null);
   const processingRef = useRef(false);
-  const finishingRef = useRef(false);
+  const sessionIdRef = useRef(0);
+  const cleanupRef = useRef<Promise<void>>(Promise.resolve());
   const iconsRef = useRef(icons);
   const targetsRef = useRef(targetMaterials);
   const confirmedMaterialsRef = useRef(new Set<MaterialType>());
@@ -63,22 +64,32 @@ export const useMaterialScreenCapture = ({
     }
   }, []);
 
+  const queueRecognizerCleanup = useCallback(() => {
+    const cleanup = async () => {
+      while (processingRef.current) {
+        await new Promise((resolve) => window.setTimeout(resolve, 50));
+      }
+      await disposeMaterialRecognizer();
+    };
+    const nextCleanup = cleanupRef.current.catch(() => undefined).then(cleanup);
+    cleanupRef.current = nextCleanup;
+    return nextCleanup;
+  }, []);
+
   const finish = useCallback(async () => {
-    if (finishingRef.current) return;
-    finishingRef.current = true;
+    sessionIdRef.current += 1;
     clearTimer();
     releaseStream();
     setStatus('review');
-    while (processingRef.current) {
-      await new Promise((resolve) => window.setTimeout(resolve, 50));
-    }
-    await disposeMaterialRecognizer();
-    finishingRef.current = false;
-  }, [clearTimer, releaseStream]);
+    await queueRecognizerCleanup();
+  }, [clearTimer, queueRecognizerCleanup, releaseStream]);
 
-  const scanFrame = useCallback(async () => {
+  const scanFrame = useCallback(async (sessionId: number) => {
     const video = videoRef.current;
-    if (!video || processingRef.current || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+    if (sessionId !== sessionIdRef.current
+      || !video
+      || processingRef.current
+      || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
     processingRef.current = true;
 
     try {
@@ -93,6 +104,7 @@ export const useMaterialScreenCapture = ({
       ));
       if (pendingTargets.length === 0) return;
       const frame = await recognizeMaterialFrame(canvas, iconsRef.current, pendingTargets);
+      if (sessionId !== sessionIdRef.current) return;
       frame.observations.forEach((observation) => {
         if (!observation.needsTooltip
           && !observation.needsReview
@@ -104,7 +116,7 @@ export const useMaterialScreenCapture = ({
       setScanCount((current) => current + 1);
       setError(null);
     } catch (scanError) {
-      setError(errorMessage(scanError));
+      if (sessionId === sessionIdRef.current) setError(errorMessage(scanError));
     } finally {
       processingRef.current = false;
     }
@@ -129,15 +141,23 @@ export const useMaterialScreenCapture = ({
       return;
     }
 
+    const sessionId = sessionIdRef.current + 1;
+    sessionIdRef.current = sessionId;
+    clearTimer();
+    releaseStream();
+    await queueRecognizerCleanup();
+    if (sessionId !== sessionIdRef.current) return;
+
     setStatus('requesting');
     setError(null);
     setSession(createRecognitionSessionResults());
     setScanCount(0);
     confirmedMaterialsRef.current.clear();
-    finishingRef.current = false;
 
+    let stream: MediaStream | null = null;
+    let video: HTMLVideoElement | null = null;
     try {
-      const stream = await navigator.mediaDevices.getDisplayMedia({
+      stream = await navigator.mediaDevices.getDisplayMedia({
         video: {
           displaySurface: 'window',
           width: { ideal: 1920 },
@@ -146,37 +166,55 @@ export const useMaterialScreenCapture = ({
         },
         audio: false,
       });
-      const video = document.createElement('video');
+      if (sessionId !== sessionIdRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      video = document.createElement('video');
       video.muted = true;
       video.playsInline = true;
       video.srcObject = stream;
       streamRef.current = stream;
       videoRef.current = video;
-      stream.getVideoTracks()[0]?.addEventListener('ended', () => { void finish(); }, { once: true });
+      stream.getVideoTracks()[0]?.addEventListener('ended', () => {
+        if (sessionId === sessionIdRef.current) void finish();
+      }, { once: true });
       await video.play();
+      if (sessionId !== sessionIdRef.current) return;
       setStatus('sharing');
-      await scanFrame();
-      timerRef.current = window.setInterval(() => { void scanFrame(); }, SCAN_INTERVAL_MS);
+      await scanFrame(sessionId);
+      if (sessionId !== sessionIdRef.current) return;
+      timerRef.current = window.setInterval(() => { void scanFrame(sessionId); }, SCAN_INTERVAL_MS);
     } catch (startError) {
-      releaseStream();
-      setStatus('error');
-      setError(errorMessage(startError));
+      stream?.getTracks().forEach((track) => track.stop());
+      if (streamRef.current === stream) streamRef.current = null;
+      if (video) video.srcObject = null;
+      if (videoRef.current === video) videoRef.current = null;
+      if (sessionId === sessionIdRef.current) {
+        setStatus('error');
+        setError(errorMessage(startError));
+      }
     }
-  }, [finish, releaseStream, scanFrame]);
+  }, [clearTimer, finish, queueRecognizerCleanup, releaseStream, scanFrame]);
 
   const reset = useCallback(() => {
+    sessionIdRef.current += 1;
+    clearTimer();
+    releaseStream();
+    void queueRecognizerCleanup();
     setStatus('idle');
     setError(null);
     setSession(createRecognitionSessionResults());
     setScanCount(0);
     confirmedMaterialsRef.current.clear();
-  }, []);
+  }, [clearTimer, queueRecognizerCleanup, releaseStream]);
 
   useEffect(() => () => {
+    sessionIdRef.current += 1;
     clearTimer();
     releaseStream();
-    void disposeMaterialRecognizer();
-  }, [clearTimer, releaseStream]);
+    void queueRecognizerCleanup();
+  }, [clearTimer, queueRecognizerCleanup, releaseStream]);
 
   const results = useMemo(() => summarizeRecognitionSession(session), [session]);
 

--- a/src/components/enhancement/material-recognition/useMaterialScreenCapture.ts
+++ b/src/components/enhancement/material-recognition/useMaterialScreenCapture.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MaterialType } from '../../../data/enhancement';
+import { disposeMaterialRecognizer, recognizeMaterialFrame } from './recognizeMaterialFrame';
+import {
+  addRecognitionFrame,
+  createRecognitionSessionResults,
+  summarizeRecognitionSession,
+  type RecognitionSessionResults,
+} from './sessionResults';
+import type { CaptureStatus, MaterialIconMap } from './types';
+
+const SCAN_INTERVAL_MS = 2500;
+
+interface UseMaterialScreenCaptureOptions {
+  icons: MaterialIconMap;
+  targetMaterials: MaterialType[];
+}
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof DOMException) {
+    if (error.name === 'NotAllowedError') return '화면 공유가 취소되었거나 권한이 허용되지 않았습니다.';
+    if (error.name === 'NotFoundError') return '공유할 수 있는 화면을 찾지 못했습니다.';
+  }
+  return error instanceof Error ? error.message : '화면 인식을 시작하지 못했습니다.';
+};
+
+export const useMaterialScreenCapture = ({
+  icons,
+  targetMaterials,
+}: UseMaterialScreenCaptureOptions) => {
+  const [status, setStatus] = useState<CaptureStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<RecognitionSessionResults>(createRecognitionSessionResults);
+  const [scanCount, setScanCount] = useState(0);
+  const streamRef = useRef<MediaStream | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const processingRef = useRef(false);
+  const finishingRef = useRef(false);
+  const iconsRef = useRef(icons);
+  const targetsRef = useRef(targetMaterials);
+  const confirmedMaterialsRef = useRef(new Set<MaterialType>());
+
+  useEffect(() => {
+    iconsRef.current = icons;
+    targetsRef.current = targetMaterials;
+  }, [icons, targetMaterials]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const releaseStream = useCallback(() => {
+    const stream = streamRef.current;
+    streamRef.current = null;
+    stream?.getTracks().forEach((track) => track.stop());
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+      videoRef.current = null;
+    }
+  }, []);
+
+  const finish = useCallback(async () => {
+    if (finishingRef.current) return;
+    finishingRef.current = true;
+    clearTimer();
+    releaseStream();
+    setStatus('review');
+    while (processingRef.current) {
+      await new Promise((resolve) => window.setTimeout(resolve, 50));
+    }
+    await disposeMaterialRecognizer();
+    finishingRef.current = false;
+  }, [clearTimer, releaseStream]);
+
+  const scanFrame = useCallback(async () => {
+    const video = videoRef.current;
+    if (!video || processingRef.current || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+    processingRef.current = true;
+
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const context = canvas.getContext('2d', { willReadFrequently: true });
+      if (!context) throw new Error('공유 화면을 읽을 수 없습니다.');
+      context.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const pendingTargets = targetsRef.current.filter((material) => (
+        !confirmedMaterialsRef.current.has(material)
+      ));
+      if (pendingTargets.length === 0) return;
+      const frame = await recognizeMaterialFrame(canvas, iconsRef.current, pendingTargets);
+      frame.observations.forEach((observation) => {
+        if (!observation.needsTooltip
+          && !observation.needsReview
+          && observation.confidence >= 0.8) {
+          confirmedMaterialsRef.current.add(observation.material);
+        }
+      });
+      setSession((current) => addRecognitionFrame(current, frame.observations));
+      setScanCount((current) => current + 1);
+      setError(null);
+    } catch (scanError) {
+      setError(errorMessage(scanError));
+    } finally {
+      processingRef.current = false;
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    if (!navigator.mediaDevices?.getDisplayMedia) {
+      setStatus('error');
+      setError('이 브라우저는 화면 공유를 지원하지 않습니다. 최신 Chrome 또는 Edge를 사용해 주세요.');
+      return;
+    }
+    if (targetsRef.current.length === 0) {
+      setStatus('error');
+      setError('먼저 재련 목표를 설정해 인식할 재료를 선택해 주세요.');
+      return;
+    }
+    if (targetsRef.current.every((material) => (
+      material !== '운명의 파편' && !iconsRef.current[material]
+    ))) {
+      setStatus('error');
+      setError('재료 아이콘을 준비하지 못했습니다. 시세 조회 후 다시 시도해 주세요.');
+      return;
+    }
+
+    setStatus('requesting');
+    setError(null);
+    setSession(createRecognitionSessionResults());
+    setScanCount(0);
+    confirmedMaterialsRef.current.clear();
+    finishingRef.current = false;
+
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: {
+          displaySurface: 'window',
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+          frameRate: { ideal: 2, max: 5 },
+        },
+        audio: false,
+      });
+      const video = document.createElement('video');
+      video.muted = true;
+      video.playsInline = true;
+      video.srcObject = stream;
+      streamRef.current = stream;
+      videoRef.current = video;
+      stream.getVideoTracks()[0]?.addEventListener('ended', () => { void finish(); }, { once: true });
+      await video.play();
+      setStatus('sharing');
+      await scanFrame();
+      timerRef.current = window.setInterval(() => { void scanFrame(); }, SCAN_INTERVAL_MS);
+    } catch (startError) {
+      releaseStream();
+      setStatus('error');
+      setError(errorMessage(startError));
+    }
+  }, [finish, releaseStream, scanFrame]);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setError(null);
+    setSession(createRecognitionSessionResults());
+    setScanCount(0);
+    confirmedMaterialsRef.current.clear();
+  }, []);
+
+  useEffect(() => () => {
+    clearTimer();
+    releaseStream();
+    void disposeMaterialRecognizer();
+  }, [clearTimer, releaseStream]);
+
+  const results = useMemo(() => summarizeRecognitionSession(session), [session]);
+
+  return {
+    status,
+    error,
+    results,
+    scanCount,
+    start,
+    stop: finish,
+    reset,
+  };
+};

--- a/src/components/enhancement/useEnhancementMarket.test.ts
+++ b/src/components/enhancement/useEnhancementMarket.test.ts
@@ -1,6 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import type { MarketItem } from '../../utils/api';
-import { selectMarketItem } from './useEnhancementMarket';
+import {
+  fetchMarketItems,
+  fetchMarketOptions,
+  type MarketItem,
+} from '../../utils/api';
+import { MARKET_SEARCH } from './enhancementModel';
+import { selectMarketItem, useEnhancementMarket } from './useEnhancementMarket';
+
+vi.mock('../../utils/api', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/api')>('../../utils/api');
+  return {
+    ...actual,
+    fetchMarketItems: vi.fn(),
+    fetchMarketOptions: vi.fn(),
+  };
+});
 
 const marketItem = (Name: string, Id: number): MarketItem => ({
   Id,
@@ -15,18 +30,44 @@ const marketItem = (Name: string, Id: number): MarketItem => ({
 });
 
 describe('selectMarketItem', () => {
-  it('selects the exact material instead of the first partial search result', () => {
+  it('selects the exact API item for the upper Abidos search term', () => {
+    const config = MARKET_SEARCH['상급 아비도스 융화'];
     const items = [
-      marketItem('상급 아비도스 융화', 1),
-      marketItem('아비도스 융화 재료', 2),
+      marketItem('상급 아비도스 융화 재료 묶음', 1),
+      marketItem('상급 아비도스 융화 재료', 2),
     ];
 
-    expect(selectMarketItem(items, '아비도스 융화 재료')?.Id).toBe(2);
+    expect(config.searchName).toBe('상급 아비도스 융화');
+    expect(selectMarketItem(items, config.itemName ?? config.searchName)?.Id).toBe(2);
   });
 
   it('does not use a different partial match when there is no exact match', () => {
     const items = [marketItem('아비도스 융화 재료 묶음', 1)];
 
     expect(selectMarketItem(items, '아비도스 융화 재료')).toBeUndefined();
+  });
+
+  it('loads the upper Abidos price and icon from the exact API item', async () => {
+    vi.mocked(fetchMarketOptions).mockResolvedValue({
+      Categories: [{ Code: 50000, CodeName: '재련 재료' }],
+    });
+    vi.mocked(fetchMarketItems).mockImplementation(async (searchName) => ({
+      PageNo: 0,
+      PageSize: 10,
+      TotalCount: searchName === '상급 아비도스 융화' ? 2 : 0,
+      Items: searchName === '상급 아비도스 융화'
+        ? [
+          marketItem('상급 아비도스 융화 재료 묶음', 1),
+          { ...marketItem('상급 아비도스 융화 재료', 2), CurrentMinPrice: 100, BundleCount: 10 },
+        ]
+        : [],
+    }));
+
+    const { result } = renderHook(() => useEnhancementMarket());
+    await waitFor(() => expect(result.current.priceLoading).toBe(false));
+
+    expect(fetchMarketItems).toHaveBeenCalledWith('상급 아비도스 융화', 50000, undefined);
+    expect(result.current.prices['상급 아비도스 융화']).toBe(10);
+    expect(result.current.icons['상급 아비도스 융화']).toBe('/2.png');
   });
 });

--- a/src/components/enhancement/useEnhancementMarket.test.ts
+++ b/src/components/enhancement/useEnhancementMarket.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { MarketItem } from '../../utils/api';
+import { selectMarketItem } from './useEnhancementMarket';
+
+const marketItem = (Name: string, Id: number): MarketItem => ({
+  Id,
+  Name,
+  Grade: '고급',
+  Icon: `/${Id}.png`,
+  BundleCount: 1,
+  TradeRemainCount: null,
+  YDayAvgPrice: 1,
+  RecentPrice: 1,
+  CurrentMinPrice: 1,
+});
+
+describe('selectMarketItem', () => {
+  it('selects the exact material instead of the first partial search result', () => {
+    const items = [
+      marketItem('상급 아비도스 융화', 1),
+      marketItem('아비도스 융화 재료', 2),
+    ];
+
+    expect(selectMarketItem(items, '아비도스 융화 재료')?.Id).toBe(2);
+  });
+
+  it('does not use a different partial match when there is no exact match', () => {
+    const items = [marketItem('아비도스 융화 재료 묶음', 1)];
+
+    expect(selectMarketItem(items, '아비도스 융화 재료')).toBeUndefined();
+  });
+});

--- a/src/components/enhancement/useEnhancementMarket.ts
+++ b/src/components/enhancement/useEnhancementMarket.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { fetchMarketItems, fetchMarketOptions } from '../../utils/api';
+import {
+  fetchMarketItems,
+  fetchMarketOptions,
+  type MarketItem,
+} from '../../utils/api';
 import {
   ALL_MATERIAL_TYPES,
   flattenCategories,
@@ -8,6 +12,11 @@ import {
   MATERIAL_CATEGORY_KEYWORD,
   type PriceMap,
 } from './enhancementModel';
+
+export const selectMarketItem = (
+  items: MarketItem[] | undefined,
+  searchName: string,
+): MarketItem | undefined => items?.find(({ Name }) => Name === searchName);
 
 export const useEnhancementMarket = () => {
   const [prices, setPrices] = useState<PriceMap>({});
@@ -31,7 +40,7 @@ export const useEnhancementMarket = () => {
           const config = MARKET_SEARCH[type];
           const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
           const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
-          const item = data.Items?.[0];
+          const item = selectMarketItem(data.Items, config.searchName);
           if (!item) return { type, price: 0, icon: '' };
           const itemsPerUnit = config.itemsPerUnit ?? 1;
           return {

--- a/src/components/enhancement/useEnhancementMarket.ts
+++ b/src/components/enhancement/useEnhancementMarket.ts
@@ -40,7 +40,7 @@ export const useEnhancementMarket = () => {
           const config = MARKET_SEARCH[type];
           const categoryCode = config.categoryCode ?? findCode(MATERIAL_CATEGORY_KEYWORD[type]);
           const data = await fetchMarketItems(config.searchName, categoryCode, config.extraParams);
-          const item = selectMarketItem(data.Items, config.searchName);
+          const item = selectMarketItem(data.Items, config.itemName ?? config.searchName);
           if (!item) return { type, price: 0, icon: '' };
           const itemsPerUnit = config.itemsPerUnit ?? 1;
           return {

--- a/src/pages/Enhancement.test.tsx
+++ b/src/pages/Enhancement.test.tsx
@@ -177,6 +177,25 @@ describe('Enhancement armlet calculations', () => {
     chooseTarget('무기', 11);
     await screen.findByText('일반 재련 설정');
 
+    const orderedSections = [
+      screen.getByText('캐릭터 강화 현황'),
+      screen.getByText('일반 재련 설정'),
+      screen.getByText(/강화 견적 합계/),
+      screen.getByText('보유 재료 입력'),
+      screen.getByText(/예상 총 비용/),
+      screen.getByRole('button', { name: '단계 별 비용' }),
+    ];
+    orderedSections.slice(0, -1).forEach((current, index) => {
+      expect(current.compareDocumentPosition(orderedSections[index + 1]))
+        .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+
+    const stepCostsButton = screen.getByRole('button', { name: '단계 별 비용' });
+    expect(stepCostsButton).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(stepCostsButton);
+    expect(stepCostsButton).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(stepCostsButton);
+
     const bookOn = screen.queryByRole('button', { name: '책 ON' });
     if (bookOn) fireEvent.click(bookOn);
     const breathOff = screen.queryByRole('button', { name: '숨결 OFF' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,7 +155,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -262,6 +262,11 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@techstark/opencv-js@5.0.0-release.1":
+  version "5.0.0-release.1"
+  resolved "https://registry.yarnpkg.com/@techstark/opencv-js/-/opencv-js-5.0.0-release.1.tgz#9fa00e762cd045dff5231b743b80207bb99af371"
+  integrity sha512-PIm+eB0MFtieXoNC2GRao0dv/02sehG+Nv2nSW5D6pQm6J/4WqvDHm0RyoqOmGYQm67jdGiaOdIeTShCY3PIUg==
 
 "@testing-library/dom@^10.4.1":
   version "10.4.1"
@@ -467,17 +472,17 @@ arg@^5.0.2:
   resolved "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
-aria-query@^5.0.0:
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz"
-  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
-
 aria-query@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
   dependencies:
     dequal "^2.0.3"
+
+aria-query@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
 assertion-error@^2.0.1:
   version "2.0.1"
@@ -516,6 +521,11 @@ binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bmp-js@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
+  integrity sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==
 
 brace-expansion@^2.0.1:
   version "2.0.1"
@@ -649,7 +659,7 @@ data-urls@^6.0.0:
     whatwg-mimetype "^5.0.0"
     whatwg-url "^15.1.0"
 
-debug@^4.3.4, debug@4:
+debug@4, debug@^4.3.4:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -847,6 +857,11 @@ https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
+idb-keyval@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.3.0.tgz#3fa4c062fcaddd7e577c51b51f69924bccfb58e6"
+  integrity sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
@@ -892,6 +907,11 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1032,17 +1052,7 @@ lru-cache@^10.2.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lru-cache@^11.2.4:
-  version "11.5.2"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz"
-  integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
-
-lru-cache@^11.2.5:
-  version "11.5.2"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz"
-  integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
-
-lru-cache@^11.2.6:
+lru-cache@^11.2.4, lru-cache@^11.2.5, lru-cache@^11.2.6:
   version "11.5.2"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz"
   integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
@@ -1113,6 +1123,13 @@ nanoid@^3.3.17:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
+node-fetch@^2.6.9:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-releases@^2.0.53:
   version "2.0.53"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz"
@@ -1137,6 +1154,11 @@ obug@^2.1.1:
   version "2.1.4"
   resolved "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz"
   integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
+
+opencollective-postinstall@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
@@ -1173,7 +1195,7 @@ pathe@^2.0.3:
   resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-picocolors@^1.0.0, picocolors@^1.1.1, picocolors@1.1.1:
+picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -1183,17 +1205,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.3:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
-  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
-
-picomatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
-  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
-
-picomatch@^4.0.5:
+picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -1333,6 +1345,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+regenerator-runtime@^0.13.3:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.14.0:
   version "0.14.1"
@@ -1549,6 +1566,26 @@ tailwindcss@^3.4.19:
     resolve "^1.22.8"
     sucrase "^3.35.0"
 
+tesseract.js-core@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz#596aa1ab5c130adab12f21059e6aa1a1cecc0bab"
+  integrity sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==
+
+tesseract.js@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tesseract.js/-/tesseract.js-7.0.0.tgz#4106fb6245efab40c57b94bc1798368807526be8"
+  integrity sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==
+  dependencies:
+    bmp-js "^0.1.0"
+    idb-keyval "^6.2.0"
+    is-url "^1.2.4"
+    node-fetch "^2.6.9"
+    opencollective-postinstall "^2.0.3"
+    regenerator-runtime "^0.13.3"
+    tesseract.js-core "^7.0.0"
+    wasm-feature-detect "^1.8.0"
+    zlibjs "^0.3.1"
+
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
@@ -1618,6 +1655,11 @@ tr46@^6.0.0:
   integrity sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==
   dependencies:
     punycode "^2.3.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"
@@ -1693,10 +1735,20 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
+wasm-feature-detect@^1.8.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.9.0.tgz#ae62b944805108fcc3b5f1e048ad2baa2d8ac2da"
+  integrity sha512-zonE+xlIIYtxPy++L24ow0hAD8CICb4+FgPyROd3buyXIqsJvUEDkBgfCCoXOd1Hu3DUr0GOfnPIdcGV+YpNaA==
+
 web-vitals@^2.1.0:
   version "2.1.4"
   resolved "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz"
   integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^8.0.0:
   version "8.0.1"
@@ -1720,6 +1772,14 @@ whatwg-url@^15.1.0:
   dependencies:
     tr46 "^6.0.0"
     webidl-conversions "^8.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"
@@ -1773,3 +1833,8 @@ yaml@^2.3.4:
   version "2.7.0"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz"
   integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
+
+zlibjs@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/zlibjs/-/zlibjs-0.3.1.tgz#50197edb28a1c42ca659cc8b4e6a9ddd6d444554"
+  integrity sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==


### PR DESCRIPTION
## 요약

- Lost Ark 화면 공유를 통해 강화창과 재료 툴팁에서 보유 재료 수량을 인식합니다.
- 공유 중 결과를 실시간 표시하고, 공유 종료 후 수정·제외한 확정 항목만 보유 재료에 적용합니다.
- 강화 페이지의 결과/보유 재료 UI 순서를 정리하고 단계별 비용을 접고 펼칠 수 있게 했습니다.

## 주요 변경

- `getDisplayMedia` 기반 Lost Ark 창 공유 및 2.5초 주기 프레임 분석
- 강화창 우선 재료 슬롯 탐색
  - 1/4 축소 coarse matching 후 후보 ROI 원본 해상도 정밀 매칭
  - 슬롯 수를 고정하지 않고 현재 대상 재료 아이콘 전체 탐색
  - `보유량 / 필요량`에서 왼쪽 보유량만 사용
- `9999` 처리
  - 확정값으로 적용하지 않고 `툴팁 확인 필요` 상태 유지
  - 툴팁의 `전체 보유 수량`, 제목 `[X 수량]` 순으로 보강
  - 툴팁 결과를 강화창 결과보다 우선
- 운명의 파편 처리
  - 상단 바 중앙 영역 우선
  - 강화창 소지 금액의 첫 번째 통화 영역 fallback
  - 실링/골드가 포함되지 않도록 OCR ROI 제한
- 동일 재료의 반복 프레임 결과를 합산하지 않고 더 신뢰할 수 있는 결과 유지
- OpenCV Mat, ImageBitmap, OCR Worker, 화면 공유 stream/track 정리
- 거래소 검색 결과에서 재료 이름이 정확히 일치하는 아이콘만 선택
- 사용자 안내 문구와 강화 페이지 섹션 순서 개선

## 샘플 확인

Temp 샘플은 제품 코드나 Git에 추가하지 않고 로컬 브라우저에서만 측정했습니다.

- 강화창: `9999 / 4260`, `879 / 44`, `659 / 47`, 운명의 파편 `3,068,727` 인식
- 이전 단계 강화창: `9999 / 780`, `1745 / 22`, `0 / 16`, 운명의 파편 `330,181` 인식
- 툴팁 전체 보유 수량 `950,870` 인식
- 상단 바 이미지에 표시된 운명의 파편 `1,236,295` 인식

## 검증

- `yarn test src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts src/components/enhancement/material-recognition/sessionResults.test.ts src/components/enhancement/material-recognition/MaterialScreenCapture.test.tsx src/components/enhancement/useEnhancementMarket.test.ts src/pages/Enhancement.test.tsx`
  - 5 files, 34 tests 통과
- `yarn typecheck` 통과
- `git diff --check origin/preview...HEAD` 통과

## 남은 위험

- 실제 완갑 강화창 샘플이 없어 파괴석/수호석 동시 인식은 코드 및 단위 테스트로만 검증했습니다.
- 울트라와이드, 추가 UI 스케일, 숨결 재료 슬롯은 더 많은 실제 샘플 검증이 필요합니다.
- OCR 신뢰도가 낮은 값은 검토 대상으로 표시하며 자동 적용하지 않습니다.

Closes #57
