### PR TITLE
비공개 배포 PWA manifest 인증 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <meta name="twitter:description" content="로아끼욧에서 로스트아크 캐릭터 조회, 원정대 주간 골드 계산, 스펙 시뮬레이터, 강화·거래소·지출 관리를 한 번에 확인하세요." />
     <meta name="twitter:image" content="https://lokki.vercel.app/og-banner.png" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
     <script id="route-structured-data" type="application/ld+json">

--- a/src/staticSeoGeneration.test.js
+++ b/src/staticSeoGeneration.test.js
@@ -37,6 +37,12 @@ afterAll(() => {
   rmSync(fixtureRoot, { recursive: true, force: true });
 });
 
+test('keeps credentials enabled for the protected deployment manifest request', () => {
+  const indexHtml = readFileSync(join(projectRoot, 'index.html'), 'utf8');
+
+  expect(indexHtml).toContain('<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />');
+});
+
 test('uses a 1200 by 630 PNG for static social metadata', () => {
   const indexHtml = readFileSync(join(projectRoot, 'index.html'), 'utf8');
   const png = readFileSync(join(projectRoot, 'public', 'og-banner.png'));


### PR DESCRIPTION
## 원인
- 비공개 Vercel 배포에서 `/manifest.json` 요청에 인증 쿠키가 포함되지 않아 Vercel SSO로 리다이렉트됩니다.
- 이 리다이렉트 응답으로 인해 manifest 로드 시 CORS 오류가 발생합니다.

## 해결
- manifest 링크에 `crossorigin="use-credentials"`를 적용해 인증 쿠키가 요청에 포함되도록 했습니다.
- Vercel Deployment Protection은 그대로 유지합니다.
- 보호 우회 토큰이나 secret은 추가하지 않았습니다.

## 테스트 및 검증
- `yarn test src/staticSeoGeneration.test.js --run` (6 tests passed)
- `yarn build` (typecheck, Vite production build, static SEO generation 성공)
- 생성된 `build/index.html`에서 `crossorigin="use-credentials"`가 포함된 manifest 링크 확인
- `git diff --check` 통과
