### PR TITLE
fix: OAuth callback 안내와 SEO 정리

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -85,6 +85,8 @@ test('matches the OAuth callback route', async () => {
 
   expect(await screen.findByText('Auth Callback Page')).toBeInTheDocument();
   expect(screen.queryByText('Not Found Page')).not.toBeInTheDocument();
+  expect(document.title).toBe('Discord 로그인 - 로아끼욧');
+  expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
 });
 
 test('falls back to the not found page for unmatched routes', async () => {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,7 +7,11 @@ import { AuthControls } from './auth/AuthControls';
 import ChangelogBell from './ChangelogBell';
 import { getNavItemClass, MORE_NAV_LINKS, NavLinks, PRIMARY_NAV_LINKS } from './nav/NavLinks';
 
-const NavBar: React.FC = () => {
+type NavBarProps = {
+  readonly suppressAuthError?: boolean;
+};
+
+const NavBar: React.FC<NavBarProps> = ({ suppressAuthError = false }) => {
   const { pathname } = useLocation();
   const { isDarkMode, toggleDarkMode } = useTheme();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -180,7 +184,7 @@ const NavBar: React.FC = () => {
                 <span className="font-medium text-gray-500 dark:text-gray-400">현재 테마</span>
                 <span className="font-bold text-gray-900 dark:text-white">{isDarkMode ? '다크 모드' : '라이트 모드'}</span>
               </div>
-              <AuthControls variant="mobile" />
+              <AuthControls variant="mobile" showError={!suppressAuthError} />
               <button
                 type="button"
                 aria-label="모바일 메뉴 닫기"
@@ -242,7 +246,7 @@ const NavBar: React.FC = () => {
         </div>
         <div className="flex items-center gap-1">
           <div className="hidden md:block">
-            <AuthControls />
+            <AuthControls showError={!suppressAuthError} />
           </div>
           <ChangelogBell />
           <button

--- a/src/components/RouteSeo.tsx
+++ b/src/components/RouteSeo.tsx
@@ -28,6 +28,15 @@ const ROUTE_SEO: readonly RouteSeoEntry[] = routeSeoEntries.map((entry) => ({
   priority: entry.priority,
 }));
 
+const AUTH_CALLBACK_SEO: RouteSeoEntry = {
+  path: '/auth/callback',
+  title: 'Discord 로그인 - 로아끼욧',
+  description: '로아끼욧 Discord 로그인 결과를 확인하고 있습니다.',
+  name: 'Discord 로그인',
+  schemaType: 'WebPage',
+  robots: 'noindex, follow',
+};
+
 const NOT_FOUND_SEO: RouteSeoEntry = {
   path: '/',
   title: '페이지를 찾을 수 없습니다 - 로아끼욧',
@@ -39,6 +48,7 @@ const NOT_FOUND_SEO: RouteSeoEntry = {
 
 function findSeoEntry(pathname: string): RouteSeoEntry {
   const normalizedPathname = normalizePathname(pathname);
+  if (normalizedPathname === AUTH_CALLBACK_SEO.path) return AUTH_CALLBACK_SEO;
   return ROUTE_SEO.find((entry) => entry.path === normalizedPathname) ?? NOT_FOUND_SEO;
 }
 

--- a/src/components/auth/AuthControls.test.tsx
+++ b/src/components/auth/AuthControls.test.tsx
@@ -68,6 +68,15 @@ test('login errors are recoverable and dismissible', async () => {
   expect(screen.getByRole('button', { name: 'Discord 로그인' })).toBeEnabled();
 });
 
+test('can suppress a callback error already shown by the page', () => {
+  vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류' }));
+
+  render(<AuthControls showError={false} />);
+
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Discord 로그인' })).toBeEnabled();
+});
+
 test('does not render authentication UI when Supabase is not configured', () => {
   vi.mocked(useAuth).mockReturnValue(authValue({ status: 'unavailable' }));
 

--- a/src/components/auth/AuthControls.tsx
+++ b/src/components/auth/AuthControls.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../../context/AuthContext';
 
 type AuthControlsProps = {
   readonly variant?: 'desktop' | 'mobile';
+  readonly showError?: boolean;
 };
 
 const getUserLabel = (metadata: Record<string, unknown> | undefined): string => {
@@ -16,7 +17,7 @@ const getAvatarUrl = (metadata: Record<string, unknown> | undefined): string | n
   return typeof avatarUrl === 'string' && avatarUrl.length > 0 ? avatarUrl : null;
 };
 
-export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop' }) => {
+export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop', showError = true }) => {
   const { status, user, isBusy, errorMessage, signInWithDiscord, signOut, clearError } = useAuth();
   if (status === 'unavailable') return null;
 
@@ -36,7 +37,7 @@ export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop' 
   if (status === 'anonymous') {
     return (
       <div className={isMobile ? 'space-y-2 rounded-xl border border-gray-200/60 p-3 dark:border-white/10' : 'flex items-center gap-2'}>
-        {errorMessage && (
+        {showError && errorMessage && (
           <div role="alert" className="flex items-center gap-2 text-xs text-red-600 dark:text-red-400">
             <span>{errorMessage}</span>
             <button type="button" onClick={clearError} className="underline">닫기</button>
@@ -71,7 +72,7 @@ export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop' 
           {label}
         </span>
       </div>
-      {errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+      {showError && errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
       <button
         type="button"
         disabled={isBusy}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -15,7 +15,7 @@ const AuthCallback: React.FC = () => {
 
   return (
     <div>
-      <NavBar />
+      <NavBar suppressAuthError />
       <main className="mx-auto flex min-h-[60vh] max-w-xl items-center px-4 py-12">
         <section className="w-full rounded-2xl border border-gray-200/70 bg-white p-6 text-center shadow-sm dark:border-white/10 dark:bg-white/5">
           <h1 className="text-xl font-bold text-gray-900 dark:text-white">Discord 로그인</h1>


### PR DESCRIPTION
## Summary
- OAuth callback 경로에 전용 noindex SEO metadata 적용
- callback 본문과 NavBar에 중복되던 인증 오류 안내 제거

## Verification
- Preview QA에서 callback rewrite와 OAuth redirect 확인
- focused test: 18/18 통과
- `yarn typecheck`: 통과

Follow-up to #82