### PR TITLE
fix: 화면 재료 인식 런타임 오류 수정

### DIFF
--- a/src/components/enhancement/material-recognition/opencvModule.ts
+++ b/src/components/enhancement/material-recognition/opencvModule.ts
@@ -1,0 +1,3 @@
+import cvModule from '@techstark/opencv-js';
+
+export default cvModule;

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import {
   createHoningObservation,
+  materialIconRequestUrl,
   parseHoningFateShardQuantity,
   parseHoningOwnedQuantity,
   parseTooltipQuantity,
   parseTooltipTitleQuantity,
   parseTopBarFateShardQuantity,
 } from './recognizeMaterialFrame';
+
+describe('materialIconRequestUrl', () => {
+  it('loads Lost Ark CDN icons through the same-origin proxy', () => {
+    expect(materialIconRequestUrl(
+      'https://cdn-lostark.game.onstove.com/efui_iconatlas/use/use_6_104.png?cache=1',
+    )).toBe('/api/material-icon/efui_iconatlas/use/use_6_104.png?cache=1');
+  });
+
+  it('does not rewrite other icon origins', () => {
+    expect(materialIconRequestUrl('https://example.com/icon.png')).toBe('https://example.com/icon.png');
+  });
+});
 
 describe('parseTooltipTitleQuantity', () => {
   it.each([

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -27,9 +27,9 @@ const templateCanvasCache = new Map<string, HTMLCanvasElement>();
 
 const getOpenCv = (): Promise<OpenCv> => {
   if (openCvPromise) return openCvPromise;
-  openCvPromise = import('@techstark/opencv-js').then(async (module) => {
-    const candidate = ('default' in module ? module.default : module) as unknown;
-    const cv = await Promise.resolve(candidate) as OpenCv;
+  openCvPromise = import('./opencvModule').then(async ({ default: importedModule }) => {
+    const candidate: unknown = importedModule;
+    const cv = (candidate instanceof Promise ? await candidate : candidate) as OpenCv;
     if (cv.Mat) return cv;
     await new Promise<void>((resolve) => {
       cv.onRuntimeInitialized = resolve;
@@ -63,11 +63,17 @@ const getTooltipOcrWorker = (): Promise<OcrWorker> => {
   return tooltipOcrWorkerPromise;
 };
 
+export const materialIconRequestUrl = (url: string): string => {
+  const parsed = new URL(url, window.location.origin);
+  if (parsed.origin !== 'https://cdn-lostark.game.onstove.com') return url;
+  return `/api/material-icon${parsed.pathname}${parsed.search}`;
+};
+
 const loadTemplateCanvas = async (url: string): Promise<HTMLCanvasElement> => {
   const cached = templateCanvasCache.get(url);
   if (cached) return cached;
 
-  const response = await fetch(url, { mode: 'cors', credentials: 'omit' });
+  const response = await fetch(materialIconRequestUrl(url), { credentials: 'omit' });
   if (!response.ok) throw new Error('재료 아이콘을 불러오지 못했습니다.');
   const bitmap = await createImageBitmap(await response.blob());
   const canvas = document.createElement('canvas');

--- a/src/staticSeoGeneration.test.js
+++ b/src/staticSeoGeneration.test.js
@@ -154,10 +154,13 @@ test('generates a noindex static 404 document with the home canonical', () => {
 });
 
 test('keeps API, known routes, missing routes, and static assets distinct in Vercel routing', () => {
-  const { outputDirectory, rewrites } = require(join(projectRoot, 'vercel.json'));
-  const apiRewrite = rewrites[0];
+  const { outputDirectory, headers, rewrites } = require(join(projectRoot, 'vercel.json'));
+  const apiRewrite = rewrites.find((rewrite) => rewrite.source === '/api/lostark/:path*');
+  const materialIconSource = '/api/material-icon/:path(.*\\.png)';
+  const materialIconRewrite = rewrites.find((rewrite) => rewrite.source === materialIconSource);
+  const materialIconHeaders = headers.find((rule) => rule.source === materialIconSource);
   const fallbackRewrite = rewrites[rewrites.length - 1];
-  const pageRewrites = rewrites.slice(1, -1);
+  const pageRewrites = rewrites.filter((rewrite) => rewrite.destination.endsWith('/index.html'));
   const indexablePageRoutes = routeSeoEntries
     .filter((route) => route.path !== '/' && route.robots === 'index, follow')
     .map((route) => route.path)
@@ -167,6 +170,20 @@ test('keeps API, known routes, missing routes, and static assets distinct in Ver
   expect(apiRewrite).toEqual({
     source: '/api/lostark/:path*',
     destination: '/api/lostark/[...]',
+  });
+  expect(materialIconRewrite).toEqual({
+    source: materialIconSource,
+    destination: 'https://cdn-lostark.game.onstove.com/:path',
+  });
+  expect(materialIconHeaders).toEqual({
+    source: materialIconSource,
+    headers: [
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400',
+      },
+    ],
   });
   expect(pageRewrites.map((rewrite) => rewrite.source).sort()).toEqual(indexablePageRoutes);
   for (const rewrite of pageRewrites) {

--- a/src/viteConfiguration.test.ts
+++ b/src/viteConfiguration.test.ts
@@ -13,8 +13,9 @@ describe('Vite migration configuration', () => {
       isPreview: false,
     });
     const proxy = config.server?.proxy?.['/api/lostark'];
+    const iconProxy = config.server?.proxy?.['/api/material-icon'];
 
-    if (!proxy || typeof proxy === 'string') {
+    if (!proxy || typeof proxy === 'string' || !iconProxy || typeof iconProxy === 'string') {
       throw new TypeError('Expected the Lost Ark proxy configuration');
     }
 
@@ -22,6 +23,10 @@ describe('Vite migration configuration', () => {
     expect(proxy.changeOrigin).toBe(true);
     expect(proxy.rewrite?.('/api/lostark/news/events')).toBe('/news/events');
     expect(proxy.headers?.accept).toBe('application/json');
+    expect(iconProxy.target).toBe('https://cdn-lostark.game.onstove.com');
+    expect(iconProxy.changeOrigin).toBe(true);
+    expect(iconProxy.rewrite?.('/api/material-icon/efui_iconatlas/icon.png'))
+      .toBe('/efui_iconatlas/icon.png');
 
     // loadEnv is consumed only while creating the dev server config. Nothing is defined in client code.
     expect(config.define).toBeUndefined();

--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,18 @@
   "installCommand": "corepack enable && corepack prepare yarn@1.22.22 --activate && yarn install --frozen-lockfile",
   "buildCommand": "yarn build",
   "outputDirectory": "build",
+  "headers": [
+    {
+      "source": "/api/material-icon/:path(.*\\.png)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/api/lostark/:path*", "destination": "/api/lostark/[...]" },
-    { "source": "/api/material-icon/:path*", "destination": "https://cdn-lostark.game.onstove.com/:path*" },
+    { "source": "/api/material-icon/:path(.*\\.png)", "destination": "https://cdn-lostark.game.onstove.com/:path" },
     { "source": "/character", "destination": "/character/index.html" },
     { "source": "/simulation", "destination": "/simulation/index.html" },
     { "source": "/spec-simulator", "destination": "/spec-simulator/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
   "outputDirectory": "build",
   "rewrites": [
     { "source": "/api/lostark/:path*", "destination": "/api/lostark/[...]" },
+    { "source": "/api/material-icon/:path*", "destination": "https://cdn-lostark.game.onstove.com/:path*" },
     { "source": "/character", "destination": "/character/index.html" },
     { "source": "/simulation", "destination": "/simulation/index.html" },
     { "source": "/spec-simulator", "destination": "/spec-simulator/index.html" },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv } from 'vite';
 
 const LOST_ARK_API_ORIGIN = 'https://developer-lostark.game.onstove.com';
+const LOST_ARK_CDN_ORIGIN = 'https://cdn-lostark.game.onstove.com';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'LOSTARK_');
@@ -20,6 +21,11 @@ export default defineConfig(({ mode }) => {
             accept: 'application/json',
             ...(apiKey ? { authorization: `bearer ${apiKey}` } : {}),
           },
+        },
+        '/api/material-icon': {
+          target: LOST_ARK_CDN_ORIGIN,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api\/material-icon/, ''),
         },
       },
     },


### PR DESCRIPTION
## 문제

- 배포 번들에서 OpenCV Promise를 초기화할 때 `Promise.prototype.then called on incompatible receiver` 오류가 발생했습니다.
- Lost Ark CDN 재료 아이콘을 canvas 분석용으로 직접 가져올 때 CORS 오류가 발생했습니다.

## 변경

- OpenCV CommonJS 모듈을 로컬 ESM 모듈로 감싸 지연 로딩합니다.
- 재료 아이콘을 동일 출처 `/api/material-icon` 경로로 프록시합니다.
- 개발 서버와 Vercel rewrite를 동일하게 구성합니다.

## 검증

- 관련 테스트 2개 파일, 20개 테스트 통과
- `yarn typecheck` 통과
- `yarn build` 통과
- 프로덕션 빌드를 브라우저에서 직접 import하여 OpenCV `Mat` 초기화 확인
- 동일 출처 아이콘 프록시에서 PNG 응답(200) 확인
- `git diff --check` 통과
