### PR TITLE
feat: 장신구·전설 아바타·팔찌 시세 검색 추가

### DIFF
--- a/api/lostark/[...].js
+++ b/api/lostark/[...].js
@@ -7,6 +7,7 @@ const ALLOWED_GET_PATHS = [
   /^news\/events$/,
   /^gamecontents\/calendar$/,
   /^markets\/options$/,
+  /^auctions\/options$/,
 ];
 const ALLOWED_POST_PATHS = new Set(['markets/items', 'auctions/items']);
 

--- a/api/lostark/[...].js
+++ b/api/lostark/[...].js
@@ -3,7 +3,7 @@ const ALLOWED_METHODS = new Set(['GET', 'POST']);
 const UPSTREAM_TIMEOUT_MS = 10 * 1000;
 const ALLOWED_GET_PATHS = [
   /^characters\/[^/]+\/siblings$/,
-  /^armories\/characters\/[^/]+\/(profiles|arkgrid|equipment|gems|engravings|arkpassive|cards)$/,
+  /^armories\/characters\/[^/]+\/(profiles|arkgrid|equipment|gems|engravings|arkpassive|cards|avatars)$/,
   /^news\/events$/,
   /^gamecontents\/calendar$/,
   /^markets\/options$/,

--- a/api/lostark/proxy.test.js
+++ b/api/lostark/proxy.test.js
@@ -107,6 +107,22 @@ nodeDescribe('Lost Ark API proxy', () => {
     });
   });
 
+  nodeTest('allows auction options used to resolve official search codes', async () => {
+    let capturedUrl;
+    const handler = createHandler({
+      fetchImpl: async (url) => {
+        capturedUrl = url;
+        return createUpstreamResponse({ body: '{"Categories":[]}' });
+      },
+    });
+    const res = createResponse();
+
+    await handler(createRequest({ query: { path: ['auctions', 'options'] } }), res);
+
+    assert.equal(capturedUrl.toString(), 'https://developer-lostark.game.onstove.com/auctions/options');
+    assert.equal(res.statusCode, 200);
+  });
+
   nodeTest('allows the character avatars endpoint used by the spec simulator', async () => {
     let capturedUrl;
     const handler = createHandler({

--- a/api/lostark/proxy.test.js
+++ b/api/lostark/proxy.test.js
@@ -107,6 +107,31 @@ nodeDescribe('Lost Ark API proxy', () => {
     });
   });
 
+  nodeTest('allows the character avatars endpoint used by the spec simulator', async () => {
+    let capturedUrl;
+    const handler = createHandler({
+      fetchImpl: async (url) => {
+        capturedUrl = url;
+        return createUpstreamResponse({ body: '[]' });
+      },
+    });
+    const res = createResponse();
+
+    await handler(
+      createRequest({
+        query: { path: ['armories', 'characters', '한건뜬', 'avatars'] },
+      }),
+      res
+    );
+
+    assert.equal(
+      capturedUrl.toString(),
+      'https://developer-lostark.game.onstove.com/armories/characters/%ED%95%9C%EA%B1%B4%EB%9C%AC/avatars'
+    );
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.payload, '[]');
+  });
+
   nodeTest('forwards only controlled headers to an allowed upstream endpoint', async () => {
     let capturedUrl;
     let capturedOptions;

--- a/src/components/enhancement/useEnhancementMarket.ts
+++ b/src/components/enhancement/useEnhancementMarket.ts
@@ -45,7 +45,7 @@ export const useEnhancementMarket = () => {
           const itemsPerUnit = config.itemsPerUnit ?? 1;
           return {
             type,
-            price: item.CurrentMinPrice / item.BundleCount / itemsPerUnit,
+            price: (item.CurrentMinPrice ?? 0) / item.BundleCount / itemsPerUnit,
             icon: item.Icon,
           };
         }),

--- a/src/components/market/AccessoryMarket.test.tsx
+++ b/src/components/market/AccessoryMarket.test.tsx
@@ -32,6 +32,7 @@ const options = {
     EtcSubs: [
       { Value: 42, Text: '적에게 주는 피해 증가', Class: '', Categorys: [200010], Tiers: null, EtcValues: [optionValue('2.00%', 200), optionValue('1.20%', 120), optionValue('0.55%', 55)] },
       { Value: 41, Text: '추가 피해', Class: '', Categorys: [200010], Tiers: null, EtcValues: [optionValue('2.60%', 260), optionValue('1.60%', 160), optionValue('0.70%', 70)] },
+      { Value: 53, Text: '공격력 +', Class: '', Categorys: [200010], Tiers: null, EtcValues: [optionValue('390', 390), optionValue('195', 195), optionValue('80', 80)] },
     ],
   }],
 };
@@ -65,7 +66,12 @@ const auctionItem = {
 };
 
 describe('AccessoryMarket', () => {
-  it('searches exact tier 4 honing grades and shows only the two selected effects', async () => {
+  beforeEach(() => {
+    mockedFetchAuctionItems.mockReset();
+    mockedGetCachedAuctionOptions.mockReset();
+  });
+
+  it('searches exact tier 4 honing grades with an optional third effect', async () => {
     mockedGetCachedAuctionOptions.mockResolvedValue(options);
     mockedFetchAuctionItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 1, Items: [auctionItem] });
 
@@ -73,8 +79,21 @@ describe('AccessoryMarket', () => {
 
     expect(await screen.findByRole('combobox', { name: '장신구 등급' })).toHaveValue('고대');
     expect(screen.queryByText('티어')).not.toBeInTheDocument();
+    expect(within(screen.getByRole('combobox', { name: '장신구 옵션 2' })).getByRole('option', { name: '적에게 주는 피해 증가' })).toBeDisabled();
+    expect(within(screen.getByRole('combobox', { name: '장신구 옵션 1' })).getByRole('option', { name: '추가 피해' })).toBeDisabled();
+    const thirdOption = screen.getByRole('combobox', { name: '장신구 옵션 3' });
+    expect(thirdOption).toHaveValue('');
+    const firstSelectionInThird = within(thirdOption).getByRole('option', { name: '적에게 주는 피해 증가' });
+    const secondSelectionInThird = within(thirdOption).getByRole('option', { name: '추가 피해' });
+    expect(firstSelectionInThird).toBeDisabled();
+    expect(firstSelectionInThird).toHaveStyle({ color: 'rgb(156, 163, 175)' });
+    expect(secondSelectionInThird).toBeDisabled();
+    expect(secondSelectionInThird).toHaveStyle({ color: 'rgb(156, 163, 175)' });
+    expect(within(thirdOption).getByRole('option', { name: '공격력 +' })).toBeEnabled();
     fireEvent.change(screen.getByRole('combobox', { name: '장신구 옵션 1 등급' }), { target: { value: '200' } });
     fireEvent.change(screen.getByRole('combobox', { name: '장신구 옵션 2 등급' }), { target: { value: '260' } });
+    fireEvent.change(thirdOption, { target: { value: '7:53' } });
+    fireEvent.change(screen.getByRole('combobox', { name: '장신구 옵션 3 등급' }), { target: { value: '390' } });
     fireEvent.click(screen.getByRole('button', { name: '장신구 검색' }));
 
     await waitFor(() => expect(mockedFetchAuctionItems).toHaveBeenCalledTimes(1));
@@ -85,10 +104,25 @@ describe('AccessoryMarket', () => {
       EtcOptions: [
         { FirstOption: 7, SecondOption: 42, MinValue: 200, MaxValue: 200 },
         { FirstOption: 7, SecondOption: 41, MinValue: 260, MaxValue: 260 },
+        { FirstOption: 7, SecondOption: 53, MinValue: 390, MaxValue: 390 },
       ],
     }));
     const results = await screen.findByRole('region', { name: '장신구 검색 결과' });
-    expect(within(results).queryByText(/전투 중 생명력 회복량/)).not.toBeInTheDocument();
+    expect(results).toHaveTextContent('전투 중 생명력 회복량 하');
     expect(within(results).getByText('힘\/민\/지 16,000')).toBeInTheDocument();
+  });
+
+  it('locks search filters while a request is loading', async () => {
+    mockedGetCachedAuctionOptions.mockResolvedValue(options);
+    mockedFetchAuctionItems.mockImplementation(() => new Promise(() => {}));
+
+    render(<AccessoryMarket />);
+
+    await screen.findByRole('combobox', { name: '장신구 등급' });
+    fireEvent.click(screen.getByRole('button', { name: '장신구 검색' }));
+
+    expect(screen.getByRole('tab', { name: '반지' })).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: '장신구 등급' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '장신구 검색' })).toBeDisabled();
   });
 });

--- a/src/components/market/AccessoryMarket.test.tsx
+++ b/src/components/market/AccessoryMarket.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fetchAuctionItems } from '../../utils/api';
+import AccessoryMarket from './AccessoryMarket';
+import { getCachedAuctionOptions } from './marketOptionsCache';
+
+vi.mock('../../utils/api', () => ({ fetchAuctionItems: vi.fn() }));
+vi.mock('./marketOptionsCache', () => ({ getCachedAuctionOptions: vi.fn() }));
+
+const mockedFetchAuctionItems = vi.mocked(fetchAuctionItems);
+const mockedGetCachedAuctionOptions = vi.mocked(getCachedAuctionOptions);
+
+const optionValue = (displayValue: string, value: number) => ({ DisplayValue: displayValue, Value: value, IsPercentage: true });
+const options = {
+  MaxItemLevel: 1700,
+  ItemGradeQualities: [],
+  Categories: [{
+    Code: 200000,
+    CodeName: '장신구',
+    Subs: [
+      { Code: 200010, CodeName: '목걸이', Subs: null },
+      { Code: 200020, CodeName: '귀걸이', Subs: null },
+      { Code: 200030, CodeName: '반지', Subs: null },
+    ],
+  }],
+  ItemGrades: ['유물', '고대'],
+  ItemTiers: [4],
+  Classes: [],
+  EtcOptions: [{
+    Value: 7,
+    Text: '연마 효과',
+    Tiers: [4],
+    EtcSubs: [
+      { Value: 42, Text: '적에게 주는 피해 증가', Class: '', Categorys: [200010], Tiers: null, EtcValues: [optionValue('2.00%', 200), optionValue('1.20%', 120), optionValue('0.55%', 55)] },
+      { Value: 41, Text: '추가 피해', Class: '', Categorys: [200010], Tiers: null, EtcValues: [optionValue('2.60%', 260), optionValue('1.60%', 160), optionValue('0.70%', 70)] },
+    ],
+  }],
+};
+
+const auctionItem = {
+  Name: '고대 목걸이',
+  Grade: '고대',
+  Tier: 4,
+  Level: 1680,
+  Icon: 'https://example.com/accessory.png',
+  GradeQuality: 95,
+  AuctionInfo: {
+    StartPrice: 100,
+    BuyPrice: 1000,
+    BidPrice: 0,
+    EndDate: '2099-01-01T00:00:00Z',
+    BidCount: 0,
+    BidStartPrice: 100,
+    IsCompetitive: false,
+    TradeAllowCount: 2,
+  },
+  Options: [
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '적에게 주는 피해 증가', OptionNameTripod: '', Value: 2, IsPenalty: false, ClassName: null, IsValuePercentage: true },
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '전투 중 생명력 회복량', OptionNameTripod: '', Value: 10, IsPenalty: false, ClassName: null, IsValuePercentage: false },
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '추가 피해', OptionNameTripod: '', Value: 2.6, IsPenalty: false, ClassName: null, IsValuePercentage: true },
+    { Type: 'STAT', OptionName: '힘', OptionNameTripod: '', Value: 16000, IsPenalty: false, ClassName: null },
+    { Type: 'STAT', OptionName: '민첩', OptionNameTripod: '', Value: 16000, IsPenalty: false, ClassName: null },
+    { Type: 'STAT', OptionName: '지능', OptionNameTripod: '', Value: 16000, IsPenalty: false, ClassName: null },
+    { Type: 'STAT', OptionName: '체력', OptionNameTripod: '', Value: 3500, IsPenalty: false, ClassName: null },
+  ],
+};
+
+describe('AccessoryMarket', () => {
+  it('searches exact tier 4 honing grades and shows only the two selected effects', async () => {
+    mockedGetCachedAuctionOptions.mockResolvedValue(options);
+    mockedFetchAuctionItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 1, Items: [auctionItem] });
+
+    render(<AccessoryMarket />);
+
+    expect(await screen.findByRole('combobox', { name: '장신구 등급' })).toHaveValue('고대');
+    expect(screen.queryByText('티어')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByRole('combobox', { name: '장신구 옵션 1 등급' }), { target: { value: '200' } });
+    fireEvent.change(screen.getByRole('combobox', { name: '장신구 옵션 2 등급' }), { target: { value: '260' } });
+    fireEvent.click(screen.getByRole('button', { name: '장신구 검색' }));
+
+    await waitFor(() => expect(mockedFetchAuctionItems).toHaveBeenCalledTimes(1));
+    expect(mockedFetchAuctionItems).toHaveBeenCalledWith(expect.objectContaining({
+      CategoryCode: 200010,
+      ItemTier: 4,
+      ItemGrade: '고대',
+      EtcOptions: [
+        { FirstOption: 7, SecondOption: 42, MinValue: 200, MaxValue: 200 },
+        { FirstOption: 7, SecondOption: 41, MinValue: 260, MaxValue: 260 },
+      ],
+    }));
+    const results = await screen.findByRole('region', { name: '장신구 검색 결과' });
+    expect(within(results).queryByText(/전투 중 생명력 회복량/)).not.toBeInTheDocument();
+    expect(within(results).getByText('힘\/민\/지 16,000')).toBeInTheDocument();
+  });
+});

--- a/src/components/market/AccessoryMarket.tsx
+++ b/src/components/market/AccessoryMarket.tsx
@@ -58,14 +58,17 @@ const createDefaultOptionInputs = (
   tier?: number,
 ): OptionInput[] => {
   const categoryCode = findCategoryCode(options.Categories, part, '장신구');
-  if (categoryCode == null) return [EMPTY_OPTION, EMPTY_OPTION];
+  if (categoryCode == null) return [EMPTY_OPTION, EMPTY_OPTION, EMPTY_OPTION];
   const availableOptions = getPartHoningEffects(getAuctionOptionsForCategory(options, categoryCode, tier), part);
-  return DEFAULT_OPTION_NAMES[part].map((optionName) => {
-    const option = availableOptions.find((candidate) => candidate.Text === optionName);
-    return option
-      ? { firstOption: option.firstOption, secondOption: option.Value, minValue: '', maxValue: '' }
-      : EMPTY_OPTION;
-  });
+  return [
+    ...DEFAULT_OPTION_NAMES[part].map((optionName) => {
+      const option = availableOptions.find((candidate) => candidate.Text === optionName);
+      return option
+        ? { firstOption: option.firstOption, secondOption: option.Value, minValue: '', maxValue: '' }
+        : EMPTY_OPTION;
+    }),
+    EMPTY_OPTION,
+  ];
 };
 
 const AccessoryMarket: React.FC = () => {
@@ -77,7 +80,7 @@ const AccessoryMarket: React.FC = () => {
   const [quality, setQuality] = useState('');
   const [tradeCount, setTradeCount] = useState('');
   const [sortCondition, setSortCondition] = useState<'ASC' | 'DESC'>('ASC');
-  const [optionInputs, setOptionInputs] = useState<OptionInput[]>([EMPTY_OPTION, EMPTY_OPTION]);
+  const [optionInputs, setOptionInputs] = useState<OptionInput[]>([EMPTY_OPTION, EMPTY_OPTION, EMPTY_OPTION]);
   const [state, setState] = useState<SearchState>('idle');
   const [items, setItems] = useState<AuctionItem[]>([]);
   const [error, setError] = useState('');
@@ -85,7 +88,6 @@ const AccessoryMarket: React.FC = () => {
   const [pageSize, setPageSize] = useState(10);
   const [totalCount, setTotalCount] = useState(0);
   const [lastFilters, setLastFilters] = useState<AccessorySearchFilters | null>(null);
-  const [selectedHoningOptionNames, setSelectedHoningOptionNames] = useState<string[]>([]);
 
   useEffect(() => {
     let active = true;
@@ -117,11 +119,10 @@ const AccessoryMarket: React.FC = () => {
   const handlePartChange = (nextPart: AccessoryPart): void => {
     if (nextPart === part) return;
     setPart(nextPart);
-    setOptionInputs(options ? createDefaultOptionInputs(options, nextPart, ACCESSORY_TIER) : [EMPTY_OPTION, EMPTY_OPTION]);
+    setOptionInputs(options ? createDefaultOptionInputs(options, nextPart, ACCESSORY_TIER) : [EMPTY_OPTION, EMPTY_OPTION, EMPTY_OPTION]);
     setState('idle');
     setItems([]);
     setLastFilters(null);
-    setSelectedHoningOptionNames([]);
     setPageNo(1);
     setTotalCount(0);
   };
@@ -169,7 +170,6 @@ const AccessoryMarket: React.FC = () => {
       pageNo: 1,
     };
     setLastFilters(filters);
-    setSelectedHoningOptionNames(selectedResolvedOptions.map(({ resolved }) => resolved.Text));
     void runSearch(filters, 1);
   };
 
@@ -188,6 +188,7 @@ const AccessoryMarket: React.FC = () => {
               type="button"
               role="tab"
               aria-selected={part === item}
+              disabled={state === 'loading'}
               onClick={() => handlePartChange(item)}
               className={`rounded-xl px-3 py-2.5 text-sm font-black transition-colors ${
                 part === item
@@ -201,21 +202,21 @@ const AccessoryMarket: React.FC = () => {
         </div>
         <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">등급
-            <select aria-label="장신구 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full">
+            <select aria-label="장신구 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               {ACCESSORY_GRADES.filter((itemGrade) => options.ItemGrades.includes(itemGrade)).map((itemGrade) => <option key={itemGrade}>{itemGrade}</option>)}
             </select>
           </label>
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">최소 품질
-            <input aria-label="최소 품질" type="number" min="0" max="100" value={quality} onChange={(event) => setQuality(event.target.value)} className="input-field mt-1 w-full" placeholder="0~100" />
+            <input aria-label="최소 품질" type="number" min="0" max="100" value={quality} onChange={(event) => setQuality(event.target.value)} className="input-field mt-1 w-full" placeholder="0~100" disabled={state === 'loading'} />
           </label>
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">거래 가능 횟수
-            <select aria-label="거래 가능 횟수" value={tradeCount} onChange={(event) => setTradeCount(event.target.value)} className="input-field mt-1 w-full">
+            <select aria-label="거래 가능 횟수" value={tradeCount} onChange={(event) => setTradeCount(event.target.value)} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               <option value="">전체</option>
               {[0, 1, 2].map((count) => <option key={count} value={count}>{count}회</option>)}
             </select>
           </label>
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">즉구가 정렬
-            <select aria-label="장신구 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full">
+            <select aria-label="장신구 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               <option value="ASC">낮은 순</option>
               <option value="DESC">높은 순</option>
             </select>
@@ -241,17 +242,34 @@ const AccessoryMarket: React.FC = () => {
                     });
                   }}
                   className="input-field w-full"
+                  disabled={state === 'loading'}
                   style={selected ? { color: getHoningEffectRoleColor(selected.Text) } : undefined}
                 >
                   <option value="">옵션 선택 안 함</option>
-                  {availableOptions.map((option) => <option key={`${option.firstOption}-${option.Value}`} value={`${option.firstOption}:${option.Value}`} style={{ color: getHoningEffectRoleColor(option.Text) }}>{option.Text}</option>)}
+                  {availableOptions.map((option) => {
+                    const selectedByOtherInput = optionInputs.some((otherInput, otherIndex) =>
+                      otherIndex !== index
+                      && otherInput.firstOption === option.firstOption
+                      && otherInput.secondOption === option.Value,
+                    );
+                    return (
+                      <option
+                        key={`${option.firstOption}-${option.Value}`}
+                        value={`${option.firstOption}:${option.Value}`}
+                        disabled={selectedByOtherInput}
+                        style={{ color: selectedByOtherInput ? 'rgb(156, 163, 175)' : getHoningEffectRoleColor(option.Text) }}
+                      >
+                        {option.Text}
+                      </option>
+                    );
+                  })}
                 </select>
                 <select
                   aria-label={`장신구 옵션 ${index + 1} 등급`}
                   value={input.minValue}
                   onChange={(event) => updateOption(index, { minValue: event.target.value, maxValue: event.target.value })}
                   className="input-field w-full"
-                  disabled={!selected || (selected.EtcValues ?? []).length === 0}
+                  disabled={state === 'loading' || !selected || (selected.EtcValues ?? []).length === 0}
                   style={input.minValue ? { color: HONING_TIER_COLORS[(selected?.EtcValues ?? []).findIndex((value) => String(value.Value) === input.minValue)] } : undefined}
                 >
                   <option value="">등급 선택</option>
@@ -264,7 +282,7 @@ const AccessoryMarket: React.FC = () => {
         <button type="button" onClick={handleSearch} className="btn-gold mt-5 w-full sm:w-auto" disabled={state === 'loading'}>장신구 검색</button>
       </GlassCard>
 
-      <AuctionResults kind="장신구" state={state} items={items} error={error} pageNo={pageNo} totalCount={totalCount} pageSize={pageSize} sortCondition={lastFilters?.sortCondition ?? sortCondition} selectedHoningOptionNames={selectedHoningOptionNames} onPageChange={(nextPage) => lastFilters && void runSearch(lastFilters, nextPage)} />
+      <AuctionResults kind="장신구" state={state} items={items} error={error} pageNo={pageNo} totalCount={totalCount} pageSize={pageSize} sortCondition={lastFilters?.sortCondition ?? sortCondition} onPageChange={(nextPage) => lastFilters && void runSearch(lastFilters, nextPage)} />
     </section>
   );
 };

--- a/src/components/market/AccessoryMarket.tsx
+++ b/src/components/market/AccessoryMarket.tsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchAuctionItems,
+  type AuctionItem,
+  type AuctionOptionsResponse,
+} from '../../utils/api';
+import GlassCard from '../GlassCard';
+import StateFeedback from '../StateFeedback';
+import AuctionResults, { type SearchState } from './AuctionResults';
+import { getHoningEffectRoleColor, HONING_EFFECT_VALUES, HONING_TIER_COLORS } from './accessoryHoning';
+import { getCachedAuctionOptions } from './marketOptionsCache';
+import {
+  buildAccessoryRequest,
+  findCategoryCode,
+  getAuctionOptionsForCategory,
+  type AccessorySearchFilters,
+  type AuctionDetailFilter,
+  type ResolvedAuctionOption,
+} from './marketSearch';
+
+const PARTS = ['목걸이', '반지', '귀걸이'] as const;
+const ACCESSORY_GRADES = ['유물', '고대'] as const;
+const ACCESSORY_TIER = 4;
+type AccessoryPart = typeof PARTS[number];
+const ACCESSORY_OPTION_NAMES: Record<AccessoryPart, readonly string[]> = {
+  목걸이: ['추가 피해', '적에게 주는 피해 증가', '공격력 +', '무기 공격력 +', '세레나데, 신앙, 조화 게이지 획득량 증가', '낙인력', '최대 생명력', '최대 마나', '상태이상 공격 지속시간', '전투 중 생명력 회복량'],
+  귀걸이: ['공격력 %', '무기 공격력 %', '공격력 +', '무기 공격력 +', '파티원 회복 효과', '파티원 보호막 효과', '최대 생명력', '최대 마나', '상태이상 공격 지속시간', '전투 중 생명력 회복량'],
+  반지: ['치명타 적중률', '치명타 피해', '공격력 +', '무기 공격력 +', '아군 공격력 강화 효과', '아군 피해량 강화 효과', '최대 생명력', '최대 마나', '상태이상 공격 지속시간', '전투 중 생명력 회복량'],
+};
+const DEFAULT_OPTION_NAMES: Record<AccessoryPart, readonly [string, string]> = {
+  목걸이: ['적에게 주는 피해 증가', '추가 피해'],
+  반지: ['치명타 적중률', '치명타 피해'],
+  귀걸이: ['공격력 %', '무기 공격력 %'],
+};
+const toOptionalNumber = (value: string): number | undefined => value === '' ? undefined : Number(value);
+
+type OptionInput = { readonly firstOption?: number; readonly secondOption?: number; readonly minValue: string; readonly maxValue: string };
+const EMPTY_OPTION: OptionInput = { minValue: '', maxValue: '' };
+const getPartHoningEffects = (options: readonly ResolvedAuctionOption[], part: AccessoryPart): ResolvedAuctionOption[] => {
+  const optionNames = ACCESSORY_OPTION_NAMES[part];
+  return options
+    .filter((option) => option.groupName === '연마 효과' && optionNames.includes(option.Text))
+    .map((option) => {
+      const allowedValues = HONING_EFFECT_VALUES[option.Text];
+      return {
+        ...option,
+        EtcValues: allowedValues
+          ? allowedValues.flatMap((value) => (option.EtcValues ?? []).filter((candidate) => candidate.Value === value))
+          : [],
+      };
+    })
+    .sort((a, b) => optionNames.indexOf(a.Text) - optionNames.indexOf(b.Text));
+};
+
+const createDefaultOptionInputs = (
+  options: AuctionOptionsResponse,
+  part: AccessoryPart,
+  tier?: number,
+): OptionInput[] => {
+  const categoryCode = findCategoryCode(options.Categories, part, '장신구');
+  if (categoryCode == null) return [EMPTY_OPTION, EMPTY_OPTION];
+  const availableOptions = getPartHoningEffects(getAuctionOptionsForCategory(options, categoryCode, tier), part);
+  return DEFAULT_OPTION_NAMES[part].map((optionName) => {
+    const option = availableOptions.find((candidate) => candidate.Text === optionName);
+    return option
+      ? { firstOption: option.firstOption, secondOption: option.Value, minValue: '', maxValue: '' }
+      : EMPTY_OPTION;
+  });
+};
+
+const AccessoryMarket: React.FC = () => {
+  const requestId = useRef(0);
+  const [options, setOptions] = useState<AuctionOptionsResponse | null>(null);
+  const [optionsError, setOptionsError] = useState('');
+  const [part, setPart] = useState<AccessoryPart>('목걸이');
+  const [grade, setGrade] = useState('');
+  const [quality, setQuality] = useState('');
+  const [tradeCount, setTradeCount] = useState('');
+  const [sortCondition, setSortCondition] = useState<'ASC' | 'DESC'>('ASC');
+  const [optionInputs, setOptionInputs] = useState<OptionInput[]>([EMPTY_OPTION, EMPTY_OPTION]);
+  const [state, setState] = useState<SearchState>('idle');
+  const [items, setItems] = useState<AuctionItem[]>([]);
+  const [error, setError] = useState('');
+  const [pageNo, setPageNo] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [totalCount, setTotalCount] = useState(0);
+  const [lastFilters, setLastFilters] = useState<AccessorySearchFilters | null>(null);
+  const [selectedHoningOptionNames, setSelectedHoningOptionNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    getCachedAuctionOptions()
+      .then((response) => {
+        if (!active) return;
+        setOptions(response);
+        const availableGrades = ACCESSORY_GRADES.filter((itemGrade) => response.ItemGrades.includes(itemGrade));
+        setGrade(availableGrades.includes('고대') ? '고대' : availableGrades[0] ?? '');
+        setOptionInputs(createDefaultOptionInputs(response, '목걸이', ACCESSORY_TIER));
+      })
+      .catch(() => active && setOptionsError('검색 옵션을 불러오지 못했습니다. 잠시 후 탭을 다시 열어 주세요.'));
+    return () => {
+      active = false;
+      requestId.current += 1;
+    };
+  }, []);
+
+  const availableOptions = useMemo(() => {
+    if (!options) return [];
+    const categoryCode = findCategoryCode(options.Categories, part, '장신구');
+    return categoryCode == null ? [] : getPartHoningEffects(getAuctionOptionsForCategory(options, categoryCode, ACCESSORY_TIER), part);
+  }, [options, part]);
+
+  const updateOption = (index: number, patch: Partial<OptionInput>): void => {
+    setOptionInputs((current) => current.map((input, inputIndex) => inputIndex === index ? { ...input, ...patch } : input));
+  };
+
+  const handlePartChange = (nextPart: AccessoryPart): void => {
+    if (nextPart === part) return;
+    setPart(nextPart);
+    setOptionInputs(options ? createDefaultOptionInputs(options, nextPart, ACCESSORY_TIER) : [EMPTY_OPTION, EMPTY_OPTION]);
+    setState('idle');
+    setItems([]);
+    setLastFilters(null);
+    setSelectedHoningOptionNames([]);
+    setPageNo(1);
+    setTotalCount(0);
+  };
+
+  const runSearch = async (filters: AccessorySearchFilters, targetPage: number): Promise<void> => {
+    if (!options) return;
+    const currentRequest = ++requestId.current;
+    setState('loading');
+    setError('');
+    try {
+      const response = await fetchAuctionItems(buildAccessoryRequest({ ...filters, pageNo: targetPage }, options));
+      if (currentRequest !== requestId.current) return;
+      setItems(response.Items ?? []);
+      setPageNo(response.PageNo || targetPage);
+      setPageSize(response.PageSize || 10);
+      setTotalCount(response.TotalCount || 0);
+      setState('success');
+    } catch (reason) {
+      if (currentRequest !== requestId.current) return;
+      setError(reason instanceof Error ? reason.message : '잠시 후 다시 시도해 주세요.');
+      setState('error');
+    }
+  };
+
+  const handleSearch = (): void => {
+    const selectedResolvedOptions = optionInputs.flatMap((input) => {
+      if (input.secondOption == null) return [];
+      const resolved = availableOptions.find((option) => option.firstOption === input.firstOption && option.Value === input.secondOption);
+      return resolved ? [{ input, resolved }] : [];
+    });
+    const selectedOptions: AuctionDetailFilter[] = selectedResolvedOptions.map(({ input, resolved }) => ({
+      firstOption: resolved.firstOption,
+      secondOption: resolved.Value,
+      minValue: toOptionalNumber(input.minValue),
+      maxValue: toOptionalNumber(input.maxValue),
+    }));
+    const filters: AccessorySearchFilters = {
+      part,
+      tier: ACCESSORY_TIER,
+      grade: grade || undefined,
+      quality: toOptionalNumber(quality),
+      tradeAllowCount: toOptionalNumber(tradeCount),
+      options: selectedOptions,
+      sortCondition,
+      pageNo: 1,
+    };
+    setLastFilters(filters);
+    setSelectedHoningOptionNames(selectedResolvedOptions.map(({ resolved }) => resolved.Text));
+    void runSearch(filters, 1);
+  };
+
+  if (optionsError) return <StateFeedback tone="error" title="장신구 검색 옵션 오류" description={optionsError} compact />;
+  if (!options) return <StateFeedback tone="loading" title="장신구 검색 옵션을 불러오는 중입니다" compact />;
+
+  return (
+    <section className="space-y-5">
+      <GlassCard className="p-5">
+        <h2 className="text-xl font-black text-gray-950 dark:text-white">장신구 검색</h2>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">필터 변경 후 검색 버튼을 눌러야 매물을 조회합니다.</p>
+        <div className="mt-4 grid grid-cols-3 gap-2" role="tablist" aria-label="장신구 부위">
+          {PARTS.map((item) => (
+            <button
+              key={item}
+              type="button"
+              role="tab"
+              aria-selected={part === item}
+              onClick={() => handlePartChange(item)}
+              className={`rounded-xl px-3 py-2.5 text-sm font-black transition-colors ${
+                part === item
+                  ? 'bg-la-gold/15 text-la-gold-dark dark:text-la-gold'
+                  : 'bg-gray-100 text-gray-500 hover:text-gray-900 dark:bg-white/5 dark:text-gray-400 dark:hover:text-white'
+              }`}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">등급
+            <select aria-label="장신구 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full">
+              {ACCESSORY_GRADES.filter((itemGrade) => options.ItemGrades.includes(itemGrade)).map((itemGrade) => <option key={itemGrade}>{itemGrade}</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">최소 품질
+            <input aria-label="최소 품질" type="number" min="0" max="100" value={quality} onChange={(event) => setQuality(event.target.value)} className="input-field mt-1 w-full" placeholder="0~100" />
+          </label>
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">거래 가능 횟수
+            <select aria-label="거래 가능 횟수" value={tradeCount} onChange={(event) => setTradeCount(event.target.value)} className="input-field mt-1 w-full">
+              <option value="">전체</option>
+              {[0, 1, 2].map((count) => <option key={count} value={count}>{count}회</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">즉구가 정렬
+            <select aria-label="장신구 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full">
+              <option value="ASC">낮은 순</option>
+              <option value="DESC">높은 순</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <h3 className="text-sm font-black text-gray-900 dark:text-white">연마 효과</h3>
+          {optionInputs.map((input, index) => {
+            const selected = availableOptions.find((option) => option.firstOption === input.firstOption && option.Value === input.secondOption);
+            return (
+              <div key={index} className="grid gap-2 sm:grid-cols-[minmax(0,2fr)_1fr]">
+                <select
+                  aria-label={`장신구 옵션 ${index + 1}`}
+                  value={input.firstOption != null && input.secondOption != null ? `${input.firstOption}:${input.secondOption}` : ''}
+                  onChange={(event) => {
+                    const [firstOption, secondOption] = event.target.value.split(':').map(Number);
+                    updateOption(index, {
+                      firstOption: event.target.value ? firstOption : undefined,
+                      secondOption: event.target.value ? secondOption : undefined,
+                      minValue: '',
+                      maxValue: '',
+                    });
+                  }}
+                  className="input-field w-full"
+                  style={selected ? { color: getHoningEffectRoleColor(selected.Text) } : undefined}
+                >
+                  <option value="">옵션 선택 안 함</option>
+                  {availableOptions.map((option) => <option key={`${option.firstOption}-${option.Value}`} value={`${option.firstOption}:${option.Value}`} style={{ color: getHoningEffectRoleColor(option.Text) }}>{option.Text}</option>)}
+                </select>
+                <select
+                  aria-label={`장신구 옵션 ${index + 1} 등급`}
+                  value={input.minValue}
+                  onChange={(event) => updateOption(index, { minValue: event.target.value, maxValue: event.target.value })}
+                  className="input-field w-full"
+                  disabled={!selected || (selected.EtcValues ?? []).length === 0}
+                  style={input.minValue ? { color: HONING_TIER_COLORS[(selected?.EtcValues ?? []).findIndex((value) => String(value.Value) === input.minValue)] } : undefined}
+                >
+                  <option value="">등급 선택</option>
+                  {(selected?.EtcValues ?? []).map((value, valueIndex) => <option key={value.Value} value={value.Value} style={{ color: HONING_TIER_COLORS[valueIndex] }}>{['상', '중', '하'][valueIndex]} · {value.DisplayValue}</option>)}
+                </select>
+              </div>
+            );
+          })}
+        </div>
+        <button type="button" onClick={handleSearch} className="btn-gold mt-5 w-full sm:w-auto" disabled={state === 'loading'}>장신구 검색</button>
+      </GlassCard>
+
+      <AuctionResults kind="장신구" state={state} items={items} error={error} pageNo={pageNo} totalCount={totalCount} pageSize={pageSize} sortCondition={lastFilters?.sortCondition ?? sortCondition} selectedHoningOptionNames={selectedHoningOptionNames} onPageChange={(nextPage) => lastFilters && void runSearch(lastFilters, nextPage)} />
+    </section>
+  );
+};
+
+export default AccessoryMarket;

--- a/src/components/market/AuctionResults.test.tsx
+++ b/src/components/market/AuctionResults.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, within } from '@testing-library/react';
+import AuctionResults, { getAuctionGradeImageStyle } from './AuctionResults';
+import type { AuctionItem } from '../../utils/api';
+
+const item: AuctionItem = {
+  Name: '고대 목걸이',
+  Grade: '고대',
+  Tier: 4,
+  Level: 0,
+  Icon: 'https://example.com/accessory.png',
+  GradeQuality: 95,
+  AuctionInfo: {
+    StartPrice: 1000,
+    BuyPrice: null,
+    BidPrice: 1500,
+    EndDate: '2020-01-01T00:00:00Z',
+    BidCount: 1,
+    BidStartPrice: 1000,
+    IsCompetitive: true,
+    TradeAllowCount: 2,
+  },
+  Options: [
+    { Type: 'STAT', OptionName: '체력', OptionNameTripod: '', Value: 3470, IsPenalty: false, ClassName: null },
+    { Type: 'STAT', OptionName: '민첩', OptionNameTripod: '', Value: 16241, IsPenalty: false, ClassName: null },
+    {
+      Type: 'ARK_PASSIVE',
+      OptionName: '깨달음',
+      OptionNameTripod: '',
+      Value: 9,
+      IsPenalty: false,
+      ClassName: null,
+      IsValuePercentage: false,
+    },
+    { Type: 'STAT', OptionName: '힘', OptionNameTripod: '', Value: 16241, IsPenalty: false, ClassName: null },
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '전투 중 생명력 회복량', OptionNameTripod: '', Value: 10, IsPenalty: false, ClassName: null, IsValuePercentage: false },
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '공격력 ', OptionNameTripod: '', Value: 1.55, IsPenalty: false, ClassName: null, IsValuePercentage: true },
+    {
+      Type: 'ACCESSORY_UPGRADE',
+      OptionName: '추가 피해',
+      OptionNameTripod: '',
+      Value: 2.6,
+      IsPenalty: false,
+      ClassName: null,
+      IsValuePercentage: true,
+    },
+    { Type: 'STAT', OptionName: '지능', OptionNameTripod: '', Value: 16241, IsPenalty: false, ClassName: null },
+  ],
+};
+
+describe('AuctionResults', () => {
+  it('uses the bracelet grade color for relic and ancient image backgrounds', () => {
+    expect(getAuctionGradeImageStyle('유물')).toMatchObject({
+      background: 'linear-gradient(135deg, #48220b, #a24006)',
+      borderColor: '#a24006',
+    });
+    expect(getAuctionGradeImageStyle('고대')).toMatchObject({
+      background: 'linear-gradient(135deg, #3d3325, #dcc999)',
+      borderColor: '#dcc999',
+    });
+  });
+
+  it('renders core accessory fields and handles nullable price and expired listings', () => {
+    render(
+      <AuctionResults
+        kind="장신구"
+        state="success"
+        items={[item]}
+        error=""
+        pageNo={1}
+        pageSize={10}
+        totalCount={1}
+        sortCondition="ASC"
+        selectedHoningOptionNames={['공격력 %', '추가 피해']}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    const results = screen.getByRole('region', { name: '장신구 검색 결과' });
+    expect(within(results).getByText('고대 목걸이')).toBeInTheDocument();
+    expect(results.querySelector('img')).toHaveStyle({ background: 'linear-gradient(135deg, #3d3325, #dcc999)' });
+    expect(within(results).getByText('품질 95')).toHaveClass('text-[#ce43fc]');
+    const honingTiers = within(results).getAllByText('상');
+    expect(honingTiers).toHaveLength(2);
+    honingTiers.forEach((honingTier) => expect(honingTier).toHaveStyle({ color: 'rgb(251, 160, 38)' }));
+    expect(honingTiers[0].parentElement).toHaveTextContent('공격력 상');
+    expect(honingTiers[1].parentElement).toHaveTextContent('추가 피해 상');
+    expect(honingTiers[1].parentElement).not.toHaveStyle({ color: 'rgb(251, 160, 38)' });
+    expect(within(results).queryByText(/전투 중 생명력 회복량|1.55%|2.6%|깨달음|^힘 |^민첩 |^지능 /)).not.toBeInTheDocument();
+    const optionTexts = Array.from(honingTiers[0].parentElement?.parentElement?.children ?? []).map((element) => element.textContent);
+    expect(optionTexts).toEqual(['공격력 상', '추가 피해 상', '힘/민/지 16,241', '체력 3,470']);
+    expect(within(results).getByText('2회')).toBeInTheDocument();
+    expect(within(results).getAllByText('만료')).toHaveLength(2);
+    expect(within(results).getByText('1,500G')).toBeInTheDocument();
+    expect(within(results).getByText('-')).toBeInTheDocument();
+  });
+
+  it('applies Lost Ark grade colors to tier 4 ancient bracelet stats in the result list', () => {
+    const bracelet: AuctionItem = {
+      ...item,
+      Name: '찬란한 구원자의 팔찌',
+      Options: [
+        { Type: 'BRACELET_RANDOM_SLOT', OptionName: '부여 효과 수량', OptionNameTripod: '', Value: 3, IsPenalty: false, ClassName: null },
+        { Type: 'STAT', OptionName: '치명', OptionNameTripod: '', Value: 84, IsPenalty: false, ClassName: '' },
+        { Type: 'STAT', OptionName: '특화', OptionNameTripod: '', Value: 85, IsPenalty: false, ClassName: '' },
+        { Type: 'STAT', OptionName: '신속', OptionNameTripod: '', Value: 103, IsPenalty: false, ClassName: '' },
+        { Type: 'STAT', OptionName: '제압', OptionNameTripod: '', Value: 120, IsPenalty: false, ClassName: '' },
+      ],
+    };
+
+    render(
+      <AuctionResults
+        kind="팔찌"
+        state="success"
+        items={[bracelet]}
+        error=""
+        pageNo={1}
+        pageSize={10}
+        totalCount={1}
+        sortCondition="ASC"
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('치명 84')).toHaveStyle({ color: 'rgb(97, 189, 109)' });
+    expect(screen.getByText('특화 85')).toHaveStyle({ color: 'rgb(44, 130, 201)' });
+    expect(screen.getByText('신속 103')).toHaveStyle({ color: 'rgb(117, 4, 251)' });
+    expect(screen.getByText('제압 120')).toHaveStyle({ color: 'rgb(251, 160, 38)' });
+    expect(screen.getByText('부여 효과 3개')).toBeInTheDocument();
+    expect(screen.getAllByText(/^(치명|특화|신속|제압|부여 효과)/).map((element) => element.textContent)).toEqual([
+      '치명 84',
+      '특화 85',
+      '신속 103',
+      '제압 120',
+      '부여 효과 3개',
+    ]);
+  });
+});

--- a/src/components/market/AuctionResults.test.tsx
+++ b/src/components/market/AuctionResults.test.tsx
@@ -34,6 +34,7 @@ const item: AuctionItem = {
     { Type: 'STAT', OptionName: '힘', OptionNameTripod: '', Value: 16241, IsPenalty: false, ClassName: null },
     { Type: 'ACCESSORY_UPGRADE', OptionName: '전투 중 생명력 회복량', OptionNameTripod: '', Value: 10, IsPenalty: false, ClassName: null, IsValuePercentage: false },
     { Type: 'ACCESSORY_UPGRADE', OptionName: '공격력 ', OptionNameTripod: '', Value: 1.55, IsPenalty: false, ClassName: null, IsValuePercentage: true },
+    { Type: 'ACCESSORY_UPGRADE', OptionName: '무기 공격력', OptionNameTripod: '', Value: 480, IsPenalty: false, ClassName: null, IsValuePercentage: false },
     {
       Type: 'ACCESSORY_UPGRADE',
       OptionName: '추가 피해',
@@ -70,7 +71,6 @@ describe('AuctionResults', () => {
         pageSize={10}
         totalCount={1}
         sortCondition="ASC"
-        selectedHoningOptionNames={['공격력 %', '추가 피해']}
         onPageChange={vi.fn()}
       />,
     );
@@ -82,12 +82,13 @@ describe('AuctionResults', () => {
     const honingTiers = within(results).getAllByText('상');
     expect(honingTiers).toHaveLength(2);
     honingTiers.forEach((honingTier) => expect(honingTier).toHaveStyle({ color: 'rgb(251, 160, 38)' }));
-    expect(honingTiers[0].parentElement).toHaveTextContent('공격력 상');
+    expect(honingTiers[0].parentElement).toHaveTextContent('공격력% 상');
     expect(honingTiers[1].parentElement).toHaveTextContent('추가 피해 상');
     expect(honingTiers[1].parentElement).not.toHaveStyle({ color: 'rgb(251, 160, 38)' });
-    expect(within(results).queryByText(/전투 중 생명력 회복량|1.55%|2.6%|깨달음|^힘 |^민첩 |^지능 /)).not.toBeInTheDocument();
+    expect(within(results).getByText('중')).toHaveStyle({ color: 'rgb(117, 4, 251)' });
+    expect(within(results).queryByText(/1.55%|2.6%|깨달음|^힘 |^민첩 |^지능 /)).not.toBeInTheDocument();
     const optionTexts = Array.from(honingTiers[0].parentElement?.parentElement?.children ?? []).map((element) => element.textContent);
-    expect(optionTexts).toEqual(['공격력 상', '추가 피해 상', '힘/민/지 16,241', '체력 3,470']);
+    expect(optionTexts).toEqual(['전투 중 생명력 회복량 하', '공격력% 상', '무기 공격력+ 중', '추가 피해 상', '힘/민/지 16,241', '체력 3,470']);
     expect(within(results).getByText('2회')).toBeInTheDocument();
     expect(within(results).getAllByText('만료')).toHaveLength(2);
     expect(within(results).getByText('1,500G')).toBeInTheDocument();

--- a/src/components/market/AuctionResults.tsx
+++ b/src/components/market/AuctionResults.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import type { AuctionItem } from '../../utils/api';
+import { qualityTextColor } from '../../utils/equipmentColors';
+import GlassCard from '../GlassCard';
+import StateFeedback from '../StateFeedback';
+import { getHoningTierColor, getHoningTierLabel, normalizeHoningOptionName } from './accessoryHoning';
+import { formatGold } from './marketFormat';
+
+export type SearchState = 'idle' | 'loading' | 'success' | 'error';
+
+interface AuctionResultsProps {
+  readonly kind: '장신구' | '팔찌';
+  readonly state: SearchState;
+  readonly items: readonly AuctionItem[];
+  readonly error: string;
+  readonly pageNo: number;
+  readonly totalCount: number;
+  readonly pageSize: number;
+  readonly sortCondition: 'ASC' | 'DESC';
+  readonly selectedHoningOptionNames?: readonly string[];
+  readonly onPageChange: (pageNo: number) => void;
+}
+
+export const formatRemainingTime = (endDate: string, now = new Date()): string => {
+  const end = new Date(endDate);
+  if (Number.isNaN(end.getTime()) || end.getTime() <= now.getTime()) return '만료';
+  const minutes = Math.ceil((end.getTime() - now.getTime()) / 60000);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const remainingMinutes = minutes % 60;
+  if (days > 0) return `${days}일 ${hours}시간`;
+  if (hours > 0) return `${hours}시간 ${remainingMinutes}분`;
+  return `${remainingMinutes}분`;
+};
+
+const visibleOptions = (
+  item: AuctionItem,
+  kind: AuctionResultsProps['kind'],
+  selectedHoningOptionNames?: readonly string[],
+) => {
+  if (kind === '팔찌') {
+    return item.Options
+      .filter((option) => option.Type === 'STAT' || option.Type === 'BRACELET_RANDOM_SLOT')
+      .sort((a, b) => Number(a.Type === 'BRACELET_RANDOM_SLOT') - Number(b.Type === 'BRACELET_RANDOM_SLOT'));
+  }
+
+  const honingEffects = item.Options.filter((option) =>
+    option.Type === 'ACCESSORY_UPGRADE'
+    && (!selectedHoningOptionNames || selectedHoningOptionNames.includes(normalizeHoningOptionName(option.OptionName, option.IsValuePercentage))),
+  );
+  const primaryStat = item.Options.find((option) => option.Type === 'STAT' && ['힘', '민첩', '지능'].includes(option.OptionName));
+  const vitality = item.Options.find((option) => option.Type === 'STAT' && option.OptionName === '체력');
+  return [
+    ...honingEffects,
+    ...(primaryStat ? [{ ...primaryStat, OptionName: '힘/민/지' }] : []),
+    ...(vitality ? [vitality] : []),
+  ];
+};
+
+export const getBraceletStatColor = (value: number): string => {
+  if (value >= 120) return 'rgb(251, 160, 38)';
+  if (value >= 103) return 'rgb(117, 4, 251)';
+  if (value >= 85) return 'rgb(44, 130, 201)';
+  return 'rgb(97, 189, 109)';
+};
+
+export const getAuctionGradeImageStyle = (grade: string): React.CSSProperties | undefined => {
+  if (grade === '유물') {
+    return {
+      background: 'linear-gradient(135deg, #48220b, #a24006)',
+      borderColor: '#a24006',
+      boxShadow: '0 0 14px rgba(162, 64, 6, 0.45)',
+    };
+  }
+  if (grade === '고대') {
+    return {
+      background: 'linear-gradient(135deg, #3d3325, #dcc999)',
+      borderColor: '#dcc999',
+      boxShadow: '0 0 14px rgba(220, 201, 153, 0.45)',
+    };
+  }
+  return undefined;
+};
+
+const AuctionResults: React.FC<AuctionResultsProps> = ({
+  kind,
+  state,
+  items,
+  error,
+  pageNo,
+  totalCount,
+  pageSize,
+  sortCondition,
+  selectedHoningOptionNames,
+  onPageChange,
+}) => {
+  if (state === 'idle') {
+    return <StateFeedback tone="empty" title={`${kind} 검색 조건을 선택해 주세요`} description="필터를 설정한 뒤 검색 버튼을 눌러 주세요." compact />;
+  }
+  if (state === 'loading') {
+    return <StateFeedback tone="loading" title={`${kind} 매물을 불러오는 중입니다`} compact />;
+  }
+  if (state === 'error') {
+    return <StateFeedback tone="error" title={`${kind} 매물을 불러오지 못했습니다`} description={error} compact />;
+  }
+  if (items.length === 0) {
+    return <StateFeedback tone="empty" title="검색 조건에 맞는 매물이 없습니다" description="조건 범위를 넓혀 다시 검색해 주세요." compact />;
+  }
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / Math.max(pageSize, 1)));
+  return (
+    <section aria-label={`${kind} 검색 결과`} className="space-y-3">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-black text-gray-950 dark:text-white">{kind} 매물</h2>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">총 {totalCount.toLocaleString()}개 · 즉구가 {sortCondition === 'ASC' ? '낮은 순' : '높은 순'}</p>
+        </div>
+        <span className="text-xs font-bold text-gray-500 dark:text-gray-400">{pageNo} / {totalPages}</span>
+      </div>
+
+      <div className="space-y-3">
+        {items.map((item, index) => {
+          const options = visibleOptions(item, kind, selectedHoningOptionNames);
+          return (
+            <GlassCard key={`${item.Name}-${item.AuctionInfo.EndDate}-${index}`} className="p-4">
+              <div className="flex gap-3">
+                <img
+                  src={item.Icon}
+                  alt=""
+                  className="h-14 w-14 flex-shrink-0 rounded-xl border border-transparent bg-gray-100 object-cover dark:bg-white/5"
+                  style={getAuctionGradeImageStyle(item.Grade)}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-black text-gray-950 dark:text-white">{item.Name}</h3>
+                    {item.GradeQuality != null && <span className={`text-xs font-bold ${qualityTextColor(item.GradeQuality)}`}>품질 {item.GradeQuality}</span>}
+                    <span className={`text-xs font-bold ${formatRemainingTime(item.AuctionInfo.EndDate) === '만료' ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}`}>
+                      {formatRemainingTime(item.AuctionInfo.EndDate)}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {options.length > 0 ? options.map((option, optionIndex) => {
+                      const optionColor = kind === '팔찌'
+                        && item.Tier === 4
+                        && item.Grade === '고대'
+                        && option.Type === 'STAT'
+                        ? getBraceletStatColor(option.Value)
+                        : undefined;
+                      const honingTierLabel = kind === '장신구' && option.Type === 'ACCESSORY_UPGRADE'
+                        ? getHoningTierLabel(option.OptionName, option.Value, option.IsValuePercentage)
+                        : undefined;
+                      const honingTierColor = kind === '장신구' && option.Type === 'ACCESSORY_UPGRADE'
+                        ? getHoningTierColor(option.OptionName, option.Value, option.IsValuePercentage)
+                        : undefined;
+                      return (
+                        <span
+                          key={`${option.Type}-${option.OptionName}-${optionIndex}`}
+                          className={`rounded-lg bg-gray-100 px-2 py-1 text-xs font-semibold dark:bg-white/10 ${optionColor ? '' : 'text-gray-700 dark:text-gray-300'}`}
+                          style={optionColor ? { color: optionColor } : undefined}
+                        >
+                          {option.Type === 'BRACELET_RANDOM_SLOT'
+                            ? `부여 효과 ${option.Value.toLocaleString()}개`
+                            : honingTierLabel && honingTierColor
+                              ? <>{option.OptionName.trim()} <span style={{ color: honingTierColor }}>{honingTierLabel}</span></>
+                              : `${option.OptionName}${option.OptionNameTripod ? ` ${option.OptionNameTripod}` : ''} ${option.Value.toLocaleString()}${option.IsValuePercentage ? '%' : ''}`}
+                        </span>
+                      );
+                    }) : <span className="text-xs text-gray-400">표시할 옵션 정보 없음</span>}
+                  </div>
+                </div>
+              </div>
+              <dl className={`mt-4 grid gap-2 text-sm ${kind === '장신구' ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'}`}>
+                <div><dt className="text-xs text-gray-500">즉구가</dt><dd className="font-black text-la-gold-deep dark:text-la-gold">{formatGold(item.AuctionInfo.BuyPrice)}</dd></div>
+                <div><dt className="text-xs text-gray-500">{kind === '팔찌' ? '최소 입찰가' : '입찰가'}</dt><dd className="font-bold text-gray-800 dark:text-gray-200">{formatGold(item.AuctionInfo.BidPrice || item.AuctionInfo.BidStartPrice)}</dd></div>
+                {kind === '장신구' && <div><dt className="text-xs text-gray-500">거래 가능</dt><dd className="font-bold text-gray-800 dark:text-gray-200">{item.AuctionInfo.TradeAllowCount}회</dd></div>}
+                <div><dt className="text-xs text-gray-500">남은 시간</dt><dd className="font-bold text-gray-800 dark:text-gray-200">{formatRemainingTime(item.AuctionInfo.EndDate)}</dd></div>
+              </dl>
+            </GlassCard>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-center gap-2">
+        <button type="button" className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-bold text-gray-700 disabled:opacity-40 dark:border-white/10 dark:text-gray-200" disabled={pageNo <= 1} onClick={() => onPageChange(pageNo - 1)}>이전</button>
+        <button type="button" className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-bold text-gray-700 disabled:opacity-40 dark:border-white/10 dark:text-gray-200" disabled={pageNo >= totalPages} onClick={() => onPageChange(pageNo + 1)}>다음</button>
+      </div>
+    </section>
+  );
+};
+
+export default AuctionResults;

--- a/src/components/market/AuctionResults.tsx
+++ b/src/components/market/AuctionResults.tsx
@@ -3,7 +3,7 @@ import type { AuctionItem } from '../../utils/api';
 import { qualityTextColor } from '../../utils/equipmentColors';
 import GlassCard from '../GlassCard';
 import StateFeedback from '../StateFeedback';
-import { getHoningTierColor, getHoningTierLabel, normalizeHoningOptionName } from './accessoryHoning';
+import { formatHoningOptionName, getHoningTierColor, getHoningTierLabel } from './accessoryHoning';
 import { formatGold } from './marketFormat';
 
 export type SearchState = 'idle' | 'loading' | 'success' | 'error';
@@ -17,7 +17,6 @@ interface AuctionResultsProps {
   readonly totalCount: number;
   readonly pageSize: number;
   readonly sortCondition: 'ASC' | 'DESC';
-  readonly selectedHoningOptionNames?: readonly string[];
   readonly onPageChange: (pageNo: number) => void;
 }
 
@@ -36,7 +35,6 @@ export const formatRemainingTime = (endDate: string, now = new Date()): string =
 const visibleOptions = (
   item: AuctionItem,
   kind: AuctionResultsProps['kind'],
-  selectedHoningOptionNames?: readonly string[],
 ) => {
   if (kind === '팔찌') {
     return item.Options
@@ -44,10 +42,7 @@ const visibleOptions = (
       .sort((a, b) => Number(a.Type === 'BRACELET_RANDOM_SLOT') - Number(b.Type === 'BRACELET_RANDOM_SLOT'));
   }
 
-  const honingEffects = item.Options.filter((option) =>
-    option.Type === 'ACCESSORY_UPGRADE'
-    && (!selectedHoningOptionNames || selectedHoningOptionNames.includes(normalizeHoningOptionName(option.OptionName, option.IsValuePercentage))),
-  );
+  const honingEffects = item.Options.filter((option) => option.Type === 'ACCESSORY_UPGRADE');
   const primaryStat = item.Options.find((option) => option.Type === 'STAT' && ['힘', '민첩', '지능'].includes(option.OptionName));
   const vitality = item.Options.find((option) => option.Type === 'STAT' && option.OptionName === '체력');
   return [
@@ -91,7 +86,6 @@ const AuctionResults: React.FC<AuctionResultsProps> = ({
   totalCount,
   pageSize,
   sortCondition,
-  selectedHoningOptionNames,
   onPageChange,
 }) => {
   if (state === 'idle') {
@@ -120,7 +114,7 @@ const AuctionResults: React.FC<AuctionResultsProps> = ({
 
       <div className="space-y-3">
         {items.map((item, index) => {
-          const options = visibleOptions(item, kind, selectedHoningOptionNames);
+          const options = visibleOptions(item, kind);
           return (
             <GlassCard key={`${item.Name}-${item.AuctionInfo.EndDate}-${index}`} className="p-4">
               <div className="flex gap-3">
@@ -161,7 +155,7 @@ const AuctionResults: React.FC<AuctionResultsProps> = ({
                           {option.Type === 'BRACELET_RANDOM_SLOT'
                             ? `부여 효과 ${option.Value.toLocaleString()}개`
                             : honingTierLabel && honingTierColor
-                              ? <>{option.OptionName.trim()} <span style={{ color: honingTierColor }}>{honingTierLabel}</span></>
+                              ? <>{formatHoningOptionName(option.OptionName, option.IsValuePercentage)} <span style={{ color: honingTierColor }}>{honingTierLabel}</span></>
                               : `${option.OptionName}${option.OptionNameTripod ? ` ${option.OptionNameTripod}` : ''} ${option.Value.toLocaleString()}${option.IsValuePercentage ? '%' : ''}`}
                         </span>
                       );

--- a/src/components/market/BraceletMarket.test.tsx
+++ b/src/components/market/BraceletMarket.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fetchAuctionItems } from '../../utils/api';
+import { getCachedAuctionOptions } from './marketOptionsCache';
+import BraceletMarket from './BraceletMarket';
+
+vi.mock('../../utils/api', () => ({ fetchAuctionItems: vi.fn() }));
+vi.mock('./marketOptionsCache', () => ({ getCachedAuctionOptions: vi.fn() }));
+
+const mockedFetchAuctionItems = vi.mocked(fetchAuctionItems);
+const mockedGetCachedAuctionOptions = vi.mocked(getCachedAuctionOptions);
+
+const options = {
+  MaxItemLevel: 1700,
+  ItemGradeQualities: [],
+  Categories: [{ Code: 200000, CodeName: '장신구', Subs: [{ Code: 200040, CodeName: '팔찌', Subs: null }] }],
+  ItemGrades: ['유물', '고대'],
+  ItemTiers: [4],
+  Classes: [],
+  EtcOptions: [
+    {
+      Value: 2,
+      Text: '전투 특성',
+      Tiers: [4],
+      EtcSubs: [
+        { Value: 15, Text: '치명', Class: '', Categorys: null, Tiers: null, EtcValues: null },
+        { Value: 16, Text: '특화', Class: '', Categorys: null, Tiers: null, EtcValues: null },
+      ],
+    },
+    {
+      Value: 4,
+      Text: '팔찌 옵션 수량',
+      Tiers: [4],
+      EtcSubs: [{ Value: 2, Text: '부여 효과 수량', Class: '', Categorys: null, Tiers: null, EtcValues: null }],
+    },
+  ],
+};
+
+describe('BraceletMarket', () => {
+  it('searches tier 4 with the default dual ranges and assigned effect count', async () => {
+    mockedGetCachedAuctionOptions.mockResolvedValue(options);
+    mockedFetchAuctionItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 0, Items: [] });
+
+    render(<BraceletMarket />);
+
+    expect(await screen.findByRole('combobox', { name: '팔찌 등급' })).toHaveValue('고대');
+    expect(screen.getAllByRole('slider')).toHaveLength(4);
+    expect(screen.queryByText('티어')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '팔찌 검색' }));
+
+    await waitFor(() => expect(mockedFetchAuctionItems).toHaveBeenCalledTimes(1));
+    expect(mockedFetchAuctionItems).toHaveBeenCalledWith(expect.objectContaining({
+      CategoryCode: 200040,
+      ItemTier: 4,
+      ItemGrade: '고대',
+      EtcOptions: [
+        { FirstOption: 2, SecondOption: 15, MinValue: 0, MaxValue: 120 },
+        { FirstOption: 2, SecondOption: 16, MinValue: 0, MaxValue: 120 },
+        { FirstOption: 4, SecondOption: 2, MinValue: 3, MaxValue: 3 },
+      ],
+    }));
+  });
+});

--- a/src/components/market/BraceletMarket.test.tsx
+++ b/src/components/market/BraceletMarket.test.tsx
@@ -36,6 +36,11 @@ const options = {
 };
 
 describe('BraceletMarket', () => {
+  beforeEach(() => {
+    mockedFetchAuctionItems.mockReset();
+    mockedGetCachedAuctionOptions.mockReset();
+  });
+
   it('searches tier 4 with the default dual ranges and assigned effect count', async () => {
     mockedGetCachedAuctionOptions.mockResolvedValue(options);
     mockedFetchAuctionItems.mockResolvedValue({ PageNo: 1, PageSize: 10, TotalCount: 0, Items: [] });
@@ -58,5 +63,19 @@ describe('BraceletMarket', () => {
         { FirstOption: 4, SecondOption: 2, MinValue: 3, MaxValue: 3 },
       ],
     }));
+  });
+
+  it('locks search filters while a request is loading', async () => {
+    mockedGetCachedAuctionOptions.mockResolvedValue(options);
+    mockedFetchAuctionItems.mockImplementation(() => new Promise(() => {}));
+
+    render(<BraceletMarket />);
+
+    await screen.findByRole('combobox', { name: '팔찌 등급' });
+    fireEvent.click(screen.getByRole('button', { name: '팔찌 검색' }));
+
+    expect(screen.getByRole('combobox', { name: '팔찌 등급' })).toBeDisabled();
+    screen.getAllByRole('slider').forEach((slider) => expect(slider).toBeDisabled());
+    expect(screen.getByRole('button', { name: '팔찌 검색' })).toBeDisabled();
   });
 });

--- a/src/components/market/BraceletMarket.tsx
+++ b/src/components/market/BraceletMarket.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  fetchAuctionItems,
+  type AuctionItem,
+  type AuctionOptionsResponse,
+} from '../../utils/api';
+import GlassCard from '../GlassCard';
+import StateFeedback from '../StateFeedback';
+import AuctionResults, { type SearchState } from './AuctionResults';
+import DualRangeSlider from './DualRangeSlider';
+import { getCachedAuctionOptions } from './marketOptionsCache';
+import { buildBraceletRequest, type BraceletSearchFilters } from './marketSearch';
+
+const STATS = [
+  { value: '치명', label: '치명' },
+  { value: '특화', label: '특화' },
+  { value: '신속', label: '신속' },
+  { value: '제압', label: '제압' },
+  { value: '인내', label: '인내' },
+  { value: '숙련', label: '숙련' },
+] as const;
+const BRACELET_TIER = 4;
+const BRACELET_STAT_MIN = 0;
+const BRACELET_STAT_MAX = 120;
+const BRACELET_GRADES = ['유물', '고대'] as const;
+const toOptionalNumber = (value: string): number | undefined => value === '' ? undefined : Number(value);
+
+type StatInput = { readonly name: string; readonly minValue: string; readonly maxValue: string };
+
+const BraceletMarket: React.FC = () => {
+  const requestId = useRef(0);
+  const [options, setOptions] = useState<AuctionOptionsResponse | null>(null);
+  const [optionsError, setOptionsError] = useState('');
+  const [grade, setGrade] = useState<string>('고대');
+  const [assignedEffectCount, setAssignedEffectCount] = useState('3');
+  const [sortCondition, setSortCondition] = useState<'ASC' | 'DESC'>('ASC');
+  const [stats, setStats] = useState<StatInput[]>([
+    { name: '치명', minValue: String(BRACELET_STAT_MIN), maxValue: String(BRACELET_STAT_MAX) },
+    { name: '특화', minValue: String(BRACELET_STAT_MIN), maxValue: String(BRACELET_STAT_MAX) },
+  ]);
+  const [state, setState] = useState<SearchState>('idle');
+  const [items, setItems] = useState<AuctionItem[]>([]);
+  const [error, setError] = useState('');
+  const [pageNo, setPageNo] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [totalCount, setTotalCount] = useState(0);
+  const [lastFilters, setLastFilters] = useState<BraceletSearchFilters | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getCachedAuctionOptions()
+      .then((response) => {
+        if (!active) return;
+        setOptions(response);
+        const availableGrades = BRACELET_GRADES.filter((itemGrade) => response.ItemGrades.includes(itemGrade));
+        setGrade((current) => availableGrades.includes(current as typeof BRACELET_GRADES[number]) ? current : availableGrades[0] ?? '');
+      })
+      .catch(() => active && setOptionsError('검색 옵션을 불러오지 못했습니다. 잠시 후 탭을 다시 열어 주세요.'));
+    return () => {
+      active = false;
+      requestId.current += 1;
+    };
+  }, []);
+
+  const updateStat = (index: number, patch: Partial<StatInput>): void => {
+    setStats((current) => current.map((stat, statIndex) => statIndex === index ? { ...stat, ...patch } : stat));
+  };
+
+  const runSearch = async (filters: BraceletSearchFilters, targetPage: number): Promise<void> => {
+    if (!options) return;
+    const currentRequest = ++requestId.current;
+    setState('loading');
+    setError('');
+    try {
+      const response = await fetchAuctionItems(buildBraceletRequest({ ...filters, pageNo: targetPage }, options));
+      if (currentRequest !== requestId.current) return;
+      setItems(response.Items ?? []);
+      setPageNo(response.PageNo || targetPage);
+      setPageSize(response.PageSize || 10);
+      setTotalCount(response.TotalCount || 0);
+      setState('success');
+    } catch (reason) {
+      if (currentRequest !== requestId.current) return;
+      setError(reason instanceof Error ? reason.message : '잠시 후 다시 시도해 주세요.');
+      setState('error');
+    }
+  };
+
+  const handleSearch = (): void => {
+    if (stats[0].name === stats[1].name) {
+      setError('서로 다른 전투 특성 두 개를 선택해 주세요.');
+      setState('error');
+      return;
+    }
+    const filters: BraceletSearchFilters = {
+      tier: BRACELET_TIER,
+      grade: grade || undefined,
+      stats: stats.map((stat) => ({
+        name: stat.name,
+        minValue: toOptionalNumber(stat.minValue),
+        maxValue: toOptionalNumber(stat.maxValue),
+      })),
+      assignedEffectCount: toOptionalNumber(assignedEffectCount),
+      sortCondition,
+      pageNo: 1,
+    };
+    setLastFilters(filters);
+    void runSearch(filters, 1);
+  };
+
+  if (optionsError) return <StateFeedback tone="error" title="팔찌 검색 옵션 오류" description={optionsError} compact />;
+  if (!options) return <StateFeedback tone="loading" title="팔찌 검색 옵션을 불러오는 중입니다" compact />;
+
+  return (
+    <section className="space-y-5">
+      <GlassCard className="p-5">
+        <h2 className="text-xl font-black text-gray-950 dark:text-white">팔찌 검색</h2>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">치명·특화·신속 중 서로 다른 두 특성을 선택하세요.</p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">등급
+            <select aria-label="팔찌 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full">
+              {BRACELET_GRADES.filter((itemGrade) => options.ItemGrades.includes(itemGrade)).map((itemGrade) => <option key={itemGrade}>{itemGrade}</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">옵션 부여 개수
+            <select aria-label="팔찌 옵션 부여 개수" value={assignedEffectCount} onChange={(event) => setAssignedEffectCount(event.target.value)} className="input-field mt-1 w-full">
+              <option value="">전체</option>
+              {[2, 3].map((count) => <option key={count} value={count}>{count}개</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-bold text-gray-700 dark:text-gray-300">즉구가 정렬
+            <select aria-label="팔찌 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full">
+              <option value="ASC">낮은 순</option>
+              <option value="DESC">높은 순</option>
+            </select>
+          </label>
+        </div>
+        <div className="mt-5 space-y-3">
+          {stats.map((stat, index) => (
+            <div key={index} className="grid gap-3 rounded-xl border border-gray-200 bg-white/60 p-3 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,2fr)] dark:border-white/10 dark:bg-white/[0.03]">
+              <select aria-label={`전투 특성 ${index + 1}`} value={stat.name} onChange={(event) => updateStat(index, { name: event.target.value })} className="input-field w-full self-center">
+                {STATS.map((statOption) => <option key={statOption.value} value={statOption.value}>{statOption.label}</option>)}
+              </select>
+              <DualRangeSlider
+                label={stat.name}
+                min={BRACELET_STAT_MIN}
+                max={BRACELET_STAT_MAX}
+                minValue={Number(stat.minValue)}
+                maxValue={Number(stat.maxValue)}
+                onChange={(minValue, maxValue) => updateStat(index, { minValue: String(minValue), maxValue: String(maxValue) })}
+              />
+            </div>
+          ))}
+        </div>
+        <button type="button" onClick={handleSearch} className="btn-gold mt-5 w-full sm:w-auto" disabled={state === 'loading'}>팔찌 검색</button>
+      </GlassCard>
+
+      <AuctionResults kind="팔찌" state={state} items={items} error={error} pageNo={pageNo} totalCount={totalCount} pageSize={pageSize} sortCondition={lastFilters?.sortCondition ?? sortCondition} onPageChange={(nextPage) => lastFilters && void runSearch(lastFilters, nextPage)} />
+    </section>
+  );
+};
+
+export default BraceletMarket;

--- a/src/components/market/BraceletMarket.tsx
+++ b/src/components/market/BraceletMarket.tsx
@@ -118,18 +118,18 @@ const BraceletMarket: React.FC = () => {
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">치명·특화·신속 중 서로 다른 두 특성을 선택하세요.</p>
         <div className="mt-4 grid gap-4 sm:grid-cols-3">
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">등급
-            <select aria-label="팔찌 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full">
+            <select aria-label="팔찌 등급" value={grade} onChange={(event) => setGrade(event.target.value)} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               {BRACELET_GRADES.filter((itemGrade) => options.ItemGrades.includes(itemGrade)).map((itemGrade) => <option key={itemGrade}>{itemGrade}</option>)}
             </select>
           </label>
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">옵션 부여 개수
-            <select aria-label="팔찌 옵션 부여 개수" value={assignedEffectCount} onChange={(event) => setAssignedEffectCount(event.target.value)} className="input-field mt-1 w-full">
+            <select aria-label="팔찌 옵션 부여 개수" value={assignedEffectCount} onChange={(event) => setAssignedEffectCount(event.target.value)} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               <option value="">전체</option>
               {[2, 3].map((count) => <option key={count} value={count}>{count}개</option>)}
             </select>
           </label>
           <label className="text-sm font-bold text-gray-700 dark:text-gray-300">즉구가 정렬
-            <select aria-label="팔찌 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full">
+            <select aria-label="팔찌 즉구가 정렬" value={sortCondition} onChange={(event) => setSortCondition(event.target.value as 'ASC' | 'DESC')} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               <option value="ASC">낮은 순</option>
               <option value="DESC">높은 순</option>
             </select>
@@ -138,7 +138,7 @@ const BraceletMarket: React.FC = () => {
         <div className="mt-5 space-y-3">
           {stats.map((stat, index) => (
             <div key={index} className="grid gap-3 rounded-xl border border-gray-200 bg-white/60 p-3 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,2fr)] dark:border-white/10 dark:bg-white/[0.03]">
-              <select aria-label={`전투 특성 ${index + 1}`} value={stat.name} onChange={(event) => updateStat(index, { name: event.target.value })} className="input-field w-full self-center">
+              <select aria-label={`전투 특성 ${index + 1}`} value={stat.name} onChange={(event) => updateStat(index, { name: event.target.value })} className="input-field w-full self-center" disabled={state === 'loading'}>
                 {STATS.map((statOption) => <option key={statOption.value} value={statOption.value}>{statOption.label}</option>)}
               </select>
               <DualRangeSlider
@@ -147,6 +147,7 @@ const BraceletMarket: React.FC = () => {
                 max={BRACELET_STAT_MAX}
                 minValue={Number(stat.minValue)}
                 maxValue={Number(stat.maxValue)}
+                disabled={state === 'loading'}
                 onChange={(minValue, maxValue) => updateStat(index, { minValue: String(minValue), maxValue: String(maxValue) })}
               />
             </div>

--- a/src/components/market/DualRangeSlider.test.tsx
+++ b/src/components/market/DualRangeSlider.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import DualRangeSlider from './DualRangeSlider';
+
+describe('DualRangeSlider', () => {
+  it('reports both handles and prevents them from crossing', () => {
+    const onChange = vi.fn();
+    render(
+      <DualRangeSlider
+        label="치명"
+        min={0}
+        max={120}
+        minValue={40}
+        maxValue={100}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByText('40 ~ 100')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('slider', { name: '치명 최소값' }), { target: { value: '90' } });
+    fireEvent.change(screen.getByRole('slider', { name: '치명 최대값' }), { target: { value: '20' } });
+
+    expect(onChange).toHaveBeenNthCalledWith(1, 90, 100);
+    expect(onChange).toHaveBeenNthCalledWith(2, 40, 40);
+  });
+});

--- a/src/components/market/DualRangeSlider.tsx
+++ b/src/components/market/DualRangeSlider.tsx
@@ -6,6 +6,7 @@ type DualRangeSliderProps = {
   readonly max: number;
   readonly minValue: number;
   readonly maxValue: number;
+  readonly disabled?: boolean;
   readonly onChange: (minValue: number, maxValue: number) => void;
 };
 
@@ -15,6 +16,7 @@ const DualRangeSlider: React.FC<DualRangeSliderProps> = ({
   max,
   minValue,
   maxValue,
+  disabled = false,
   onChange,
 }) => {
   const range = Math.max(max - min, 1);
@@ -42,6 +44,7 @@ const DualRangeSlider: React.FC<DualRangeSliderProps> = ({
           max={max}
           step="1"
           value={minValue}
+          disabled={disabled}
           onChange={(event) => onChange(Math.min(Number(event.target.value), maxValue), maxValue)}
           className="dual-range-input"
         />
@@ -52,6 +55,7 @@ const DualRangeSlider: React.FC<DualRangeSliderProps> = ({
           max={max}
           step="1"
           value={maxValue}
+          disabled={disabled}
           onChange={(event) => onChange(minValue, Math.max(Number(event.target.value), minValue))}
           className="dual-range-input"
         />

--- a/src/components/market/DualRangeSlider.tsx
+++ b/src/components/market/DualRangeSlider.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+type DualRangeSliderProps = {
+  readonly label: string;
+  readonly min: number;
+  readonly max: number;
+  readonly minValue: number;
+  readonly maxValue: number;
+  readonly onChange: (minValue: number, maxValue: number) => void;
+};
+
+const DualRangeSlider: React.FC<DualRangeSliderProps> = ({
+  label,
+  min,
+  max,
+  minValue,
+  maxValue,
+  onChange,
+}) => {
+  const range = Math.max(max - min, 1);
+  const left = ((minValue - min) / range) * 100;
+  const right = 100 - ((maxValue - min) / range) * 100;
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between text-xs font-bold text-gray-500 dark:text-gray-400">
+        <span>수치 범위</span>
+        <strong className="rounded-lg bg-la-gold/10 px-2 py-1 text-la-gold-deep dark:text-la-gold">
+          {minValue} ~ {maxValue}
+        </strong>
+      </div>
+      <div className="relative h-6">
+        <div className="absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 rounded-full bg-gray-200 dark:bg-white/10" />
+        <div
+          className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-gradient-to-r from-la-gold to-la-gold-light"
+          style={{ left: `${left}%`, right: `${right}%` }}
+        />
+        <input
+          aria-label={`${label} 최소값`}
+          type="range"
+          min={min}
+          max={max}
+          step="1"
+          value={minValue}
+          onChange={(event) => onChange(Math.min(Number(event.target.value), maxValue), maxValue)}
+          className="dual-range-input"
+        />
+        <input
+          aria-label={`${label} 최대값`}
+          type="range"
+          min={min}
+          max={max}
+          step="1"
+          value={maxValue}
+          onChange={(event) => onChange(minValue, Math.max(Number(event.target.value), minValue))}
+          className="dual-range-input"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DualRangeSlider;

--- a/src/components/market/LegendAvatarMarket.test.tsx
+++ b/src/components/market/LegendAvatarMarket.test.tsx
@@ -17,6 +17,11 @@ const parts = [
 ];
 
 describe('LegendAvatarMarket', () => {
+  beforeEach(() => {
+    mockedFetchMarketItems.mockReset();
+    mockedGetCachedMarketOptions.mockReset();
+  });
+
   it('loads the four legendary avatar parts only after search is pressed', async () => {
     mockedGetCachedMarketOptions.mockResolvedValue({
       Categories: [{ Code: 30000, CodeName: '아바타', Subs: parts }],
@@ -50,5 +55,23 @@ describe('LegendAvatarMarket', () => {
     await waitFor(() => expect(mockedFetchMarketItems).toHaveBeenCalledTimes(4));
     expect(mockedFetchMarketItems.mock.calls.map((call) => call[1])).toEqual([30001, 30002, 30003, 30004]);
     expect(await screen.findByText('아바타 30004')).toBeInTheDocument();
+  });
+
+  it('locks the class selector while a search is loading', async () => {
+    mockedGetCachedMarketOptions.mockResolvedValue({
+      Categories: [{ Code: 30000, CodeName: '아바타', Subs: parts }],
+      ItemGrades: ['전설'],
+      ItemTiers: [],
+      Classes: ['버서커', '바드'],
+    });
+    mockedFetchMarketItems.mockImplementation(() => new Promise(() => {}));
+
+    render(<LegendAvatarMarket />);
+
+    await screen.findByRole('combobox', { name: '전설 아바타 직업' });
+    fireEvent.click(screen.getByRole('button', { name: '아바타 검색' }));
+
+    expect(screen.getByRole('combobox', { name: '전설 아바타 직업' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '아바타 검색' })).toBeDisabled();
   });
 });

--- a/src/components/market/LegendAvatarMarket.test.tsx
+++ b/src/components/market/LegendAvatarMarket.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fetchMarketItems } from '../../utils/api';
+import { getCachedMarketOptions } from './marketOptionsCache';
+import LegendAvatarMarket from './LegendAvatarMarket';
+
+vi.mock('../../utils/api', () => ({ fetchMarketItems: vi.fn() }));
+vi.mock('./marketOptionsCache', () => ({ getCachedMarketOptions: vi.fn() }));
+
+const mockedFetchMarketItems = vi.mocked(fetchMarketItems);
+const mockedGetCachedMarketOptions = vi.mocked(getCachedMarketOptions);
+
+const parts = [
+  { Code: 30001, CodeName: '무기', Subs: null },
+  { Code: 30002, CodeName: '머리', Subs: null },
+  { Code: 30003, CodeName: '상의', Subs: null },
+  { Code: 30004, CodeName: '하의', Subs: null },
+];
+
+describe('LegendAvatarMarket', () => {
+  it('loads the four legendary avatar parts only after search is pressed', async () => {
+    mockedGetCachedMarketOptions.mockResolvedValue({
+      Categories: [{ Code: 30000, CodeName: '아바타', Subs: parts }],
+      ItemGrades: ['전설'],
+      ItemTiers: [],
+      Classes: ['슬레이어'],
+    });
+    mockedFetchMarketItems.mockImplementation(async (_name, categoryCode) => ({
+      PageNo: 1,
+      PageSize: 10,
+      TotalCount: 1,
+      Items: [{
+        Id: categoryCode,
+        Name: `아바타 ${categoryCode}`,
+        Grade: '전설',
+        Icon: 'https://example.com/avatar.png',
+        BundleCount: 1,
+        TradeRemainCount: null,
+        YDayAvgPrice: null,
+        RecentPrice: 900,
+        CurrentMinPrice: 1000,
+      }],
+    }));
+
+    render(<LegendAvatarMarket />);
+
+    expect(await screen.findByRole('combobox', { name: '전설 아바타 직업' })).toHaveValue('슬레이어');
+    expect(mockedFetchMarketItems).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '아바타 검색' }));
+
+    await waitFor(() => expect(mockedFetchMarketItems).toHaveBeenCalledTimes(4));
+    expect(mockedFetchMarketItems.mock.calls.map((call) => call[1])).toEqual([30001, 30002, 30003, 30004]);
+    expect(await screen.findByText('아바타 30004')).toBeInTheDocument();
+  });
+});

--- a/src/components/market/LegendAvatarMarket.tsx
+++ b/src/components/market/LegendAvatarMarket.tsx
@@ -92,7 +92,7 @@ const LegendAvatarMarket: React.FC = () => {
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">선택한 직업의 최저가 아바타를 조회합니다.</p>
         <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
           <label className="flex-1 text-sm font-bold text-gray-700 dark:text-gray-300">직업
-            <select aria-label="전설 아바타 직업" value={characterClass} onChange={(event) => setCharacterClass(event.target.value)} className="input-field mt-1 w-full">
+            <select aria-label="전설 아바타 직업" value={characterClass} onChange={(event) => setCharacterClass(event.target.value)} className="input-field mt-1 w-full" disabled={state === 'loading'}>
               {options.Classes.map((className) => <option key={className}>{className}</option>)}
             </select>
           </label>

--- a/src/components/market/LegendAvatarMarket.tsx
+++ b/src/components/market/LegendAvatarMarket.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  fetchMarketItems,
+  type MarketItem,
+  type MarketOptionsResponse,
+} from '../../utils/api';
+import GlassCard from '../GlassCard';
+import StateFeedback from '../StateFeedback';
+import type { SearchState } from './AuctionResults';
+import { formatGold } from './marketFormat';
+import { getCachedMarketOptions } from './marketOptionsCache';
+import { resolveAvatarPartCategories } from './marketSearch';
+
+type AvatarResult = { readonly part: string; readonly item: MarketItem | null };
+
+const LegendAvatarMarket: React.FC = () => {
+  const requestId = useRef(0);
+  const [options, setOptions] = useState<MarketOptionsResponse | null>(null);
+  const [optionsError, setOptionsError] = useState('');
+  const [characterClass, setCharacterClass] = useState('');
+  const [state, setState] = useState<SearchState>('idle');
+  const [results, setResults] = useState<AvatarResult[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    getCachedMarketOptions()
+      .then((response) => {
+        if (!active) return;
+        setOptions(response);
+        setCharacterClass(response.Classes[0] ?? '');
+      })
+      .catch(() => active && setOptionsError('검색 옵션을 불러오지 못했습니다. 잠시 후 탭을 다시 열어 주세요.'));
+    return () => {
+      active = false;
+      requestId.current += 1;
+    };
+  }, []);
+
+  const handleSearch = async (): Promise<void> => {
+    if (!options || !characterClass) return;
+    const partCategories = resolveAvatarPartCategories(options);
+    if (partCategories.length !== 4) {
+      setError('공식 API 옵션에서 전설 아바타 4개 부위 코드를 찾을 수 없습니다.');
+      setState('error');
+      return;
+    }
+
+    const legendaryGrade = options.ItemGrades.find((grade) => grade.includes('전설'));
+    if (!legendaryGrade) {
+      setError('공식 API 옵션에서 전설 등급을 찾을 수 없습니다.');
+      setState('error');
+      return;
+    }
+
+    const currentRequest = ++requestId.current;
+    setState('loading');
+    setError('');
+    try {
+      const nextResults: AvatarResult[] = [];
+      for (const { part, categoryCode } of partCategories) {
+        const response = await fetchMarketItems('', categoryCode, {
+          CharacterClass: characterClass,
+          ItemGrade: legendaryGrade,
+          PageNo: 1,
+          Sort: 'CURRENT_MIN_PRICE',
+          SortCondition: 'ASC',
+        });
+        if (currentRequest !== requestId.current) return;
+        const sortedItems = [...(response.Items ?? [])].sort((a, b) =>
+          (a.CurrentMinPrice && a.CurrentMinPrice > 0 ? a.CurrentMinPrice : Number.MAX_SAFE_INTEGER)
+          - (b.CurrentMinPrice && b.CurrentMinPrice > 0 ? b.CurrentMinPrice : Number.MAX_SAFE_INTEGER),
+        );
+        nextResults.push({ part, item: sortedItems[0] ?? null });
+      }
+      setResults(nextResults);
+      setState('success');
+    } catch (reason) {
+      if (currentRequest !== requestId.current) return;
+      setError(reason instanceof Error ? reason.message : '잠시 후 다시 시도해 주세요.');
+      setState('error');
+    }
+  };
+
+  if (optionsError) return <StateFeedback tone="error" title="전설 아바타 검색 옵션 오류" description={optionsError} compact />;
+  if (!options) return <StateFeedback tone="loading" title="전설 아바타 검색 옵션을 불러오는 중입니다" compact />;
+
+  return (
+    <section className="space-y-5">
+      <GlassCard className="p-5">
+        <h2 className="text-xl font-black text-gray-950 dark:text-white">전설 아바타 검색</h2>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">선택한 직업의 최저가 아바타를 조회합니다.</p>
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+          <label className="flex-1 text-sm font-bold text-gray-700 dark:text-gray-300">직업
+            <select aria-label="전설 아바타 직업" value={characterClass} onChange={(event) => setCharacterClass(event.target.value)} className="input-field mt-1 w-full">
+              {options.Classes.map((className) => <option key={className}>{className}</option>)}
+            </select>
+          </label>
+          <button type="button" onClick={() => void handleSearch()} className="btn-gold w-full sm:w-auto" disabled={!characterClass || state === 'loading'}>아바타 검색</button>
+        </div>
+      </GlassCard>
+
+      {state === 'idle' && <StateFeedback tone="empty" title="조회할 직업을 선택해 주세요" description="검색 버튼을 누르면 선택한 직업만 조회합니다." compact />}
+      {state === 'loading' && <StateFeedback tone="loading" title={`${characterClass} 전설 아바타를 불러오는 중입니다`} compact />}
+      {state === 'error' && <StateFeedback tone="error" title="전설 아바타 시세를 불러오지 못했습니다" description={error} compact />}
+      {state === 'success' && results.every((result) => !result.item) && <StateFeedback tone="empty" title="등록된 전설 아바타가 없습니다" description="다른 직업을 선택하거나 잠시 후 다시 검색해 주세요." compact />}
+      {state === 'success' && results.some((result) => result.item) && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {results.map(({ part, item }) => (
+            <GlassCard key={part} className="p-4">
+              <div className="flex items-center gap-3">
+                {item ? <img src={item.Icon} alt="" className="h-14 w-14 rounded-xl bg-gray-100 object-cover dark:bg-white/5" /> : <div className="h-14 w-14 rounded-xl bg-gray-100 dark:bg-white/5" />}
+                <div className="min-w-0">
+                  <span className="text-xs font-black text-la-gold-dark dark:text-la-gold">{part}</span>
+                  <h3 className="mt-0.5 truncate font-black text-gray-950 dark:text-white">{item?.Name ?? '등록 매물 없음'}</h3>
+                </div>
+              </div>
+              <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div><dt className="text-xs text-gray-500">현재 최저가</dt><dd className="font-black text-la-gold-deep dark:text-la-gold">{formatGold(item?.CurrentMinPrice)}</dd></div>
+                <div><dt className="text-xs text-gray-500">최근 거래가</dt><dd className="font-bold text-gray-800 dark:text-gray-200">{formatGold(item?.RecentPrice)}</dd></div>
+              </dl>
+            </GlassCard>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default LegendAvatarMarket;

--- a/src/components/market/accessoryHoning.test.ts
+++ b/src/components/market/accessoryHoning.test.ts
@@ -1,0 +1,21 @@
+import { getHoningEffectRoleColor, getHoningTierColor, getHoningTierLabel } from './accessoryHoning';
+
+describe('accessory honing colors', () => {
+  it('classifies honing effect roles using the reference colors', () => {
+    expect(getHoningEffectRoleColor('추가 피해')).toBe('rgb(224, 140, 20)');
+    expect(getHoningEffectRoleColor('낙인력')).toBe('rgb(35, 82, 196)');
+    expect(getHoningEffectRoleColor('최대 생명력')).toBe('rgb(23, 190, 199)');
+    expect(getHoningEffectRoleColor('전투 중 생명력 회복량')).toBe('rgb(156, 163, 175)');
+  });
+
+  it('colors high, medium, and low honing values as legendary, heroic, and rare', () => {
+    expect(getHoningTierColor('적에게 주는 피해 증가', 2, true)).toBe('rgb(251, 160, 38)');
+    expect(getHoningTierColor('적에게 주는 피해 증가', 1.2, true)).toBe('rgb(117, 4, 251)');
+    expect(getHoningTierColor('적에게 주는 피해 증가', 0.55, true)).toBe('rgb(44, 130, 201)');
+    expect(getHoningTierLabel('적에게 주는 피해 증가', 2, true)).toBe('상');
+    expect(getHoningTierLabel('적에게 주는 피해 증가', 1.2, true)).toBe('중');
+    expect(getHoningTierLabel('적에게 주는 피해 증가', 0.55, true)).toBe('하');
+    expect(getHoningTierLabel('공격력 ', 1.55, true)).toBe('상');
+    expect(getHoningTierLabel('무기 공격력 ', 1.8, true)).toBe('중');
+  });
+});

--- a/src/components/market/accessoryHoning.test.ts
+++ b/src/components/market/accessoryHoning.test.ts
@@ -1,4 +1,4 @@
-import { getHoningEffectRoleColor, getHoningTierColor, getHoningTierLabel } from './accessoryHoning';
+import { formatHoningOptionName, getHoningEffectRoleColor, getHoningTierColor, getHoningTierLabel } from './accessoryHoning';
 
 describe('accessory honing colors', () => {
   it('classifies honing effect roles using the reference colors', () => {
@@ -6,6 +6,14 @@ describe('accessory honing colors', () => {
     expect(getHoningEffectRoleColor('낙인력')).toBe('rgb(35, 82, 196)');
     expect(getHoningEffectRoleColor('최대 생명력')).toBe('rgb(23, 190, 199)');
     expect(getHoningEffectRoleColor('전투 중 생명력 회복량')).toBe('rgb(156, 163, 175)');
+  });
+
+  it('distinguishes percentage and fixed attack effect names', () => {
+    expect(formatHoningOptionName('공격력 ', true)).toBe('공격력%');
+    expect(formatHoningOptionName('공격력', false)).toBe('공격력+');
+    expect(formatHoningOptionName('무기 공격력 ', true)).toBe('무기 공격력%');
+    expect(formatHoningOptionName('무기 공격력', false)).toBe('무기 공격력+');
+    expect(formatHoningOptionName('추가 피해', true)).toBe('추가 피해');
   });
 
   it('colors high, medium, and low honing values as legendary, heroic, and rare', () => {
@@ -17,5 +25,12 @@ describe('accessory honing colors', () => {
     expect(getHoningTierLabel('적에게 주는 피해 증가', 0.55, true)).toBe('하');
     expect(getHoningTierLabel('공격력 ', 1.55, true)).toBe('상');
     expect(getHoningTierLabel('무기 공격력 ', 1.8, true)).toBe('중');
+    expect(getHoningTierLabel('공격력', 390, false)).toBe('상');
+    expect(getHoningTierLabel('무기 공격력', 480, false)).toBe('중');
+    expect(getHoningTierLabel('파티원 회복 효과', 0.95, true)).toBe('하');
+    expect(getHoningTierLabel('최대 생명력', 3250)).toBe('중');
+    expect(getHoningTierLabel('최대 마나', 30)).toBe('상');
+    expect(getHoningTierLabel('상태이상 공격 지속시간', 0.5, true)).toBe('중');
+    expect(getHoningTierLabel('전투 중 생명력 회복량', 10)).toBe('하');
   });
 });

--- a/src/components/market/accessoryHoning.ts
+++ b/src/components/market/accessoryHoning.ts
@@ -1,0 +1,70 @@
+export const HONING_EFFECT_VALUES: Readonly<Record<string, readonly number[]>> = {
+  '추가 피해': [260, 160, 70],
+  '적에게 주는 피해 증가': [200, 120, 55],
+  '공격력 +': [390, 195, 80],
+  '무기 공격력 +': [960, 480, 195],
+  '세레나데, 신앙, 조화 게이지 획득량 증가': [600, 360, 160],
+  낙인력: [800, 480, 215],
+  '공격력 %': [155, 95, 40],
+  '무기 공격력 %': [300, 180, 80],
+  '치명타 적중률': [155, 95, 40],
+  '치명타 피해': [400, 240, 110],
+  '아군 공격력 강화 효과': [500, 300, 135],
+  '아군 피해량 강화 효과': [750, 450, 200],
+};
+
+const DEALER_EFFECTS = new Set([
+  '추가 피해', '적에게 주는 피해 증가', '공격력 +', '무기 공격력 +',
+  '공격력 %', '무기 공격력 %', '치명타 적중률', '치명타 피해',
+]);
+const SUPPORT_EFFECTS = new Set([
+  '세레나데, 신앙, 조화 게이지 획득량 증가', '낙인력',
+  '아군 공격력 강화 효과', '아군 피해량 강화 효과',
+]);
+const SUPPORT_COMPROMISE_EFFECTS = new Set([
+  '파티원 회복 효과', '파티원 보호막 효과', '최대 생명력', '최대 마나',
+]);
+
+export const HONING_TIER_COLORS = [
+  'rgb(251, 160, 38)',
+  'rgb(117, 4, 251)',
+  'rgb(44, 130, 201)',
+] as const;
+
+export const getHoningEffectRoleColor = (optionName?: string): string | undefined => {
+  if (!optionName) return undefined;
+  if (DEALER_EFFECTS.has(optionName)) return 'rgb(224, 140, 20)';
+  if (SUPPORT_EFFECTS.has(optionName)) return 'rgb(35, 82, 196)';
+  if (SUPPORT_COMPROMISE_EFFECTS.has(optionName)) return 'rgb(23, 190, 199)';
+  return 'rgb(156, 163, 175)';
+};
+
+export const normalizeHoningOptionName = (optionName: string, isPercentage?: boolean): string => {
+  const trimmedName = optionName.trim();
+  return isPercentage && ['공격력', '무기 공격력'].includes(trimmedName)
+    ? `${trimmedName} %`
+    : trimmedName;
+};
+
+const getHoningTierIndex = (optionName: string, value: number, isPercentage?: boolean): number => {
+  const comparableValue = isPercentage ? Math.round(value * 100) : value;
+  return HONING_EFFECT_VALUES[normalizeHoningOptionName(optionName, isPercentage)]?.indexOf(comparableValue) ?? -1;
+};
+
+export const getHoningTierColor = (
+  optionName: string,
+  value: number,
+  isPercentage?: boolean,
+): string | undefined => {
+  const tierIndex = getHoningTierIndex(optionName, value, isPercentage);
+  return tierIndex >= 0 ? HONING_TIER_COLORS[tierIndex] : undefined;
+};
+
+export const getHoningTierLabel = (
+  optionName: string,
+  value: number,
+  isPercentage?: boolean,
+): string | undefined => {
+  const tierIndex = getHoningTierIndex(optionName, value, isPercentage);
+  return tierIndex >= 0 ? ['상', '중', '하'][tierIndex] : undefined;
+};

--- a/src/components/market/accessoryHoning.ts
+++ b/src/components/market/accessoryHoning.ts
@@ -11,6 +11,12 @@ export const HONING_EFFECT_VALUES: Readonly<Record<string, readonly number[]>> =
   '치명타 피해': [400, 240, 110],
   '아군 공격력 강화 효과': [500, 300, 135],
   '아군 피해량 강화 효과': [750, 450, 200],
+  '파티원 회복 효과': [350, 210, 95],
+  '파티원 보호막 효과': [350, 210, 95],
+  '최대 생명력': [6500, 3250, 1300],
+  '최대 마나': [30, 15, 6],
+  '상태이상 공격 지속시간': [100, 50, 20],
+  '전투 중 생명력 회복량': [50, 25, 10],
 };
 
 const DEALER_EFFECTS = new Set([
@@ -41,10 +47,12 @@ export const getHoningEffectRoleColor = (optionName?: string): string | undefine
 
 export const normalizeHoningOptionName = (optionName: string, isPercentage?: boolean): string => {
   const trimmedName = optionName.trim();
-  return isPercentage && ['공격력', '무기 공격력'].includes(trimmedName)
-    ? `${trimmedName} %`
-    : trimmedName;
+  if (!['공격력', '무기 공격력'].includes(trimmedName)) return trimmedName;
+  return `${trimmedName} ${isPercentage ? '%' : '+'}`;
 };
+
+export const formatHoningOptionName = (optionName: string, isPercentage?: boolean): string =>
+  normalizeHoningOptionName(optionName, isPercentage).replace(/ ([%+])$/, '$1');
 
 const getHoningTierIndex = (optionName: string, value: number, isPercentage?: boolean): number => {
   const comparableValue = isPercentage ? Math.round(value * 100) : value;

--- a/src/components/market/marketFormat.ts
+++ b/src/components/market/marketFormat.ts
@@ -1,0 +1,2 @@
+export const formatGold = (value?: number | null): string =>
+  value == null || value <= 0 ? '-' : `${value.toLocaleString()}G`;

--- a/src/components/market/marketOptionsCache.test.ts
+++ b/src/components/market/marketOptionsCache.test.ts
@@ -1,0 +1,49 @@
+import { fetchAuctionOptions, fetchMarketOptions } from '../../utils/api';
+
+vi.mock('../../utils/api', () => ({
+  fetchAuctionOptions: vi.fn(),
+  fetchMarketOptions: vi.fn(),
+}));
+
+const mockedFetchAuctionOptions = vi.mocked(fetchAuctionOptions);
+const mockedFetchMarketOptions = vi.mocked(fetchMarketOptions);
+
+beforeEach(() => {
+  vi.resetModules();
+  mockedFetchAuctionOptions.mockReset();
+  mockedFetchMarketOptions.mockReset();
+});
+
+describe('market option cache', () => {
+  it('shares one pending auction options request across market tabs', async () => {
+    const response = { Categories: [] };
+    mockedFetchAuctionOptions.mockResolvedValue(response as never);
+    const { getCachedAuctionOptions } = await import('./marketOptionsCache');
+
+    const [first, second] = await Promise.all([getCachedAuctionOptions(), getCachedAuctionOptions()]);
+
+    expect(first).toBe(response);
+    expect(second).toBe(response);
+    expect(mockedFetchAuctionOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a failed request so auction options can be retried', async () => {
+    mockedFetchAuctionOptions
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({ Categories: [] } as never);
+    const { getCachedAuctionOptions } = await import('./marketOptionsCache');
+
+    await expect(getCachedAuctionOptions()).rejects.toThrow('temporary failure');
+    await expect(getCachedAuctionOptions()).resolves.toMatchObject({ Categories: [] });
+    expect(mockedFetchAuctionOptions).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares one pending market options request for avatar searches', async () => {
+    mockedFetchMarketOptions.mockResolvedValue({ Categories: [] } as never);
+    const { getCachedMarketOptions } = await import('./marketOptionsCache');
+
+    await Promise.all([getCachedMarketOptions(), getCachedMarketOptions()]);
+
+    expect(mockedFetchMarketOptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/market/marketOptionsCache.ts
+++ b/src/components/market/marketOptionsCache.ts
@@ -1,0 +1,29 @@
+import {
+  fetchAuctionOptions,
+  fetchMarketOptions,
+  type AuctionOptionsResponse,
+  type MarketOptionsResponse,
+} from '../../utils/api';
+
+let auctionOptionsPromise: Promise<AuctionOptionsResponse> | null = null;
+let marketOptionsPromise: Promise<MarketOptionsResponse> | null = null;
+
+export const getCachedAuctionOptions = (): Promise<AuctionOptionsResponse> => {
+  if (!auctionOptionsPromise) {
+    auctionOptionsPromise = fetchAuctionOptions().catch((error) => {
+      auctionOptionsPromise = null;
+      throw error;
+    });
+  }
+  return auctionOptionsPromise;
+};
+
+export const getCachedMarketOptions = (): Promise<MarketOptionsResponse> => {
+  if (!marketOptionsPromise) {
+    marketOptionsPromise = fetchMarketOptions().catch((error) => {
+      marketOptionsPromise = null;
+      throw error;
+    });
+  }
+  return marketOptionsPromise;
+};

--- a/src/components/market/marketSearch.test.ts
+++ b/src/components/market/marketSearch.test.ts
@@ -1,0 +1,96 @@
+import { buildAccessoryRequest, buildBraceletRequest } from './marketSearch';
+import type { AuctionOptionsResponse } from '../../utils/api';
+
+const options: AuctionOptionsResponse = {
+  MaxItemLevel: 1700,
+  ItemGradeQualities: [0, 10],
+  ItemGrades: ['유물', '고대'],
+  ItemTiers: [3, 4],
+  Classes: [],
+  Categories: [{
+    Code: 200000,
+    CodeName: '장비',
+    Subs: [
+      { Code: 200010, CodeName: '장신구', Subs: [
+        { Code: 200011, CodeName: '목걸이' },
+        { Code: 200012, CodeName: '귀걸이' },
+      ] },
+      { Code: 200020, CodeName: '팔찌' },
+    ],
+  }],
+  EtcOptions: [
+    {
+      Value: 1,
+      Text: '전투 특성',
+      Tiers: [4],
+      EtcSubs: [
+        { Value: 15, Text: '치명', Class: '', Categorys: null, Tiers: null, EtcValues: null },
+        { Value: 16, Text: '특화', Class: '', Categorys: [200000], Tiers: [4], EtcValues: [] },
+      ],
+    },
+    {
+      Value: 4,
+      Text: '팔찌 옵션 수량',
+      Tiers: [4],
+      EtcSubs: [
+        { Value: 2, Text: '부여 효과 수량', Class: '', Categorys: null, Tiers: null, EtcValues: null },
+      ],
+    },
+    {
+      Value: 7,
+      Text: '아크 패시브',
+      Tiers: [4],
+      EtcSubs: [
+        { Value: 71, Text: '추가 피해', Class: '', Categorys: [200011], Tiers: [4], EtcValues: [] },
+      ],
+    },
+  ],
+};
+
+describe('market auction filter conversion', () => {
+  it('builds an accessory request from category and option codes returned by auctions/options', () => {
+    expect(buildAccessoryRequest({
+      part: '목걸이',
+      tier: 4,
+      grade: '고대',
+      quality: 80,
+      tradeAllowCount: 2,
+      options: [{ firstOption: 7, secondOption: 71, minValue: 2, maxValue: 3 }],
+      sortCondition: 'ASC',
+      pageNo: 2,
+    }, options)).toEqual({
+      CategoryCode: 200011,
+      ItemTier: 4,
+      ItemGrade: '고대',
+      ItemGradeQuality: 80,
+      ItemTradeAllowCount: 2,
+      EtcOptions: [{ FirstOption: 7, SecondOption: 71, MinValue: 2, MaxValue: 3 }],
+      PageNo: 2,
+      Sort: 'BUY_PRICE',
+      SortCondition: 'ASC',
+    });
+  });
+
+  it('resolves bracelet stat codes when optional API filter arrays are null', () => {
+    expect(buildBraceletRequest({
+      tier: 4,
+      grade: '고대',
+      stats: [
+        { name: '치명', minValue: 80, maxValue: 120 },
+        { name: '특화', minValue: 90, maxValue: 110 },
+      ],
+      assignedEffectCount: 3,
+      sortCondition: 'DESC',
+      pageNo: 1,
+    }, options)).toMatchObject({
+      CategoryCode: 200020,
+      EtcOptions: [
+        { FirstOption: 1, SecondOption: 15, MinValue: 80, MaxValue: 120 },
+        { FirstOption: 1, SecondOption: 16, MinValue: 90, MaxValue: 110 },
+        { FirstOption: 4, SecondOption: 2, MinValue: 3, MaxValue: 3 },
+      ],
+      Sort: 'BUY_PRICE',
+      SortCondition: 'DESC',
+    });
+  });
+});

--- a/src/components/market/marketSearch.ts
+++ b/src/components/market/marketSearch.ts
@@ -1,0 +1,192 @@
+import type {
+  AuctionEtcSubOption,
+  AuctionOptionsResponse,
+  AuctionSearchParams,
+  MarketCategory,
+  MarketOptionsResponse,
+} from '../../utils/api';
+
+export type AuctionDetailFilter = {
+  readonly firstOption: number;
+  readonly secondOption: number;
+  readonly minValue?: number;
+  readonly maxValue?: number;
+};
+
+export type AccessorySearchFilters = {
+  readonly part: string;
+  readonly tier?: number;
+  readonly grade?: string;
+  readonly quality?: number;
+  readonly tradeAllowCount?: number;
+  readonly options: readonly AuctionDetailFilter[];
+  readonly sortCondition: 'ASC' | 'DESC';
+  readonly pageNo: number;
+};
+
+export type BraceletStatFilter = {
+  readonly name: string;
+  readonly minValue?: number;
+  readonly maxValue?: number;
+};
+
+export type BraceletSearchFilters = {
+  readonly tier?: number;
+  readonly grade?: string;
+  readonly stats: readonly BraceletStatFilter[];
+  readonly assignedEffectCount?: number;
+  readonly sortCondition: 'ASC' | 'DESC';
+  readonly pageNo: number;
+};
+
+export type ResolvedAuctionOption = AuctionEtcSubOption & {
+  readonly firstOption: number;
+  readonly groupName: string;
+};
+
+const normalize = (value: string): string => value.replace(/\s+/g, '').toLowerCase();
+
+const flattenCategories = (
+  categories: readonly MarketCategory[],
+  parentNames: readonly string[] = [],
+  parentCodes: readonly number[] = [],
+): Array<{ readonly code: number; readonly name: string; readonly path: readonly string[]; readonly codes: readonly number[] }> =>
+  categories.flatMap((category) => {
+    const path = [...parentNames, category.CodeName];
+    const codes = [...parentCodes, category.Code];
+    return [
+      { code: category.Code, name: category.CodeName, path, codes },
+      ...flattenCategories(category.Subs ?? [], path, codes),
+    ];
+  });
+
+export const findCategoryCode = (
+  categories: readonly MarketCategory[],
+  name: string,
+  requiredPathText?: string,
+): number | undefined => {
+  const target = normalize(name);
+  const required = requiredPathText ? normalize(requiredPathText) : null;
+  const candidates = flattenCategories(categories).filter(({ path }) =>
+    !required || path.some((part) => normalize(part).includes(required)),
+  );
+  return candidates.find((category) => normalize(category.name) === target)?.code
+    ?? candidates.find((category) => normalize(category.name).includes(target))?.code;
+};
+
+export const getAuctionOptionsForCategory = (
+  options: AuctionOptionsResponse,
+  categoryCode: number,
+  tier?: number,
+): ResolvedAuctionOption[] => {
+  const categoryCodes = flattenCategories(options.Categories)
+    .find((category) => category.code === categoryCode)?.codes ?? [categoryCode];
+  return options.EtcOptions.flatMap((group) =>
+    (group.EtcSubs ?? [])
+      .filter((option) => {
+        const categoryFilters = option.Categorys ?? [];
+        const tierFilters = option.Tiers ?? [];
+        return (categoryFilters.length === 0 || categoryFilters.some((code) => categoryCodes.includes(code)))
+          && (tier == null || tierFilters.length === 0 || tierFilters.includes(tier));
+      })
+      .map((option) => ({ ...option, firstOption: group.Value, groupName: group.Text })),
+  );
+};
+
+const compactParams = (params: AuctionSearchParams): AuctionSearchParams =>
+  Object.fromEntries(Object.entries(params).filter(([, value]) => value != null && value !== ''));
+
+export const buildAccessoryRequest = (
+  filters: AccessorySearchFilters,
+  options: AuctionOptionsResponse,
+): AuctionSearchParams => {
+  const categoryCode = findCategoryCode(options.Categories, filters.part, '장신구');
+  if (categoryCode == null) throw new Error(`${filters.part} 카테고리를 찾을 수 없습니다.`);
+
+  return compactParams({
+    CategoryCode: categoryCode,
+    ItemTier: filters.tier,
+    ItemGrade: filters.grade,
+    ItemGradeQuality: filters.quality,
+    ItemTradeAllowCount: filters.tradeAllowCount,
+    EtcOptions: filters.options.map((option) => ({
+      FirstOption: option.firstOption,
+      SecondOption: option.secondOption,
+      MinValue: option.minValue,
+      MaxValue: option.maxValue,
+    })),
+    PageNo: filters.pageNo,
+    Sort: 'BUY_PRICE',
+    SortCondition: filters.sortCondition,
+  });
+};
+
+const findStatOption = (
+  options: AuctionOptionsResponse,
+  categoryCode: number,
+  statName: string,
+  tier?: number,
+): ResolvedAuctionOption | undefined => {
+  const target = normalize(statName);
+  return getAuctionOptionsForCategory(options, categoryCode, tier)
+    .find((option) => normalize(option.Text) === target);
+};
+
+export const buildBraceletRequest = (
+  filters: BraceletSearchFilters,
+  options: AuctionOptionsResponse,
+): AuctionSearchParams => {
+  const categoryCode = findCategoryCode(options.Categories, '팔찌');
+  if (categoryCode == null) throw new Error('팔찌 카테고리를 찾을 수 없습니다.');
+  if (filters.stats.length !== 2 || filters.stats[0].name === filters.stats[1].name) {
+    throw new Error('서로 다른 전투 특성 두 개를 선택해 주세요.');
+  }
+
+  const resolvedStats = filters.stats.map((stat) => {
+    const option = findStatOption(options, categoryCode, stat.name, filters.tier);
+    if (!option) throw new Error(`${stat.name} 옵션 코드를 찾을 수 없습니다.`);
+    return {
+      FirstOption: option.firstOption,
+      SecondOption: option.Value,
+      MinValue: stat.minValue,
+      MaxValue: stat.maxValue,
+    };
+  });
+  const assignedEffectOption = filters.assignedEffectCount == null
+    ? undefined
+    : getAuctionOptionsForCategory(options, categoryCode, filters.tier).find((option) =>
+        normalize(option.groupName) === normalize('팔찌 옵션 수량')
+        && normalize(option.Text) === normalize('부여 효과 수량'),
+      );
+  if (filters.assignedEffectCount != null && !assignedEffectOption) {
+    throw new Error('부여 효과 수량 옵션 코드를 찾을 수 없습니다.');
+  }
+
+  return compactParams({
+    CategoryCode: categoryCode,
+    ItemTier: filters.tier,
+    ItemGrade: filters.grade,
+    EtcOptions: [
+      ...resolvedStats,
+      ...(assignedEffectOption && filters.assignedEffectCount != null ? [{
+        FirstOption: assignedEffectOption.firstOption,
+        SecondOption: assignedEffectOption.Value,
+        MinValue: filters.assignedEffectCount,
+        MaxValue: filters.assignedEffectCount,
+      }] : []),
+    ],
+    PageNo: filters.pageNo,
+    Sort: 'BUY_PRICE',
+    SortCondition: filters.sortCondition,
+  });
+};
+
+export const resolveAvatarPartCategories = (
+  options: MarketOptionsResponse,
+): Array<{ readonly part: string; readonly categoryCode: number }> => {
+  const parts = ['무기', '머리', '상의', '하의'];
+  return parts.flatMap((part) => {
+    const categoryCode = findCategoryCode(options.Categories, part, '아바타');
+    return categoryCode == null ? [] : [{ part, categoryCode }];
+  });
+};

--- a/src/index.css
+++ b/src/index.css
@@ -111,6 +111,33 @@
            dark:bg-white/5 dark:border-white/10 dark:text-white dark:placeholder-gray-500;
   }
 
+  .input-field {
+    @apply min-h-11 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900
+           focus:outline-none focus:border-la-gold/50 focus:ring-2 focus:ring-la-gold/20 disabled:opacity-50
+           dark:border-white/10 dark:bg-la-dark-card dark:text-white;
+  }
+
+  .dual-range-input {
+    @apply pointer-events-none absolute inset-0 h-6 w-full appearance-none bg-transparent;
+  }
+
+  .dual-range-input::-webkit-slider-runnable-track {
+    @apply h-2 bg-transparent;
+  }
+
+  .dual-range-input::-webkit-slider-thumb {
+    @apply pointer-events-auto h-5 w-5 cursor-grab appearance-none rounded-full border-2 border-white bg-la-gold shadow-md active:cursor-grabbing dark:border-la-dark-card;
+    margin-top: -0.375rem;
+  }
+
+  .dual-range-input::-moz-range-track {
+    @apply h-2 bg-transparent;
+  }
+
+  .dual-range-input::-moz-range-thumb {
+    @apply pointer-events-auto h-5 w-5 cursor-grab rounded-full border-2 border-white bg-la-gold shadow-md active:cursor-grabbing dark:border-la-dark-card;
+  }
+
   .skeleton {
     @apply bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 bg-[length:200%_100%] animate-shimmer rounded-lg
            dark:from-white/5 dark:via-white/10 dark:to-white/5;

--- a/src/pages/Market.test.tsx
+++ b/src/pages/Market.test.tsx
@@ -1,16 +1,25 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import Market, { EngravingRanking, GemRanking } from './Market';
-import { fetchAuctionItems, fetchMarketItems } from '../utils/api';
+import {
+  fetchAuctionItems,
+  fetchAuctionOptions,
+  fetchMarketItems,
+  fetchMarketOptions,
+} from '../utils/api';
 
 vi.mock('../components/NavBar', () => ({ default: () => <div>NavBar</div> }));
 
 vi.mock('../utils/api', () => ({
   fetchAuctionItems: vi.fn(),
+  fetchAuctionOptions: vi.fn(),
   fetchMarketItems: vi.fn(),
+  fetchMarketOptions: vi.fn(),
 }));
 
 const mockedFetchAuctionItems = vi.mocked(fetchAuctionItems);
+const mockedFetchAuctionOptions = vi.mocked(fetchAuctionOptions);
 const mockedFetchMarketItems = vi.mocked(fetchMarketItems);
+const mockedFetchMarketOptions = vi.mocked(fetchMarketOptions);
 
 describe('Market ranking states', () => {
   beforeEach(() => {
@@ -110,5 +119,28 @@ describe('Market ranking states', () => {
 
     await waitFor(() => expect(mockedFetchMarketItems).toHaveBeenCalledTimes(2));
     expect(await screen.findAllByText('유물 원한 각인서')).toHaveLength(2);
+  });
+
+  it('loads search options only after its market tab becomes active', async () => {
+    mockedFetchAuctionOptions.mockResolvedValue({
+      MaxItemLevel: 1700,
+      ItemGradeQualities: [],
+      EtcOptions: [],
+      Categories: [],
+      ItemGrades: ['고대'],
+      ItemTiers: [4],
+      Classes: [],
+    });
+
+    render(<Market />);
+
+    expect(mockedFetchAuctionOptions).not.toHaveBeenCalled();
+    expect(mockedFetchMarketOptions).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('tab', { name: '장신구' }));
+
+    await waitFor(() => expect(mockedFetchAuctionOptions).toHaveBeenCalledTimes(1));
+    expect(mockedFetchMarketOptions).not.toHaveBeenCalled();
+    expect(mockedFetchAuctionItems).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -14,7 +14,11 @@ import {
   type AuctionItem,
 } from '../utils/api';
 
-type ActiveTab = 'engraving' | 'gem';
+const AccessoryMarket = React.lazy(() => import('../components/market/AccessoryMarket'));
+const LegendAvatarMarket = React.lazy(() => import('../components/market/LegendAvatarMarket'));
+const BraceletMarket = React.lazy(() => import('../components/market/BraceletMarket'));
+
+type ActiveTab = 'engraving' | 'gem' | 'accessory' | 'avatar' | 'bracelet';
 
 const GEM_KINDS: GemKind[] = ['겁화', '작열'];
 const GEM_TARGETS = Array.from({ length: 10 }, (_, index) => 10 - index).flatMap((level) =>
@@ -24,6 +28,9 @@ const GEM_TARGETS = Array.from({ length: 10 }, (_, index) => 10 - index).flatMap
 const TABS: Array<{ key: ActiveTab; label: string }> = [
   { key: 'engraving', label: '유물 각인서' },
   { key: 'gem', label: '보석' },
+  { key: 'accessory', label: '장신구' },
+  { key: 'avatar', label: '전설 아바타' },
+  { key: 'bracelet', label: '팔찌' },
 ];
 
 const MARKET_REQUEST_CONCURRENCY = 3;
@@ -62,7 +69,8 @@ const runSettledWithConcurrency = async <T, R>(
 
 let cachedEngravingState: RankState<EngravingRankItem> | null = null;
 let cachedGemState: RankState<GemRankItem> | null = null;
-let pendingRankings: Promise<[RankState<EngravingRankItem>, RankState<GemRankItem>]> | null = null;
+let pendingEngraving: Promise<RankState<EngravingRankItem>> | null = null;
+let pendingGem: Promise<RankState<GemRankItem>> | null = null;
 
 const initialRankState = <T,>(): RankState<T> => ({
   status: 'loading',
@@ -74,8 +82,8 @@ const initialRankState = <T,>(): RankState<T> => ({
 const getLowestAuctionItem = (items: AuctionItem[] | undefined): AuctionItem | null => {
   if (!items) return null;
   return items
-    .filter((item) => item.AuctionInfo.BuyPrice > 0)
-    .sort((a, b) => a.AuctionInfo.BuyPrice - b.AuctionInfo.BuyPrice)[0] ?? null;
+    .filter((item) => item.AuctionInfo.BuyPrice != null && item.AuctionInfo.BuyPrice > 0)
+    .sort((a, b) => (a.AuctionInfo.BuyPrice ?? Number.MAX_SAFE_INTEGER) - (b.AuctionInfo.BuyPrice ?? Number.MAX_SAFE_INTEGER))[0] ?? null;
 };
 
 const rankEngravingsByPrice = (items: Omit<EngravingRankItem, 'rank'>[]): EngravingRankItem[] =>
@@ -117,65 +125,39 @@ const fetchRelicEngravingItems = async () => {
   return Array.from(uniqueItems.values());
 };
 
-const fetchRankingStates = async (): Promise<[RankState<EngravingRankItem>, RankState<GemRankItem>]> => {
-  const engravingPromise = fetchRelicEngravingItems();
+const fetchEngravingState = async (): Promise<RankState<EngravingRankItem>> => {
+  try {
+    const items = await fetchRelicEngravingItems();
+    const engravingItems = items
+      .filter((item) => item.CurrentMinPrice != null && item.CurrentMinPrice > 0 && item.Name.includes('각인서'))
+      .map((item) => ({
+        name: item.Name.replace(/^유물\s*/, '').replace(/\s*각인서$/, ''),
+        itemName: item.Name,
+        icon: item.Icon,
+        price: item.CurrentMinPrice!,
+        yDayAvgPrice: item.YDayAvgPrice ?? 0,
+      }));
+    return { status: engravingItems.length > 0 ? 'success' : 'error', items: rankEngravingsByPrice(engravingItems), fetchedAt: new Date(), failedCount: 0 };
+  } catch {
+    return { status: 'error', items: [], fetchedAt: new Date(), failedCount: 1 };
+  }
+};
 
-  const gemPromise = runSettledWithConcurrency(GEM_TARGETS, MARKET_REQUEST_CONCURRENCY, async ({ level, kind }) => {
-    const response = await fetchAuctionItems({
-      CategoryCode: 210000,
-      ItemName: `${level}레벨 ${kind}의 보석`,
-      ItemTier: 4,
-      PageSize: 1,
-    });
+const fetchGemState = async (): Promise<RankState<GemRankItem>> => {
+  const settled = await runSettledWithConcurrency(GEM_TARGETS, MARKET_REQUEST_CONCURRENCY, async ({ level, kind }) => {
+    const response = await fetchAuctionItems({ CategoryCode: 210000, ItemName: `${level}레벨 ${kind}의 보석`, ItemTier: 4, PageSize: 1 });
     const item = getLowestAuctionItem(response.Items);
-    if (!item) return null;
-    return {
-      level,
-      kind,
-      name: item.Name,
-      icon: item.Icon,
-      price: item.AuctionInfo.BuyPrice,
-    };
+    if (!item?.AuctionInfo.BuyPrice) return null;
+    return { level, kind, name: item.Name, icon: item.Icon, price: item.AuctionInfo.BuyPrice };
   });
-
-  const [engravingSettled, gemSettled] = await Promise.allSettled([engravingPromise, gemPromise]);
-  const fetchedAt = new Date();
-
-  const engravingItems = engravingSettled.status === 'fulfilled'
-    ? engravingSettled.value
-        .filter((item) => item.CurrentMinPrice > 0 && item.Name.includes('각인서'))
-        .map((item) => ({
-          name: item.Name.replace(/^유물\s*/, '').replace(/\s*각인서$/, ''),
-          itemName: item.Name,
-          icon: item.Icon,
-          price: item.CurrentMinPrice,
-          yDayAvgPrice: item.YDayAvgPrice,
-        }))
-    : [];
-
-  const gemItems = gemSettled.status === 'fulfilled'
-    ? gemSettled.value.flatMap((result) =>
-        result.status === 'fulfilled' && result.value ? [result.value] : [],
-      )
-    : [];
-  const gemFailedCount = gemSettled.status === 'fulfilled'
-    ? gemSettled.value.filter((result) => result.status === 'rejected').length
-    : GEM_TARGETS.length;
-
-  return [
-    {
-      status: engravingItems.length > 0 ? 'success' : 'error',
-      items: rankEngravingsByPrice(engravingItems),
-      fetchedAt,
-      failedCount: engravingSettled.status === 'rejected' ? 1 : 0,
-    },
-    {
-      status: gemItems.length > 0 || gemFailedCount < GEM_TARGETS.length ? 'success' : 'error',
-      items: rankGemsByPrice(gemItems),
-      fetchedAt,
-      failedCount: gemFailedCount,
-    },
-  ];
+  const items = settled.flatMap((result) => result.status === 'fulfilled' && result.value ? [result.value] : []);
+  const failedCount = settled.filter((result) => result.status === 'rejected').length;
+  return {
+    status: items.length > 0 || failedCount < GEM_TARGETS.length ? 'success' : 'error',
+    items: rankGemsByPrice(items),
+    fetchedAt: new Date(),
+    failedCount,
+  };
 };
 
 const Market: React.FC = () => {
@@ -184,43 +166,39 @@ const Market: React.FC = () => {
   const [engravingState, setEngravingState] = useState<RankState<EngravingRankItem>>(initialRankState);
   const [gemState, setGemState] = useState<RankState<GemRankItem>>(initialRankState);
 
-  const loadRankings = useCallback(async (force = false): Promise<void> => {
-    const requestId = requestIdRef.current + 1;
-    requestIdRef.current = requestId;
-
-    if (force) {
-      cachedEngravingState = null;
-      cachedGemState = null;
-      pendingRankings = null;
-    }
-
-    if (cachedEngravingState && cachedGemState) {
-      setEngravingState(cachedEngravingState);
-      setGemState(cachedGemState);
+  const loadRanking = useCallback(async (tab: 'engraving' | 'gem', force = false): Promise<void> => {
+    const requestId = ++requestIdRef.current;
+    if (tab === 'engraving') {
+      if (force) cachedEngravingState = null;
+      if (cachedEngravingState) {
+        setEngravingState(cachedEngravingState);
+        return;
+      }
+      setEngravingState((current) => ({ ...current, status: 'loading', failedCount: 0 }));
+      if (!pendingEngraving) pendingEngraving = fetchEngravingState().finally(() => { pendingEngraving = null; });
+      const nextState = await pendingEngraving;
+      cachedEngravingState = nextState;
+      if (requestIdRef.current !== requestId) return;
+      setEngravingState(nextState);
       return;
     }
 
-    setEngravingState((current) => ({ ...current, status: 'loading', failedCount: 0 }));
-    setGemState((current) => ({ ...current, status: 'loading', failedCount: 0 }));
-
-    if (!pendingRankings) {
-      pendingRankings = fetchRankingStates().finally(() => {
-        pendingRankings = null;
-      });
+    if (force) cachedGemState = null;
+    if (cachedGemState) {
+      setGemState(cachedGemState);
+      return;
     }
-
-    const [nextEngravingState, nextGemState] = await pendingRankings;
+    setGemState((current) => ({ ...current, status: 'loading', failedCount: 0 }));
+    if (!pendingGem) pendingGem = fetchGemState().finally(() => { pendingGem = null; });
+    const nextState = await pendingGem;
+    cachedGemState = nextState;
     if (requestIdRef.current !== requestId) return;
-
-    cachedEngravingState = nextEngravingState;
-    cachedGemState = nextGemState;
-    setEngravingState(nextEngravingState);
-    setGemState(nextGemState);
+    setGemState(nextState);
   }, []);
 
   useEffect(() => {
-    void loadRankings();
-  }, [loadRankings]);
+    if (activeTab === 'engraving' || activeTab === 'gem') void loadRanking(activeTab);
+  }, [activeTab, loadRanking]);
 
   return (
     <div className="min-h-screen bg-gray-50 transition-colors duration-300 dark:bg-la-dark">
@@ -232,21 +210,23 @@ const Market: React.FC = () => {
               <span className="inline-flex rounded-full border border-la-gold/20 bg-la-gold/10 px-3 py-1 text-xs font-bold text-la-gold-dark dark:text-la-gold">
                 Market Rank
               </span>
-              <h1 className="mt-4 text-3xl font-black tracking-tight text-gray-950 dark:text-white sm:text-4xl">시세 랭킹</h1>
+              <h1 className="mt-4 text-3xl font-black tracking-tight text-gray-950 dark:text-white sm:text-4xl">시세</h1>
             </div>
-            <button
-              type="button"
-              onClick={() => void loadRankings(true)}
-              className="btn-gold w-full sm:w-auto"
-              disabled={engravingState.status === 'loading' || gemState.status === 'loading'}
-            >
-              새로고침
-            </button>
+            {(activeTab === 'engraving' || activeTab === 'gem') && (
+              <button
+                type="button"
+                onClick={() => void loadRanking(activeTab, true)}
+                className="btn-gold w-full sm:w-auto"
+                disabled={activeTab === 'engraving' ? engravingState.status === 'loading' : gemState.status === 'loading'}
+              >
+                새로고침
+              </button>
+            )}
           </div>
         </GlassCard>
 
         <GlassCard className="p-2">
-          <div className="grid grid-cols-2 gap-2" role="tablist" aria-label="시세 랭킹 종류">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5" role="tablist" aria-label="시세 종류">
             {TABS.map((tab) => (
               <button
                 key={tab.key}
@@ -266,11 +246,13 @@ const Market: React.FC = () => {
           </div>
         </GlassCard>
 
-        {activeTab === 'engraving' ? (
-          <EngravingRanking state={engravingState} onRetry={() => void loadRankings(true)} />
-        ) : (
-          <GemRanking state={gemState} onRetry={() => void loadRankings(true)} />
-        )}
+        {activeTab === 'engraving' && <EngravingRanking state={engravingState} onRetry={() => void loadRanking('engraving', true)} />}
+        {activeTab === 'gem' && <GemRanking state={gemState} onRetry={() => void loadRanking('gem', true)} />}
+        <React.Suspense fallback={<GlassCard className="p-6 text-center text-sm text-gray-500 dark:text-gray-400">탭을 불러오는 중입니다.</GlassCard>}>
+          {activeTab === 'accessory' && <AccessoryMarket />}
+          {activeTab === 'avatar' && <LegendAvatarMarket />}
+          {activeTab === 'bracelet' && <BraceletMarket />}
+        </React.Suspense>
       </main>
     </div>
   );

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -72,11 +72,14 @@ export const fetchCalendar = (): Promise<CalendarItem[]> =>
 export interface MarketCategory {
   Code: number;
   CodeName: string;
-  Subs?: MarketCategory[];
+  Subs?: MarketCategory[] | null;
 }
 
 export interface MarketOptionsResponse {
   Categories: MarketCategory[];
+  ItemGrades: string[];
+  ItemTiers: number[];
+  Classes: string[];
 }
 
 export const fetchMarketOptions = (): Promise<MarketOptionsResponse> =>
@@ -89,9 +92,9 @@ export interface MarketItem {
   Icon: string;
   BundleCount: number;
   TradeRemainCount: number | null;
-  YDayAvgPrice: number;
-  RecentPrice: number;
-  CurrentMinPrice: number;
+  YDayAvgPrice: number | null;
+  RecentPrice: number | null;
+  CurrentMinPrice: number | null;
 }
 
 export interface MarketSearchResponse {
@@ -118,13 +121,49 @@ export const fetchMarketItems = (
     }),
   });
 
+export interface AuctionOptionValue {
+  DisplayValue: string;
+  Value: number;
+  IsPercentage: boolean;
+}
+
+export interface AuctionEtcSubOption {
+  Value: number;
+  Text: string;
+  Class: string;
+  Categorys: number[] | null;
+  Tiers: number[] | null;
+  EtcValues: AuctionOptionValue[] | null;
+}
+
+export interface AuctionEtcOption {
+  Value: number;
+  Text: string;
+  Tiers: number[] | null;
+  EtcSubs: AuctionEtcSubOption[] | null;
+}
+
+export interface AuctionOptionsResponse {
+  MaxItemLevel: number;
+  ItemGradeQualities: number[];
+  EtcOptions: AuctionEtcOption[];
+  Categories: MarketCategory[];
+  ItemGrades: string[];
+  ItemTiers: number[];
+  Classes: string[];
+}
+
+export const fetchAuctionOptions = (): Promise<AuctionOptionsResponse> =>
+  apiFetch<AuctionOptionsResponse>('/auctions/options');
+
 export interface AuctionItemOption {
   Type: string;
   OptionName: string;
   OptionNameTripod: string;
   Value: number;
   IsPenalty: boolean;
-  ClassName: string;
+  ClassName: string | null;
+  IsValuePercentage?: boolean;
 }
 
 export interface AuctionItem {
@@ -136,7 +175,7 @@ export interface AuctionItem {
   GradeQuality: number | null;
   AuctionInfo: {
     StartPrice: number;
-    BuyPrice: number;
+    BuyPrice: number | null;
     BidPrice: number;
     EndDate: string;
     BidCount: number;

--- a/src/utils/equipmentColors.ts
+++ b/src/utils/equipmentColors.ts
@@ -91,11 +91,11 @@ export const EFFECT_GRADE_COLORS: Record<string, { bg: string; text: string }> =
   최상: { bg: 'bg-red-500/60', text: 'text-red-100' },
 };
 
-/** 품질(0~100) 텍스트 색상 클래스: 100 노랑, 90~99 보라, 70~89 하늘, 30~69 연두, 10~29 연한노랑, 0~9 빨강 */
+/** 품질(0~100) 텍스트 색상 클래스: 100 주황, 90~99 보라, 70~89 하늘, 30~69 연두, 10~29 연한노랑, 0~9 빨강 */
 export function qualityTextColor(q: number): string {
-  if (q >= 100) return 'text-yellow-400';
-  if (q >= 90) return 'text-purple-400';
-  if (q >= 70) return 'text-sky-400';
+  if (q >= 100) return 'text-[#fe9600]';
+  if (q >= 90) return 'text-[#ce43fc]';
+  if (q >= 70) return 'text-[#00b5ff]';
   if (q >= 30) return 'text-lime-400';
   if (q >= 10) return 'text-yellow-200';
   return 'text-red-500';
@@ -103,9 +103,9 @@ export function qualityTextColor(q: number): string {
 
 /** 품질(0~100) 게이지 바 배경 색상 클래스 */
 export function qualityBgColor(q: number): string {
-  if (q >= 100) return 'bg-yellow-400';
-  if (q >= 90) return 'bg-purple-500';
-  if (q >= 70) return 'bg-sky-400';
+  if (q >= 100) return 'bg-[#fe9600]';
+  if (q >= 90) return 'bg-[#ce43fc]';
+  if (q >= 70) return 'bg-[#00b5ff]';
   if (q >= 30) return 'bg-lime-400';
   if (q >= 10) return 'bg-yellow-200';
   return 'bg-red-500';


### PR DESCRIPTION
## 요약
- 시세 페이지에 장신구, 전설 아바타, 팔찌 탭을 추가했습니다.
- 공식 Lost Ark 옵션 API로 카테고리와 검색 옵션 코드를 동적으로 해석합니다.
- 장신구 연마 효과, 팔찌 특성 범위, 즉구가 정렬과 등급별 결과 표시를 지원합니다.
- 활성 탭만 지연 로딩하고 옵션 응답을 공유해 중복 API 요청을 방지합니다.

## 주요 변경
- 장신구 부위별 연마 효과 상·중·하 검색 및 결과 정규화
- 전설 아바타 직업별 4부위 최저가 조회
- 팔찌 치명·특화·신속·제압·인내·숙련 중 서로 다른 두 특성의 양방향 범위 및 부여 효과 개수 검색
- nullable 가격·만료 매물·빈 결과·오류 상태 처리
- `/auctions/options` 프록시 허용

## 검증
- `yarn test` — 71개 파일, 472개 테스트 통과
- `yarn test:proxy` — 11개 테스트 통과
- `yarn build` — 성공
- 실제 API로 장신구 3부위, 팔찌, 전설 아바타 조회 확인
- 모바일 390px 가로 overflow 없음

Refs #67
