### PR TITLE
비공개 배포 재료 아이콘 인증 오류 수정

### DIFF
--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createHoningObservation,
+  fetchMaterialIcon,
   materialIconRequestUrl,
   parseHoningFateShardQuantity,
   parseHoningOwnedQuantity,
@@ -10,10 +11,28 @@ import {
 } from './recognizeMaterialFrame';
 
 describe('materialIconRequestUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('loads Lost Ark CDN icons through the same-origin proxy', () => {
     expect(materialIconRequestUrl(
       'https://cdn-lostark.game.onstove.com/efui_iconatlas/use/use_6_104.png?cache=1',
     )).toBe('/api/material-icon/efui_iconatlas/use/use_6_104.png?cache=1');
+  });
+
+  it('includes same-origin credentials for protected preview deployments', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchMaterialIcon(
+      'https://cdn-lostark.game.onstove.com/efui_iconatlas/use/use_6_104.png?cache=1',
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/material-icon/efui_iconatlas/use/use_6_104.png?cache=1',
+      { credentials: 'same-origin' },
+    );
   });
 
   it('does not rewrite other icon origins', () => {

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -69,11 +69,15 @@ export const materialIconRequestUrl = (url: string): string => {
   return `/api/material-icon${parsed.pathname}${parsed.search}`;
 };
 
+export const fetchMaterialIcon = (url: string): Promise<Response> => (
+  fetch(materialIconRequestUrl(url), { credentials: 'same-origin' })
+);
+
 const loadTemplateCanvas = async (url: string): Promise<HTMLCanvasElement> => {
   const cached = templateCanvasCache.get(url);
   if (cached) return cached;
 
-  const response = await fetch(materialIconRequestUrl(url), { credentials: 'omit' });
+  const response = await fetchMaterialIcon(url);
   if (!response.ok) throw new Error('재료 아이콘을 불러오지 못했습니다.');
   const bitmap = await createImageBitmap(await response.blob());
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
## 원인
- 화면 인식용 재료 아이콘을 `/api/material-icon/...` same-origin 프록시로 요청하면서 `credentials: 'omit'`을 명시하고 있었습니다.
- 비공개 Vercel 배포에서는 인증 쿠키가 제외되어 Vercel SSO로 리다이렉트되고, 리다이렉트 응답에서 CORS 오류가 발생했습니다.

## 해결
- 재료 아이콘 요청의 credentials 모드를 `same-origin`으로 변경했습니다.
- 보호된 preview의 same-origin 요청에는 Vercel 인증 쿠키가 포함됩니다.
- 외부 origin에는 쿠키를 보내지 않으므로 공개 production 동작과 보안 경계를 유지합니다.
- Deployment Protection 설정과 secret/config는 변경하지 않았습니다.

## 테스트 및 검증
- `yarn test src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts --run` (19 tests passed)
- `yarn typecheck` 통과
- `git diff --check` 통과
