### PR TITLE
feat: Supabase Auth 로그인·로그아웃과 인증 UI 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": "24.x"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.115.0",
     "@techstark/opencv-js": "5.0.0-release.1",
     "@vercel/analytics": "^2.0.0",
     "react": "^19.0.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -29,6 +29,7 @@ vi.mock('./pages/Market', () => ({ default: () => <div>Market Page</div> }));
 vi.mock('./pages/Spending', () => ({ default: () => <div>Spending Page</div> }));
 vi.mock('./pages/Changelog', () => ({ default: () => <div>Changelog Page</div> }));
 vi.mock('./pages/Policy', () => ({ default: () => <div>Policy Page</div> }));
+vi.mock('./pages/AuthCallback', () => ({ default: () => <div>Auth Callback Page</div> }));
 vi.mock('./pages/NotFound', () => ({ default: () => <div>Not Found Page</div> }));
 
 import App from './App';
@@ -75,6 +76,15 @@ test('matches the policy route and renders the common footer', async () => {
 
   expect(await screen.findByText('Policy Page')).toBeInTheDocument();
   expect(screen.getByRole('contentinfo')).toHaveTextContent('© 2026 로아끼욧. All rights reserved.');
+});
+
+test('matches the OAuth callback route', async () => {
+  mockPathname = '/auth/callback';
+
+  render(<App />);
+
+  expect(await screen.findByText('Auth Callback Page')).toBeInTheDocument();
+  expect(screen.queryByText('Not Found Page')).not.toBeInTheDocument();
 });
 
 test('falls back to the not found page for unmatched routes', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from './components/Footer';
 import { LoadingIndicator } from './components/Loading';
 import { RouteSeo } from './components/RouteSeo';
 import { ROUTES } from './utils/routes';
+import { AuthProvider } from './context/AuthContext';
 import { PwaChunkProvider, usePwaChunk } from './context/PwaChunkContext';
 import { ThemeProvider } from './context/ThemeContext';
 
@@ -18,6 +19,7 @@ const Spending = React.lazy(() => import(/* webpackChunkName: "route-spending" *
 const Market = React.lazy(() => import(/* webpackChunkName: "route-market" */ './pages/Market'));
 const Changelog = React.lazy(() => import(/* webpackChunkName: "route-changelog" */ './pages/Changelog'));
 const Policy = React.lazy(() => import(/* webpackChunkName: "route-policy" */ './pages/Policy'));
+const AuthCallback = React.lazy(() => import(/* webpackChunkName: "route-auth-callback" */ './pages/AuthCallback'));
 const NotFound = React.lazy(() => import(/* webpackChunkName: "route-not-found" */ './pages/NotFound'));
 
 const ChunkErrorBanner: React.FC = () => {
@@ -72,6 +74,7 @@ const AppContent: React.FC = () => {
               <Route path="/spending" element={<Spending />} />
               <Route path={ROUTES.changelog} element={<Changelog />} />
               <Route path={ROUTES.policy} element={<Policy />} />
+              <Route path="/auth/callback" element={<AuthCallback />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </React.Suspense>
@@ -84,9 +87,11 @@ const AppContent: React.FC = () => {
 
 const App: React.FC = () => (
   <PwaChunkProvider>
-    <ThemeProvider>
-      <AppContent />
-    </ThemeProvider>
+    <AuthProvider>
+      <ThemeProvider>
+        <AppContent />
+      </ThemeProvider>
+    </AuthProvider>
   </PwaChunkProvider>
 );
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { AuthControls } from './auth/AuthControls';
 import ChangelogBell from './ChangelogBell';
 import { getNavItemClass, MORE_NAV_LINKS, NavLinks, PRIMARY_NAV_LINKS } from './nav/NavLinks';
 
@@ -179,6 +180,7 @@ const NavBar: React.FC = () => {
                 <span className="font-medium text-gray-500 dark:text-gray-400">현재 테마</span>
                 <span className="font-bold text-gray-900 dark:text-white">{isDarkMode ? '다크 모드' : '라이트 모드'}</span>
               </div>
+              <AuthControls variant="mobile" />
               <button
                 type="button"
                 aria-label="모바일 메뉴 닫기"
@@ -239,6 +241,9 @@ const NavBar: React.FC = () => {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          <div className="hidden md:block">
+            <AuthControls />
+          </div>
           <ChangelogBell />
           <button
             ref={themeButtonRef}

--- a/src/components/auth/AuthControls.test.tsx
+++ b/src/components/auth/AuthControls.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { User } from '@supabase/supabase-js';
+
+vi.mock('../../context/AuthContext', () => ({ useAuth: vi.fn() }));
+
+import { useAuth } from '../../context/AuthContext';
+import { AuthControls } from './AuthControls';
+
+const signInWithDiscord = vi.fn();
+const signOut = vi.fn();
+const clearError = vi.fn();
+
+const authValue = (overrides: Partial<ReturnType<typeof useAuth>> = {}): ReturnType<typeof useAuth> => ({
+  status: 'anonymous',
+  session: null,
+  user: null,
+  isBusy: false,
+  errorMessage: null,
+  signInWithDiscord,
+  signOut,
+  clearError,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAuth).mockReturnValue(authValue());
+});
+
+test('anonymous users can start Discord login', async () => {
+  render(<AuthControls />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'Discord 로그인' }));
+
+  expect(signInWithDiscord).toHaveBeenCalledOnce();
+});
+
+test('authenticated users see their profile and can log out', async () => {
+  const user = {
+    id: 'user-id',
+    app_metadata: {},
+    user_metadata: {
+      global_name: 'Lokki 사용자',
+      avatar_url: 'https://example.com/avatar.png',
+    },
+    aud: 'authenticated',
+    created_at: '2026-09-04T00:00:00Z',
+  } as User;
+  vi.mocked(useAuth).mockReturnValue(authValue({ status: 'authenticated', user }));
+
+  const { container } = render(<AuthControls />);
+
+  expect(screen.getByText('Lokki 사용자')).toBeInTheDocument();
+  expect(container.querySelector('img')).toHaveAttribute('src', 'https://example.com/avatar.png');
+  await userEvent.click(screen.getByRole('button', { name: '로그아웃' }));
+  expect(signOut).toHaveBeenCalledOnce();
+});
+
+test('login errors are recoverable and dismissible', async () => {
+  vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류' }));
+
+  render(<AuthControls variant="mobile" />);
+
+  expect(screen.getByRole('alert')).toHaveTextContent('로그인 오류');
+  await userEvent.click(screen.getByRole('button', { name: '닫기' }));
+  expect(clearError).toHaveBeenCalledOnce();
+  expect(screen.getByRole('button', { name: 'Discord 로그인' })).toBeEnabled();
+});
+
+test('does not render authentication UI when Supabase is not configured', () => {
+  vi.mocked(useAuth).mockReturnValue(authValue({ status: 'unavailable' }));
+
+  const { container } = render(<AuthControls />);
+
+  expect(container).toBeEmptyDOMElement();
+});

--- a/src/components/auth/AuthControls.tsx
+++ b/src/components/auth/AuthControls.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useAuth } from '../../context/AuthContext';
+
+type AuthControlsProps = {
+  readonly variant?: 'desktop' | 'mobile';
+};
+
+const getUserLabel = (metadata: Record<string, unknown> | undefined): string => {
+  const candidates = [metadata?.global_name, metadata?.full_name, metadata?.name];
+  return candidates.find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    ?? '로그인 사용자';
+};
+
+const getAvatarUrl = (metadata: Record<string, unknown> | undefined): string | null => {
+  const avatarUrl = metadata?.avatar_url;
+  return typeof avatarUrl === 'string' && avatarUrl.length > 0 ? avatarUrl : null;
+};
+
+export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop' }) => {
+  const { status, user, isBusy, errorMessage, signInWithDiscord, signOut, clearError } = useAuth();
+  if (status === 'unavailable') return null;
+
+  const isMobile = variant === 'mobile';
+  const buttonClass = isMobile
+    ? 'inline-flex min-h-10 flex-1 items-center justify-center rounded-lg px-3 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40'
+    : 'inline-flex h-9 items-center justify-center rounded-lg px-3 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40';
+
+  if (status === 'loading') {
+    return (
+      <span role="status" className="px-2 text-xs text-gray-500 dark:text-gray-400">
+        로그인 확인 중
+      </span>
+    );
+  }
+
+  if (status === 'anonymous') {
+    return (
+      <div className={isMobile ? 'space-y-2 rounded-xl border border-gray-200/60 p-3 dark:border-white/10' : 'flex items-center gap-2'}>
+        {errorMessage && (
+          <div role="alert" className="flex items-center gap-2 text-xs text-red-600 dark:text-red-400">
+            <span>{errorMessage}</span>
+            <button type="button" onClick={clearError} className="underline">닫기</button>
+          </div>
+        )}
+        <button
+          type="button"
+          disabled={isBusy}
+          onClick={() => void signInWithDiscord()}
+          className={`${buttonClass} bg-indigo-600 text-white hover:bg-indigo-700 disabled:cursor-wait disabled:opacity-60`}
+        >
+          {isBusy ? '연결 중...' : 'Discord 로그인'}
+        </button>
+      </div>
+    );
+  }
+
+  const label = getUserLabel(user?.user_metadata);
+  const avatarUrl = getAvatarUrl(user?.user_metadata);
+
+  return (
+    <div className={isMobile ? 'space-y-2 rounded-xl border border-gray-200/60 p-3 dark:border-white/10' : 'flex items-center gap-2'}>
+      <div className="flex min-w-0 items-center gap-2">
+        {avatarUrl ? (
+          <img src={avatarUrl} alt="" className="h-7 w-7 shrink-0 rounded-full" referrerPolicy="no-referrer" />
+        ) : (
+          <span aria-hidden className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300">
+            {label.slice(0, 1)}
+          </span>
+        )}
+        <span className="max-w-28 truncate text-sm font-medium text-gray-700 dark:text-gray-200" title={label}>
+          {label}
+        </span>
+      </div>
+      {errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+      <button
+        type="button"
+        disabled={isBusy}
+        onClick={() => void signOut()}
+        className={`${buttonClass} ${isMobile ? 'w-full bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-white/10 dark:text-gray-200 dark:hover:bg-white/15' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white'} disabled:cursor-wait disabled:opacity-60`}
+      >
+        {isBusy ? '로그아웃 중...' : '로그아웃'}
+      </button>
+    </div>
+  );
+};

--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Session } from '@supabase/supabase-js';
+
+const mocks = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+  getSession: vi.fn(),
+  onAuthStateChange: vi.fn(),
+  signInWithOAuth: vi.fn(),
+  signOut: vi.fn(),
+  unsubscribe: vi.fn(),
+  getSupabaseBrowserClient: vi.fn(),
+}));
+
+vi.mock('../lib/supabase', () => ({
+  getSupabaseBrowserClient: mocks.getSupabaseBrowserClient,
+  isSupabaseConfigured: true,
+}));
+
+import { AuthProvider, useAuth } from './AuthContext';
+
+const session = {
+  access_token: 'test-access-token',
+  refresh_token: 'test-refresh-token',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: '11111111-1111-1111-1111-111111111111',
+    app_metadata: {},
+    user_metadata: { global_name: '테스트 사용자' },
+    aud: 'authenticated',
+    created_at: '2026-09-04T00:00:00Z',
+  },
+} as Session;
+
+const client = {
+  auth: {
+    exchangeCodeForSession: mocks.exchangeCodeForSession,
+    getSession: mocks.getSession,
+    onAuthStateChange: mocks.onAuthStateChange,
+    signInWithOAuth: mocks.signInWithOAuth,
+    signOut: mocks.signOut,
+  },
+};
+
+const Probe = () => {
+  const auth = useAuth();
+  return (
+    <div>
+      <span data-testid="status">{auth.status}</span>
+      <span data-testid="user">{auth.user?.id ?? 'none'}</span>
+      {auth.errorMessage && <span role="alert">{auth.errorMessage}</span>}
+      <button type="button" onClick={() => void auth.signInWithDiscord()}>login</button>
+      <button type="button" onClick={() => void auth.signOut()}>logout</button>
+    </div>
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.replaceState({}, '', '/');
+  mocks.getSupabaseBrowserClient.mockReturnValue(client);
+  mocks.getSession.mockResolvedValue({ data: { session: null }, error: null });
+  mocks.exchangeCodeForSession.mockResolvedValue({ data: { session }, error: null });
+  mocks.signInWithOAuth.mockResolvedValue({ data: { provider: 'discord', url: null }, error: null });
+  mocks.signOut.mockResolvedValue({ error: null });
+  mocks.onAuthStateChange.mockReturnValue({
+    data: { subscription: { unsubscribe: mocks.unsubscribe } },
+  });
+});
+
+test('keeps children available when Supabase environment variables are missing', () => {
+  mocks.getSupabaseBrowserClient.mockReturnValue(null);
+
+  render(<AuthProvider><Probe /></AuthProvider>);
+
+  expect(screen.getByTestId('status')).toHaveTextContent('unavailable');
+  expect(mocks.getSession).not.toHaveBeenCalled();
+});
+
+test('restores an existing session and unsubscribes on unmount', async () => {
+  mocks.getSession.mockResolvedValue({ data: { session }, error: null });
+
+  const view = render(<AuthProvider><Probe /></AuthProvider>);
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+  expect(screen.getByTestId('user')).toHaveTextContent(session.user.id);
+
+  view.unmount();
+  expect(mocks.unsubscribe).toHaveBeenCalledOnce();
+});
+
+test('exchanges a PKCE code on the callback route', async () => {
+  window.history.replaceState({}, '', '/auth/callback?code=test-code');
+
+  render(<AuthProvider><Probe /></AuthProvider>);
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+  expect(mocks.exchangeCodeForSession).toHaveBeenCalledWith('test-code');
+  expect(mocks.getSession).not.toHaveBeenCalled();
+});
+
+test('reports an OAuth cancellation without blocking anonymous use', async () => {
+  window.history.replaceState({}, '', '/auth/callback?error=access_denied');
+
+  render(<AuthProvider><Probe /></AuthProvider>);
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+  expect(screen.getByRole('alert')).toHaveTextContent('다시 시도');
+  expect(mocks.exchangeCodeForSession).not.toHaveBeenCalled();
+});
+
+test('does not treat an error query on a public route as an OAuth callback', async () => {
+  window.history.replaceState({}, '', '/?error=search-filter');
+
+  render(<AuthProvider><Probe /></AuthProvider>);
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+  expect(mocks.getSession).toHaveBeenCalledOnce();
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});
+
+test('starts Discord OAuth with the exact callback and signs out', async () => {
+  mocks.getSession.mockResolvedValue({ data: { session }, error: null });
+  render(<AuthProvider><Probe /></AuthProvider>);
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+
+  await userEvent.click(screen.getByRole('button', { name: 'login' }));
+  expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+    provider: 'discord',
+    options: { redirectTo: `${window.location.origin}/auth/callback` },
+  });
+
+  await userEvent.click(screen.getByRole('button', { name: 'logout' }));
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+  expect(mocks.signOut).toHaveBeenCalledOnce();
+});

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,156 @@
+import type { Session, User } from '@supabase/supabase-js';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { getSupabaseBrowserClient, isSupabaseConfigured } from '../lib/supabase';
+
+export type AuthStatus = 'loading' | 'authenticated' | 'anonymous' | 'unavailable';
+
+interface AuthContextValue {
+  readonly status: AuthStatus;
+  readonly session: Session | null;
+  readonly user: User | null;
+  readonly isBusy: boolean;
+  readonly errorMessage: string | null;
+  signInWithDiscord(): Promise<void>;
+  signOut(): Promise<void>;
+  clearError(): void;
+}
+
+const unavailableValue: AuthContextValue = {
+  status: 'unavailable',
+  session: null,
+  user: null,
+  isBusy: false,
+  errorMessage: null,
+  signInWithDiscord: async () => undefined,
+  signOut: async () => undefined,
+  clearError: () => undefined,
+};
+
+const AuthContext = createContext<AuthContextValue>(unavailableValue);
+const callbackExchanges = new Map<string, ReturnType<NonNullable<ReturnType<typeof getSupabaseBrowserClient>>['auth']['exchangeCodeForSession']>>();
+
+const exchangeCallbackCode = (code: string) => {
+  const existing = callbackExchanges.get(code);
+  if (existing) return existing;
+
+  const client = getSupabaseBrowserClient();
+  if (!client) return null;
+  const exchange = client.auth.exchangeCodeForSession(code);
+  callbackExchanges.set(code, exchange);
+  return exchange;
+};
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const client = useMemo(() => getSupabaseBrowserClient(), []);
+  const [status, setStatus] = useState<AuthStatus>(client ? 'loading' : 'unavailable');
+  const [session, setSession] = useState<Session | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    let active = true;
+
+    const applySession = (nextSession: Session | null) => {
+      if (!active) return;
+      setSession(nextSession);
+      setStatus(nextSession ? 'authenticated' : 'anonymous');
+    };
+
+    const { data: authListener } = client.auth.onAuthStateChange((_event, nextSession) => {
+      applySession(nextSession);
+    });
+
+    const initialize = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const isCallbackRoute = window.location.pathname === '/auth/callback';
+      const callbackError = isCallbackRoute ? params.get('error') : null;
+      const code = isCallbackRoute ? params.get('code') : null;
+
+      if (callbackError) {
+        if (!active) return;
+        setErrorMessage('Discord 로그인이 취소되었거나 완료되지 않았습니다. 다시 시도해 주세요.');
+        applySession(null);
+        return;
+      }
+
+      try {
+        const result = code
+          ? await exchangeCallbackCode(code)
+          : await client.auth.getSession();
+
+        if (!active || !result) return;
+        if (result.error) {
+          setErrorMessage('로그인 상태를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+          applySession(null);
+          return;
+        }
+        applySession(result.data.session);
+      } catch {
+        if (!active) return;
+        setErrorMessage('로그인 서버에 연결하지 못했습니다. 공개 기능은 계속 이용할 수 있습니다.');
+        applySession(null);
+      }
+    };
+
+    void initialize();
+    return () => {
+      active = false;
+      authListener.subscription.unsubscribe();
+    };
+  }, [client]);
+
+  const signInWithDiscord = useCallback(async () => {
+    if (!client) return;
+    setIsBusy(true);
+    setErrorMessage(null);
+    try {
+      const { error } = await client.auth.signInWithOAuth({
+        provider: 'discord',
+        options: { redirectTo: `${window.location.origin}/auth/callback` },
+      });
+      if (error) {
+        setErrorMessage('Discord 로그인을 시작하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      }
+    } catch {
+      setErrorMessage('로그인 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsBusy(false);
+    }
+  }, [client]);
+
+  const signOut = useCallback(async () => {
+    if (!client) return;
+    setIsBusy(true);
+    setErrorMessage(null);
+    try {
+      const { error } = await client.auth.signOut();
+      if (error) {
+        setErrorMessage('로그아웃하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      } else {
+        setSession(null);
+        setStatus('anonymous');
+      }
+    } catch {
+      setErrorMessage('로그인 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsBusy(false);
+    }
+  }, [client]);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    status,
+    session,
+    user: session?.user ?? null,
+    isBusy,
+    errorMessage,
+    signInWithDiscord,
+    signOut,
+    clearError: () => setErrorMessage(null),
+  }), [errorMessage, isBusy, session, signInWithDiscord, signOut, status]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => useContext(AuthContext);
+export { isSupabaseConfigured };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,29 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
+
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+let browserClient: SupabaseClient | null = null;
+
+export const getSupabaseBrowserClient = (): SupabaseClient | null => {
+  if (!isSupabaseConfigured) return null;
+
+  if (!browserClient) {
+    try {
+      browserClient = createClient(supabaseUrl!, supabaseAnonKey!, {
+        auth: {
+          autoRefreshToken: true,
+          detectSessionInUrl: false,
+          flowType: 'pkce',
+          persistSession: true,
+        },
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  return browserClient;
+};

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import NavBar from '../components/NavBar';
+import { useAuth } from '../context/AuthContext';
+
+const AuthCallback: React.FC = () => {
+  const navigate = useNavigate();
+  const { status, errorMessage, isBusy, signInWithDiscord } = useAuth();
+
+  useEffect(() => {
+    if (status === 'authenticated') navigate('/', { replace: true });
+  }, [navigate, status]);
+
+  const isLoading = status === 'loading' || status === 'authenticated';
+
+  return (
+    <div>
+      <NavBar />
+      <main className="mx-auto flex min-h-[60vh] max-w-xl items-center px-4 py-12">
+        <section className="w-full rounded-2xl border border-gray-200/70 bg-white p-6 text-center shadow-sm dark:border-white/10 dark:bg-white/5">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">Discord 로그인</h1>
+          {isLoading ? (
+            <p role="status" className="mt-3 text-sm text-gray-600 dark:text-gray-300">
+              로그인 정보를 확인하고 있습니다...
+            </p>
+          ) : (
+            <>
+              <p role={errorMessage ? 'alert' : undefined} className="mt-3 text-sm text-gray-600 dark:text-gray-300">
+                {errorMessage ?? (status === 'unavailable'
+                  ? '현재 환경에는 로그인 기능이 설정되어 있지 않습니다.'
+                  : '로그인이 완료되지 않았습니다. 다시 시도해 주세요.')}
+              </p>
+              <div className="mt-6 flex flex-col justify-center gap-2 sm:flex-row">
+                {status !== 'unavailable' && (
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => void signInWithDiscord()}
+                    className="min-h-10 rounded-lg bg-indigo-600 px-4 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-wait disabled:opacity-60"
+                  >
+                    Discord 로그인 다시 시도
+                  </button>
+                )}
+                <Link to="/" className="inline-flex min-h-10 items-center justify-center rounded-lg bg-gray-100 px-4 text-sm font-semibold text-gray-700 hover:bg-gray-200 dark:bg-white/10 dark:text-gray-200 dark:hover:bg-white/15">
+                  홈으로 돌아가기
+                </Link>
+              </div>
+            </>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default AuthCallback;

--- a/src/staticSeoGeneration.test.js
+++ b/src/staticSeoGeneration.test.js
@@ -165,8 +165,10 @@ test('keeps API, known routes, missing routes, and static assets distinct in Ver
   const materialIconSource = '/api/material-icon/:path(.*\\.png)';
   const materialIconRewrite = rewrites.find((rewrite) => rewrite.source === materialIconSource);
   const materialIconHeaders = headers.find((rule) => rule.source === materialIconSource);
+  const authCallbackRewrite = rewrites.find((rewrite) => rewrite.source === '/auth/callback');
   const fallbackRewrite = rewrites[rewrites.length - 1];
-  const pageRewrites = rewrites.filter((rewrite) => rewrite.destination.endsWith('/index.html'));
+  const pageRewrites = rewrites.filter((rewrite) =>
+    rewrite.source !== '/auth/callback' && rewrite.destination.endsWith('/index.html'));
   const indexablePageRoutes = routeSeoEntries
     .filter((route) => route.path !== '/' && route.robots === 'index, follow')
     .map((route) => route.path)
@@ -191,6 +193,7 @@ test('keeps API, known routes, missing routes, and static assets distinct in Ver
       },
     ],
   });
+  expect(authCallbackRewrite).toEqual({ source: '/auth/callback', destination: '/index.html' });
   expect(pageRewrites.map((rewrite) => rewrite.source).sort()).toEqual(indexablePageRoutes);
   for (const rewrite of pageRewrites) {
     expect(rewrite.destination).toBe(`${rewrite.source}/index.html`);

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,7 @@
     { "source": "/spending", "destination": "/spending/index.html" },
     { "source": "/changelog", "destination": "/changelog/index.html" },
     { "source": "/policy", "destination": "/policy/index.html" },
+    { "source": "/auth/callback", "destination": "/index.html" },
     { "source": "/:path*", "destination": "/404.html" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,6 +285,13 @@
   resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
+"@supabase/auth-js@2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/auth-js/-/auth-js-2.115.0.tgz#59eb3dbf3d7f3ca0a7b890dcea202b006686753c"
+  integrity sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ==
+  dependencies:
+    tslib "2.8.1"
+
 "@supabase/cli-darwin-arm64@2.116.0":
   version "2.116.0"
   resolved "https://registry.yarnpkg.com/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.116.0.tgz#49111826c784a4828a08c1d054927c5d132f2b07"
@@ -324,6 +331,52 @@
   version "2.116.0"
   resolved "https://registry.yarnpkg.com/@supabase/cli-windows-x64/-/cli-windows-x64-2.116.0.tgz#0e0160656b1e515fc4f4a57225ce7c16e65fab03"
   integrity sha512-pz4zNDs3KCEx0l9JS9Xaiuzd5WXrISajVlBSxC5/2Jyo2+g+N/ftQJDYTHQ6Jir5fNelIqSHIXZelmGds14upw==
+
+"@supabase/functions-js@2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-2.115.0.tgz#dccd4493acb8c0e7b1aa096ed8671233e9e6b20e"
+  integrity sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/phoenix@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@supabase/phoenix/-/phoenix-0.4.5.tgz#28f6a0dc020f53f171899b9c6021eecfe2a112d1"
+  integrity sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==
+
+"@supabase/postgrest-js@2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-2.115.0.tgz#f7858eabec36688c039a0e9e370e40063b532dce"
+  integrity sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/realtime-js@2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.115.0.tgz#21ce950be88b383dc291bdd5456b3780c39fda73"
+  integrity sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw==
+  dependencies:
+    "@supabase/phoenix" "0.4.5"
+    tslib "2.8.1"
+
+"@supabase/storage-js@2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-2.115.0.tgz#735e93a6ddb78ec968424f65c776e4f379362d72"
+  integrity sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA==
+  dependencies:
+    iceberg-js "^0.8.1"
+    tslib "2.8.1"
+
+"@supabase/supabase-js@^2.115.0":
+  version "2.115.0"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-2.115.0.tgz#26820d188f9f1cacf634afd6424abe6d7649227b"
+  integrity sha512-PYJSxtCo37R7tTZW6pAqsxUeSx/dlhA7zn8RzKEUSCqyTxCUhG+iHrDTb04UyVBYbttaUbhwkNTvb8h5HW+uZA==
+  dependencies:
+    "@supabase/auth-js" "2.115.0"
+    "@supabase/functions-js" "2.115.0"
+    "@supabase/postgrest-js" "2.115.0"
+    "@supabase/realtime-js" "2.115.0"
+    "@supabase/storage-js" "2.115.0"
 
 "@techstark/opencv-js@5.0.0-release.1":
   version "5.0.0-release.1"
@@ -928,6 +981,11 @@ https-proxy-agent@^7.0.6:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+iceberg-js@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/iceberg-js/-/iceberg-js-0.8.1.tgz#47d893468293a010385e1c70123f29d0fc1d9912"
+  integrity sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==
 
 idb-keyval@^6.2.0:
   version "6.3.0"
@@ -1759,6 +1817,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 typescript@^5.9.3:
   version "5.9.3"


### PR DESCRIPTION
## Summary
- Supabase 브라우저 클라이언트와 전역 Auth Provider 추가
- Discord PKCE OAuth 및 `/auth/callback` code exchange 구현
- 데스크톱·모바일 NavBar 로그인/프로필/로그아웃 UI 추가
- 환경변수 누락, OAuth 취소, 세션 및 네트워크 오류 fallback 처리
- Vercel callback rewrite 추가

## Verification
- focused test: 28/28 통과
- `yarn typecheck`: 통과
- localhost Discord OAuth 로그인 성공
- 새로고침 후 세션 복구 확인
- 로그아웃 후 익명 UI 복귀 확인
- 재로그인 시 동일 Supabase 사용자/프로필 복원 확인

Closes #82