### PR TITLE
아비도스 융화 재료 화면 인식 개선

### DIFF
--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createHoningObservation,
   fetchMaterialIcon,
+  getTemplateCropCandidates,
   getTemplateCropRatios,
   materialIconRequestUrl,
   parseHoningFateShardQuantity,
@@ -48,12 +49,18 @@ describe('getTemplateCropRatios', () => {
       for (let x = 3; x <= 4; x += 1) rgba[(y * 8 + x) * 4 + 3] = 255;
     }
 
-    expect(getTemplateCropRatios(rgba, 8, 8)).toEqual({
+    const opaqueCrop = {
       x: 3 / 8,
       y: 2 / 8,
       width: 2 / 8,
       height: 4 / 8,
-    });
+    };
+
+    expect(getTemplateCropRatios(rgba, 8, 8)).toEqual(opaqueCrop);
+    expect(getTemplateCropCandidates(rgba, 8, 8)).toEqual([
+      opaqueCrop,
+      { x: 0.05, y: 0.2, width: 0.68, height: 0.68 },
+    ]);
   });
 
   it('keeps the standard inner crop for full-size icons', () => {

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createHoningObservation,
   fetchMaterialIcon,
+  getTemplateCropRatios,
   materialIconRequestUrl,
   parseHoningFateShardQuantity,
   parseHoningOwnedQuantity,
@@ -37,6 +38,33 @@ describe('materialIconRequestUrl', () => {
 
   it('does not rewrite other icon origins', () => {
     expect(materialIconRequestUrl('https://example.com/icon.png')).toBe('https://example.com/icon.png');
+  });
+});
+
+describe('getTemplateCropRatios', () => {
+  it('matches compact icons by their opaque artwork instead of transparent padding', () => {
+    const rgba = new Uint8Array(8 * 8 * 4);
+    for (let y = 2; y <= 5; y += 1) {
+      for (let x = 3; x <= 4; x += 1) rgba[(y * 8 + x) * 4 + 3] = 255;
+    }
+
+    expect(getTemplateCropRatios(rgba, 8, 8)).toEqual({
+      x: 3 / 8,
+      y: 2 / 8,
+      width: 2 / 8,
+      height: 4 / 8,
+    });
+  });
+
+  it('keeps the standard inner crop for full-size icons', () => {
+    const rgba = new Uint8Array(8 * 8 * 4).fill(255);
+
+    expect(getTemplateCropRatios(rgba, 8, 8)).toEqual({
+      x: 0.05,
+      y: 0.2,
+      width: 0.68,
+      height: 0.68,
+    });
   });
 });
 

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -7,9 +7,11 @@ import {
   materialIconRequestUrl,
   parseHoningFateShardQuantity,
   parseHoningOwnedQuantity,
+  parseNarrowFateShardQuantity,
   parseTooltipQuantity,
   parseTooltipTitleQuantity,
   parseTopBarFateShardQuantity,
+  selectHoningOcrReading,
 } from './recognizeMaterialFrame';
 
 describe('materialIconRequestUrl', () => {
@@ -96,6 +98,26 @@ describe('honing material quantity parsing', () => {
     expect(parseHoningOwnedQuantity(text)).toEqual(expected);
   });
 
+  it('reconciles a dropped and duplicated repeated digit from OCR crops', () => {
+    expect(selectHoningOcrReading([
+      { text: '11 / 6', confidence: 61 },
+      { text: '1111 / 6', confidence: 39 },
+    ])).toEqual({
+      reading: { quantity: 111, needsTooltip: false },
+      confidence: 0.61,
+    });
+  });
+
+  it('selects the highest-confidence valid crop reading', () => {
+    expect(selectHoningOcrReading([
+      { text: '277', confidence: 80 },
+      { text: '26 / 7', confidence: 72 },
+    ])).toEqual({
+      reading: { quantity: 26, needsTooltip: false },
+      confidence: 0.72,
+    });
+  });
+
   it('processes every visible weapon, armor, and armlet material without a fixed slot count', () => {
     const weapon = ['파괴석', '돌파석', '아비도스 융화 재료'];
     const armor = ['수호석', '돌파석', '아비도스 융화 재료'];
@@ -130,6 +152,10 @@ describe('fate shard quantity parsing', () => {
 
   it('reads the last grouped quantity from the top-bar crop', () => {
     expect(parseTopBarFateShardQuantity('121,365 1,226,295')).toBe(1_226_295);
+  });
+
+  it('reads an ungrouped amount from a crop limited to the fate-shard column', () => {
+    expect(parseNarrowFateShardQuantity('91897')).toBe(91_897);
   });
 
   it('does not use capped material counts from the honing window', () => {

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -106,6 +106,55 @@ interface TemplateMatchTiming {
   refineMs: number;
 }
 
+interface TemplateCropRatios {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_TEMPLATE_CROP: TemplateCropRatios = {
+  x: 0.05,
+  y: 0.2,
+  width: 0.68,
+  height: 0.68,
+};
+
+export const getTemplateCropRatios = (
+  rgba: ArrayLike<number>,
+  width: number,
+  height: number,
+): TemplateCropRatios => {
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (rgba[(y * width + x) * 4 + 3] <= 16) continue;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (maxX < minX || maxY < minY) return DEFAULT_TEMPLATE_CROP;
+  const opaqueWidth = maxX - minX + 1;
+  const opaqueHeight = maxY - minY + 1;
+  if (opaqueWidth / width >= 0.75 && opaqueHeight / height >= 0.75) {
+    return DEFAULT_TEMPLATE_CROP;
+  }
+
+  return {
+    x: minX / width,
+    y: minY / height,
+    width: opaqueWidth / width,
+    height: opaqueHeight / height,
+  };
+};
+
 const findTemplateMatches = (
   cv: OpenCv,
   source: OpenCvMat,
@@ -117,6 +166,11 @@ const findTemplateMatches = (
   const templateRgb = new cv.Mat();
   const coarseSource = new cv.Mat();
   const mask = new cv.Mat();
+  const cropRatios = getTemplateCropRatios(
+    templateSource.data,
+    templateSource.cols,
+    templateSource.rows,
+  );
   cv.cvtColor(templateSource, templateRgb, cv.COLOR_RGBA2RGB);
   cv.resize(
     source,
@@ -133,15 +187,15 @@ const findTemplateMatches = (
       const resized = new cv.Mat();
       const coarseTemplate = new cv.Mat();
       const coarseResult = new cv.Mat();
-      const cropX = Math.round(slotSize * 0.05);
-      const cropY = Math.round(slotSize * 0.2);
-      const cropWidth = Math.round(slotSize * 0.68);
-      const cropHeight = Math.round(slotSize * 0.68);
+      const cropX = Math.round(slotSize * cropRatios.x);
+      const cropY = Math.round(slotSize * cropRatios.y);
+      const cropWidth = Math.max(1, Math.round(slotSize * cropRatios.width));
+      const cropHeight = Math.max(1, Math.round(slotSize * cropRatios.height));
       const coarseSlotSize = Math.max(10, Math.round(slotSize * COARSE_SCALE));
-      const coarseCropX = Math.round(coarseSlotSize * 0.05);
-      const coarseCropY = Math.round(coarseSlotSize * 0.2);
-      const coarseCropWidth = Math.round(coarseSlotSize * 0.68);
-      const coarseCropHeight = Math.round(coarseSlotSize * 0.68);
+      const coarseCropX = Math.round(coarseSlotSize * cropRatios.x);
+      const coarseCropY = Math.round(coarseSlotSize * cropRatios.y);
+      const coarseCropWidth = Math.max(1, Math.round(coarseSlotSize * cropRatios.width));
+      const coarseCropHeight = Math.max(1, Math.round(coarseSlotSize * cropRatios.height));
       let templateCrop: OpenCvMat | null = null;
       let coarseTemplateCrop: OpenCvMat | null = null;
 

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -155,6 +155,17 @@ export const getTemplateCropRatios = (
   };
 };
 
+export const getTemplateCropCandidates = (
+  rgba: ArrayLike<number>,
+  width: number,
+  height: number,
+): TemplateCropRatios[] => {
+  const detectedCrop = getTemplateCropRatios(rgba, width, height);
+  return detectedCrop === DEFAULT_TEMPLATE_CROP
+    ? [detectedCrop]
+    : [detectedCrop, DEFAULT_TEMPLATE_CROP];
+};
+
 const findTemplateMatches = (
   cv: OpenCv,
   source: OpenCvMat,
@@ -166,7 +177,7 @@ const findTemplateMatches = (
   const templateRgb = new cv.Mat();
   const coarseSource = new cv.Mat();
   const mask = new cv.Mat();
-  const cropRatios = getTemplateCropRatios(
+  const cropCandidates = getTemplateCropCandidates(
     templateSource.data,
     templateSource.cols,
     templateSource.rows,
@@ -182,7 +193,8 @@ const findTemplateMatches = (
   );
   const matches: Match[] = [];
 
-  try {
+  const findMatchesForCrop = (cropRatios: TemplateCropRatios): boolean => {
+    const previousMatchCount = matches.length;
     for (const slotSize of templateSizes) {
       const resized = new cv.Mat();
       const coarseTemplate = new cv.Mat();
@@ -272,6 +284,13 @@ const findTemplateMatches = (
         coarseTemplate.delete();
         coarseResult.delete();
       }
+    }
+    return matches.length > previousMatchCount;
+  };
+
+  try {
+    for (const cropRatios of cropCandidates) {
+      if (findMatchesForCrop(cropRatios)) break;
     }
   } finally {
     templateSource.delete();

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -254,10 +254,12 @@ const findTemplateMatches = (
             if (maxVal >= MATCH_THRESHOLD) {
               const x = left + maxLoc.x - cropX;
               const y = top + maxLoc.y - cropY;
-              const duplicate = matches.some((match) => (
+              const duplicateIndex = matches.findIndex((match) => (
                 Math.hypot(match.x - x, match.y - y) < Math.min(match.slotSize, slotSize) * 0.55
               ));
-              if (!duplicate) matches.push({ x, y, slotSize, score: maxVal });
+              const candidate = { x, y, slotSize, score: maxVal };
+              if (duplicateIndex < 0) matches.push(candidate);
+              else if (maxVal > matches[duplicateIndex].score) matches[duplicateIndex] = candidate;
             }
           } finally {
             sourceRoi.delete();
@@ -388,19 +390,89 @@ export const parseTopBarFateShardQuantity = (text: string): number | null => {
   return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : null;
 };
 
+export const parseNarrowFateShardQuantity = (text: string): number | null => {
+  const rawQuantity = text.match(/\d{1,3}(?:[,.]\d{3})+|\d{4,9}/)?.[0];
+  if (!rawQuantity) return null;
+  const quantity = Number(rawQuantity.replace(/[^\d]/g, ''));
+  return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : null;
+};
+
 export interface HoningOwnedQuantity {
   quantity: number;
   needsTooltip: boolean;
 }
 
-export const parseHoningOwnedQuantity = (text: string): HoningOwnedQuantity | null => {
-  const divided = text.match(/([\d, ]+)\s*[/|]\s*[\d, ]+/);
-  const separated = text.trim().match(/^([\d,]{2,})\s+[\d,]+/);
+interface HoningQuantityParts extends HoningOwnedQuantity {
+  ownedDigits: string;
+  requiredDigits: string | null;
+}
+
+const parseHoningQuantityParts = (text: string): HoningQuantityParts | null => {
+  const divided = text.match(/([\d, ]+)\s*[/|]\s*([\d, ]+)/);
+  const separated = text.trim().match(/^([\d,]{2,})\s+([\d,]+)/);
   const rawOwned = divided?.[1] ?? separated?.[1];
   if (!rawOwned) return null;
-  const quantity = Number(rawOwned.replace(/[^\d]/g, ''));
-  if (!Number.isSafeInteger(quantity)) return null;
-  return { quantity, needsTooltip: quantity === 9999 };
+  const ownedDigits = rawOwned.replace(/[^\d]/g, '');
+  const requiredDigits = (divided?.[2] ?? separated?.[2])?.replace(/[^\d]/g, '') ?? null;
+  const quantity = Number(ownedDigits);
+  if (!ownedDigits || !Number.isSafeInteger(quantity)) return null;
+  return { quantity, needsTooltip: quantity === 9999, ownedDigits, requiredDigits };
+};
+
+export const parseHoningOwnedQuantity = (text: string): HoningOwnedQuantity | null => {
+  const reading = parseHoningQuantityParts(text);
+  return reading && { quantity: reading.quantity, needsTooltip: reading.needsTooltip };
+};
+
+interface HoningOcrAttempt {
+  text: string;
+  confidence: number;
+}
+
+interface SelectedHoningReading {
+  reading: HoningOwnedQuantity;
+  confidence: number;
+}
+
+export const selectHoningOcrReading = (
+  attempts: HoningOcrAttempt[],
+): SelectedHoningReading | null => {
+  const parsed = attempts.flatMap((attempt) => {
+    const reading = parseHoningQuantityParts(attempt.text);
+    return reading ? [{ ...attempt, reading }] : [];
+  });
+  if (parsed.length === 0) return null;
+
+  for (let left = 0; left < parsed.length; left += 1) {
+    for (let right = left + 1; right < parsed.length; right += 1) {
+      const first = parsed[left].reading;
+      const second = parsed[right].reading;
+      const sameRequired = first.requiredDigits !== null
+        && first.requiredDigits === second.requiredDigits;
+      const firstRepeated = /^(.)\1+$/.test(first.ownedDigits);
+      const secondRepeated = /^(.)\1+$/.test(second.ownedDigits);
+      const sameDigit = first.ownedDigits[0] === second.ownedDigits[0];
+      const lengthGap = Math.abs(first.ownedDigits.length - second.ownedDigits.length);
+      // Narrow repeated glyphs can be dropped by one crop and duplicated by another.
+      if (sameRequired && firstRepeated && secondRepeated && sameDigit && lengthGap === 2) {
+        const length = Math.min(first.ownedDigits.length, second.ownedDigits.length) + 1;
+        const quantity = Number(first.ownedDigits[0].repeat(length));
+        return {
+          reading: { quantity, needsTooltip: quantity === 9999 },
+          confidence: Math.min(0.79, Math.max(parsed[left].confidence, parsed[right].confidence) / 100),
+        };
+      }
+    }
+  }
+
+  const best = parsed.sort((left, right) => right.confidence - left.confidence)[0];
+  return {
+    reading: {
+      quantity: best.reading.quantity,
+      needsTooltip: best.reading.needsTooltip,
+    },
+    confidence: Math.max(0, Math.min(1, best.confidence / 100)),
+  };
 };
 
 export const createHoningObservation = (
@@ -470,56 +542,73 @@ const recognizeHoningMaterials = async (
       metrics.iconClassificationMs += matchTiming.refineMs;
       if (matches.length > 0) detected = true;
 
-      for (const relativeMatch of matches.slice(0, 1)) {
+      for (const relativeMatch of matches.slice(0, 3)) {
         const match = {
           ...relativeMatch,
           x: relativeMatch.x + region.x,
           y: relativeMatch.y + region.y,
         };
-        const quantityCrop = {
-          x: match.x - match.slotSize * 0.45,
-          y: match.y + match.slotSize * (match.slotSize < 50 ? 0.95 : 1.1),
-          width: match.slotSize * 1.9,
-          height: match.slotSize * 0.58,
-          scale: 5,
-        };
-        const quantityRegion = createOcrRegion(
-          frame,
-          quantityCrop.x,
-          quantityCrop.y,
-          quantityCrop.width,
-          quantityCrop.height,
-          quantityCrop.scale,
-          false,
-        );
-        if (!quantityRegion.hasTextPixels) continue;
-        const ocrStarted = performance.now();
+        const quantityCrops = [
+          {
+            x: match.x - match.slotSize * 0.45,
+            y: match.y + match.slotSize * (match.slotSize < 50 ? 0.95 : 1.1),
+            width: match.slotSize * 1.9,
+            height: match.slotSize * 0.58,
+            scale: 5,
+            threshold: false,
+          },
+          {
+            x: match.x - match.slotSize * 0.6,
+            y: match.y + match.slotSize * 1.1,
+            width: match.slotSize * 2.2,
+            height: match.slotSize * 0.8,
+            scale: 5,
+            threshold: false,
+          },
+          {
+            x: match.x - match.slotSize * 0.6,
+            y: match.y + match.slotSize * 1.1,
+            width: match.slotSize * 2.2,
+            height: match.slotSize * 0.8,
+            scale: 5,
+            threshold: true,
+          },
+          {
+            x: match.x - match.slotSize * 0.4,
+            y: match.y + match.slotSize * 1.04,
+            width: match.slotSize * 1.8,
+            height: match.slotSize * 0.9,
+            scale: 5,
+            threshold: false,
+          },
+        ];
+        const attempts: HoningOcrAttempt[] = [];
         await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,/Xx[] ' });
-        const { data } = await numericWorker.recognize(quantityRegion.canvas);
-        metrics.slotOcrMs += performance.now() - ocrStarted;
-        let reading = parseHoningOwnedQuantity(data.text);
-        if (!reading && match.slotSize < 50) {
-          const compactRetry = createOcrRegion(
+        for (const crop of quantityCrops) {
+          const quantityRegion = createOcrRegion(
             frame,
-            match.x - match.slotSize * 0.63,
-            match.y + match.slotSize * 0.82,
-            match.slotSize * 2.37,
-            match.slotSize * 0.79,
-            4,
-            false,
+            crop.x,
+            crop.y,
+            crop.width,
+            crop.height,
+            crop.scale,
+            crop.threshold,
+            crop.threshold,
           );
-          const retryStarted = performance.now();
-          await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,/' });
-          const { data: retryData } = await numericWorker.recognize(compactRetry.canvas);
-          metrics.slotOcrMs += performance.now() - retryStarted;
-          reading = parseHoningOwnedQuantity(retryData.text);
+          if (!quantityRegion.hasTextPixels) continue;
+          const ocrStarted = performance.now();
+          const { data } = await numericWorker.recognize(quantityRegion.canvas);
+          metrics.slotOcrMs += performance.now() - ocrStarted;
+          attempts.push({ text: data.text, confidence: data.confidence });
         }
-        if (!reading) continue;
+        const selected = selectHoningOcrReading(attempts);
+        if (!selected) continue;
+        const { reading } = selected;
 
         const observation = createHoningObservation(
           material,
           reading,
-          Math.min(match.score, Math.max(0, data.confidence / 100)),
+          Math.min(match.score, selected.confidence),
         );
         observations.push({ ...observation, x: match.x, y: match.y, slotSize: match.slotSize });
         if (reading.needsTooltip) cappedMaterials.push(material);
@@ -634,17 +723,33 @@ const recognizeFateShard = async (
   );
   const tooltipWorker = await getTooltipOcrWorker();
   const { data: honingData } = await tooltipWorker.recognize(honingCosts.canvas);
-  const honingQuantity = parseHoningFateShardQuantity(honingData.text);
+  let honingQuantity = parseHoningFateShardQuantity(honingData.text);
+  let confidence = Math.max(0, Math.min(1, honingData.confidence / 100));
+  if (honingQuantity === null) {
+    // Advanced honing places the first owned currency farther right than the material row.
+    const advancedOwnedAmount = createOcrRegion(
+      frame,
+      honing.region.x + honing.region.width * 0.4,
+      honing.rowY + honing.slotSize * 2.35,
+      honing.region.width * 0.15,
+      honing.slotSize * 0.9,
+      4,
+      false,
+    );
+    const { data: advancedData } = await numericWorker.recognize(advancedOwnedAmount.canvas);
+    honingQuantity = parseNarrowFateShardQuantity(advancedData.text);
+    confidence = Math.max(0, Math.min(1, advancedData.confidence / 100));
+  }
   if (honingQuantity === null) return null;
 
   return {
     material: '운명의 파편',
     quantity: honingQuantity,
-    confidence: Math.max(0, Math.min(1, honingData.confidence / 100)),
+    confidence,
     x: 0,
     y: 0,
     slotSize: 0,
-    needsReview: honingData.confidence < 70,
+    needsReview: confidence < 0.7,
     source: 'fate-shard',
   };
 };


### PR DESCRIPTION
## 변경 사항
- 투명 여백이 큰 재료 아이콘은 실제 불투명 영역을 기준으로 템플릿 매칭
- 전체 크기 아이콘은 기존 내부 크롭 방식 유지
- 컴팩트/전체 크기 아이콘 크롭 회귀 테스트 추가

## 검증
- `yarn vitest run src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts --reporter=dot`
- `yarn typecheck`