### PR TITLE
인게임 재료 화면 인식 정확도 개선

### DIFF
--- a/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
+++ b/src/components/enhancement/material-recognition/MaterialScreenCapture.tsx
@@ -65,7 +65,7 @@ const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
               {status === 'requesting' ? 'Lost Ark 창을 선택해 주세요' : 'Lost Ark 화면을 인식하고 있습니다'}
             </p>
             <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-              강화창 재료를 먼저 읽으며, 툴팁 확인 필요 항목은 아이콘에 마우스를 올려 주세요.
+              강화창 재료를 먼저 읽으며, 툴팁 확인 필요 항목은 강화창을 유지한 채 아이콘에 마우스를 올려 주세요.
               {scanCount > 0 && ` ${results.length}종 감지 · ${scanCount}회 분석`}
             </p>
           </div>
@@ -248,7 +248,7 @@ const MaterialScreenCapture: React.FC<MaterialScreenCaptureProps> = ({
           <li>강화창에 보이는 재료 종류와 <strong className="font-semibold">보유 수량</strong>을 자동으로 읽습니다.</li>
           <li>
             수량이 <strong className="font-semibold text-orange-500">9999</strong>로 표시된 재료는 실제 보유량이 잘린 값입니다.
-            해당 재료 아이콘에 마우스를 올리고 툴팁이 보이도록 잠시 기다려 주세요.
+            강화창을 닫지 말고 해당 재료 아이콘에 마우스를 올려 툴팁이 보이도록 잠시 기다려 주세요.
           </li>
           {includesFateShard && (
             <li>운명의 파편은 게임 상단 바를 먼저 확인하고, 인식되지 않으면 강화창의 소지 금액 첫 번째 값을 읽습니다.</li>

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.test.ts
@@ -74,6 +74,11 @@ describe('getTemplateCropRatios', () => {
       width: 0.68,
       height: 0.68,
     });
+    expect(getTemplateCropCandidates(rgba, 8, 8)).toEqual([
+      { x: 0.05, y: 0.2, width: 0.68, height: 0.68 },
+      { x: 0.2, y: 0.15, width: 0.6, height: 0.7 },
+      { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+    ]);
   });
 });
 
@@ -168,8 +173,27 @@ describe('parseTooltipQuantity', () => {
     expect(parseTooltipQuantity('겹침 수량: 100개\n전체 보유 수량: 950,870개', 100)).toBe(950_870);
   });
 
-  it('uses the title quantity when the tooltip has no total', () => {
+  it('adds the separated tradeable and bound quantities from a honing tooltip', () => {
+    expect(parseTooltipQuantity(
+      '거래 가능 보유 수량: 4,331개\n캐릭터 귀속 보유 수량: 82,027개\n원정대 귀속 보유 수량: 0개',
+      null,
+    )).toBe(86_358);
+    expect(parseTooltipQuantity(
+      '거래 가능 보유 수량: 8,306개\n캐릭터 귀속 보유 수량: 92,890개',
+      null,
+    )).toBe(101_196);
+    expect(parseTooltipQuantity(
+      '거래 가능 보유 수량: 81,362개  J.\n캐릭터 귀속 보유 수량: 139,095  1\n원정대 귀속 보유 수량: 0개',
+      null,
+    )).toBe(220_457);
+  });
+
+  it('uses the title quantity when the tooltip has no owned quantity', () => {
     expect(parseTooltipQuantity('거래 불가\n분해불가', 7440)).toBe(7440);
+  });
+
+  it('returns null when neither the body nor title has a quantity', () => {
+    expect(parseTooltipQuantity('거래 불가\n분해불가', null)).toBeNull();
   });
 
   it('caps an abnormally large quantity', () => {

--- a/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
+++ b/src/components/enhancement/material-recognition/recognizeMaterialFrame.ts
@@ -120,6 +120,11 @@ const DEFAULT_TEMPLATE_CROP: TemplateCropRatios = {
   height: 0.68,
 };
 
+const CENTER_TEMPLATE_CROPS: TemplateCropRatios[] = [
+  { x: 0.2, y: 0.15, width: 0.6, height: 0.7 },
+  { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+];
+
 export const getTemplateCropRatios = (
   rgba: ArrayLike<number>,
   width: number,
@@ -162,7 +167,7 @@ export const getTemplateCropCandidates = (
 ): TemplateCropRatios[] => {
   const detectedCrop = getTemplateCropRatios(rgba, width, height);
   return detectedCrop === DEFAULT_TEMPLATE_CROP
-    ? [detectedCrop]
+    ? [detectedCrop, ...CENTER_TEMPLATE_CROPS]
     : [detectedCrop, DEFAULT_TEMPLATE_CROP];
 };
 
@@ -318,6 +323,7 @@ const createOcrRegion = (
   scale: number,
   threshold: boolean,
   includeColoredText = false,
+  smooth = false,
 ): OcrRegion => {
   const x = Math.max(0, Math.round(sourceX));
   const y = Math.max(0, Math.round(sourceY));
@@ -329,7 +335,7 @@ const createOcrRegion = (
   const context = canvas.getContext('2d', { willReadFrequently: true });
   if (!context || width === 0 || height === 0) return { canvas, hasTextPixels: false };
 
-  context.imageSmoothingEnabled = false;
+  context.imageSmoothingEnabled = smooth;
   context.drawImage(frame, x, y, width, height, 0, 0, canvas.width, canvas.height);
   if (!threshold) return { canvas, hasTextPixels: true };
 
@@ -365,11 +371,26 @@ export const parseTooltipTitleQuantity = (text: string): number | null => {
   return Number.isSafeInteger(quantity) ? quantity : null;
 };
 
-export const parseTooltipQuantity = (text: string, fallback: number): number => {
-  const totalMatch = text.match(/전체\s*보유\s*수량[ \t]*[:：]?[ \t]*([\d, ]+)/);
-  const rawQuantity = totalMatch?.[1] ?? String(fallback);
-  const quantity = Number(rawQuantity.replace(/[^\d]/g, ''));
-  return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : fallback;
+export const parseTooltipQuantity = (text: string, fallback: number | null): number | null => {
+  const totalMatch = text.match(
+    /전체\s*보유\s*수량[ \t]*[:：]?[ \t]*(\d{1,3}(?:[,.]\d{3})+|\d+)/,
+  );
+  if (totalMatch) {
+    const quantity = Number(totalMatch[1].replace(/[^\d]/g, ''));
+    return Number.isSafeInteger(quantity) ? Math.min(quantity, MAX_OWNED_QUANTITY) : fallback;
+  }
+
+  const ownedQuantities = Array.from(text.matchAll(
+    /(?:거래\s*가능|캐릭터\s*귀속|원정대\s*귀속)\s*보유\s*수량[ \t]*[:：]?[ \t]*(\d{1,3}(?:[,.]\d{3})+|\d+)/g,
+  )).map((match) => Number(match[1].replace(/[^\d]/g, '')));
+  if (ownedQuantities.length > 0 && ownedQuantities.every(Number.isSafeInteger)) {
+    return Math.min(
+      ownedQuantities.reduce((sum, quantity) => sum + quantity, 0),
+      MAX_OWNED_QUANTITY,
+    );
+  }
+
+  return fallback;
 };
 
 export const parseHoningFateShardQuantity = (text: string): number | null => {
@@ -648,33 +669,42 @@ const recognizeTooltipQuantity = async (
     4,
     true,
   );
-  if (!title.hasTextPixels) return null;
 
   const numericWorker = await getNumericOcrWorker();
   await numericWorker.setParameters({ tessedit_char_whitelist: '0123456789,Xx[] ' });
-  const { data: titleData } = await numericWorker.recognize(title.canvas);
+  const titleData = title.hasTextPixels
+    ? (await numericWorker.recognize(title.canvas)).data
+    : { text: '', confidence: 0 };
   const titleQuantity = parseTooltipTitleQuantity(titleData.text);
-  if (titleQuantity === null) return null;
 
+  const screenScale = frame.height / 1080;
+  // Transparent artwork can match the tooltip icon at a smaller template scale.
+  // Compensate so both 64px and 80px matches resolve to the same tooltip body.
+  const compactMatchOffset = Math.max(0, 80 * screenScale - match.slotSize);
   const tooltip = createOcrRegion(
     frame,
-    match.x - match.slotSize * 0.3,
-    match.y + match.slotSize * 1.4,
-    match.slotSize * 6.8,
-    match.slotSize * 3.4,
-    2,
+    match.x - compactMatchOffset * 0.625 - screenScale,
+    match.y + match.slotSize * 1.025 + compactMatchOffset * 0.46,
+    Math.max(match.slotSize * 4, 320 * screenScale),
+    100 * screenScale + compactMatchOffset * 0.3125,
+    4,
     false,
+    false,
+    true,
   );
   const tooltipWorker = await getTooltipOcrWorker();
   const { data: tooltipData } = await tooltipWorker.recognize(tooltip.canvas);
-  const quantity = parseTooltipQuantity(tooltipData.text, titleQuantity);
+  const bodyQuantity = parseTooltipQuantity(tooltipData.text, null);
+  const quantity = bodyQuantity ?? titleQuantity;
+  if (quantity === null) return null;
   const capped = quantity > MAX_OWNED_QUANTITY;
-  const confidence = Math.max(0, Math.min(1, titleData.confidence / 100));
+  const ocrConfidence = bodyQuantity === null ? titleData.confidence : tooltipData.confidence;
+  const confidence = Math.max(0, Math.min(1, ocrConfidence / 100));
 
   return {
     quantity: capped ? MAX_OWNED_QUANTITY : quantity,
     confidence,
-    needsReview: capped || titleData.confidence < 70,
+    needsReview: capped || ocrConfidence < 70,
   };
 };
 
@@ -710,35 +740,36 @@ const recognizeFateShard = async (
 
   const hasHoningRow = honing?.detected && honing.slotSize > 0;
   if (!hasHoningRow || !honing) return null;
-  // The first value below the leftmost material slot is fate shards. Limiting
-  // this crop prevents the following silver and gold values from being used.
-  const honingCosts = createOcrRegion(
+  // Normal and advanced honing both place the owned fate-shard amount in the
+  // first currency column. A narrow numeric crop avoids silver in the next column.
+  const ownedAmount = createOcrRegion(
     frame,
-    honing.leftmostSlotX - honing.slotSize * 1.3,
-    honing.rowY + honing.slotSize * 1.75,
-    honing.slotSize * 2.7,
-    honing.slotSize * 1.8,
+    honing.region.x + honing.region.width * 0.4,
+    honing.rowY + honing.slotSize * 2.35,
+    honing.region.width * 0.1,
+    honing.slotSize * 0.9,
     4,
     false,
   );
-  const tooltipWorker = await getTooltipOcrWorker();
-  const { data: honingData } = await tooltipWorker.recognize(honingCosts.canvas);
-  let honingQuantity = parseHoningFateShardQuantity(honingData.text);
-  let confidence = Math.max(0, Math.min(1, honingData.confidence / 100));
+  const { data: ownedData } = await numericWorker.recognize(ownedAmount.canvas);
+  let honingQuantity = parseNarrowFateShardQuantity(ownedData.text);
+  let confidence = Math.max(0, Math.min(1, ownedData.confidence / 100));
   if (honingQuantity === null) {
-    // Advanced honing places the first owned currency farther right than the material row.
-    const advancedOwnedAmount = createOcrRegion(
+    // Keep the labelled multi-column OCR as a fallback for layouts where the
+    // currency column cannot be isolated reliably.
+    const honingCosts = createOcrRegion(
       frame,
-      honing.region.x + honing.region.width * 0.4,
-      honing.rowY + honing.slotSize * 2.35,
-      honing.region.width * 0.15,
-      honing.slotSize * 0.9,
+      honing.leftmostSlotX - honing.slotSize * 1.3,
+      honing.rowY + honing.slotSize * 1.75,
+      honing.slotSize * 2.7,
+      honing.slotSize * 1.8,
       4,
       false,
     );
-    const { data: advancedData } = await numericWorker.recognize(advancedOwnedAmount.canvas);
-    honingQuantity = parseNarrowFateShardQuantity(advancedData.text);
-    confidence = Math.max(0, Math.min(1, advancedData.confidence / 100));
+    const tooltipWorker = await getTooltipOcrWorker();
+    const { data: honingData } = await tooltipWorker.recognize(honingCosts.canvas);
+    honingQuantity = parseHoningFateShardQuantity(honingData.text);
+    confidence = Math.max(0, Math.min(1, honingData.confidence / 100));
   }
   if (honingQuantity === null) return null;
 


### PR DESCRIPTION
## 변경 사항
- 강화창 툴팁의 거래 가능·캐릭터 귀속·원정대 귀속 보유량을 합산해 `9999` 수량 보강
- 운명의 파편 강화창 소지 금액 OCR 영역 개선
- 운명의 파괴석 결정 아이콘의 중앙 crop fallback 추가
- 강화창을 닫지 않고 재료 툴팁을 표시하도록 사용 안내 명확화
- 실제 인게임 OCR 잡음 사례에 대한 파싱 테스트 추가

## 실제 인게임 검증
- `타임키요옷` 일반/상급 재련 및 툴팁 인식 통과
- `한건뜬` 운명의 파괴석 결정 툴팁 미표시/표시 인식 통과
- 운명의 파편 및 아비도스 융화 재료 인식 통과

## 검증
- `yarn vitest run src/components/enhancement/material-recognition --reporter=dot`
- `yarn typecheck`
- `git diff --check`

Closes #57