### PR TITLE
fix: 인증 오류 스코프 분리로 Header 잔류 제거

### DIFF
--- a/src/components/auth/AuthControls.test.tsx
+++ b/src/components/auth/AuthControls.test.tsx
@@ -17,6 +17,7 @@ const authValue = (overrides: Partial<ReturnType<typeof useAuth>> = {}): ReturnT
   user: null,
   isBusy: false,
   errorMessage: null,
+  errorScope: null,
   signInWithDiscord,
   signOut,
   clearError,
@@ -58,7 +59,7 @@ test('authenticated users see their profile and can log out', async () => {
 });
 
 test('login errors are recoverable and dismissible', async () => {
-  vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류' }));
+  vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류', errorScope: 'action' }));
 
   render(<AuthControls variant="mobile" />);
 
@@ -75,6 +76,16 @@ test('can suppress a callback error already shown by the page', () => {
 
   expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Discord 로그인' })).toBeEnabled();
+});
+
+test('callback-scoped errors are not shown in the header', () => {
+  vi.mocked(useAuth).mockReturnValue(
+    authValue({ errorMessage: 'Discord 로그인이 취소되었거나 완료되지 않았습니다.', errorScope: 'callback' }),
+  );
+
+  render(<AuthControls />);
+
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
 
 test('does not render authentication UI when Supabase is not configured', () => {

--- a/src/components/auth/AuthControls.tsx
+++ b/src/components/auth/AuthControls.tsx
@@ -18,7 +18,7 @@ const getAvatarUrl = (metadata: Record<string, unknown> | undefined): string | n
 };
 
 export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop', showError = true }) => {
-  const { status, user, isBusy, errorMessage, signInWithDiscord, signOut, clearError } = useAuth();
+  const { status, user, isBusy, errorMessage, errorScope, signInWithDiscord, signOut, clearError } = useAuth();
   if (status === 'unavailable') return null;
 
   const isMobile = variant === 'mobile';
@@ -37,7 +37,7 @@ export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop',
   if (status === 'anonymous') {
     return (
       <div className={isMobile ? 'space-y-2 rounded-xl border border-gray-200/60 p-3 dark:border-white/10' : 'flex items-center gap-2'}>
-        {showError && errorMessage && (
+        {showError && errorScope !== 'callback' && errorMessage && (
           <div role="alert" className="flex items-center gap-2 text-xs text-red-600 dark:text-red-400">
             <span>{errorMessage}</span>
             <button type="button" onClick={clearError} className="underline">닫기</button>
@@ -72,7 +72,7 @@ export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop',
           {label}
         </span>
       </div>
-      {showError && errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+      {showError && errorScope !== 'callback' && errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
       <button
         type="button"
         disabled={isBusy}

--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -50,6 +50,7 @@ const Probe = () => {
       <span data-testid="status">{auth.status}</span>
       <span data-testid="user">{auth.user?.id ?? 'none'}</span>
       {auth.errorMessage && <span role="alert">{auth.errorMessage}</span>}
+      <span data-testid="error-scope">{auth.errorScope ?? 'none'}</span>
       <button type="button" onClick={() => void auth.signInWithDiscord()}>login</button>
       <button type="button" onClick={() => void auth.signOut()}>logout</button>
     </div>
@@ -107,6 +108,7 @@ test('reports an OAuth cancellation without blocking anonymous use', async () =>
 
   await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
   expect(screen.getByRole('alert')).toHaveTextContent('다시 시도');
+  expect(screen.getByTestId('error-scope')).toHaveTextContent('callback');
   expect(mocks.exchangeCodeForSession).not.toHaveBeenCalled();
 });
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,6 +10,7 @@ interface AuthContextValue {
   readonly user: User | null;
   readonly isBusy: boolean;
   readonly errorMessage: string | null;
+  readonly errorScope: 'callback' | 'action' | null;
   signInWithDiscord(): Promise<void>;
   signOut(): Promise<void>;
   clearError(): void;
@@ -21,6 +22,7 @@ const unavailableValue: AuthContextValue = {
   user: null,
   isBusy: false,
   errorMessage: null,
+  errorScope: null,
   signInWithDiscord: async () => undefined,
   signOut: async () => undefined,
   clearError: () => undefined,
@@ -46,6 +48,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const [session, setSession] = useState<Session | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorScope, setErrorScope] = useState<'callback' | 'action' | null>(null);
+
+  const clearError = useCallback(() => {
+    setErrorMessage(null);
+    setErrorScope(null);
+  }, []);
 
   useEffect(() => {
     if (!client) return;
@@ -70,6 +78,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       if (callbackError) {
         if (!active) return;
         setErrorMessage('Discord 로그인이 취소되었거나 완료되지 않았습니다. 다시 시도해 주세요.');
+        setErrorScope('callback');
         applySession(null);
         return;
       }
@@ -82,6 +91,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         if (!active || !result) return;
         if (result.error) {
           setErrorMessage('로그인 상태를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+          setErrorScope(isCallbackRoute ? 'callback' : 'action');
           applySession(null);
           return;
         }
@@ -89,6 +99,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       } catch {
         if (!active) return;
         setErrorMessage('로그인 서버에 연결하지 못했습니다. 공개 기능은 계속 이용할 수 있습니다.');
+        setErrorScope(isCallbackRoute ? 'callback' : 'action');
         applySession(null);
       }
     };
@@ -103,7 +114,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const signInWithDiscord = useCallback(async () => {
     if (!client) return;
     setIsBusy(true);
-    setErrorMessage(null);
+    clearError();
     try {
       const { error } = await client.auth.signInWithOAuth({
         provider: 'discord',
@@ -111,32 +122,36 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       });
       if (error) {
         setErrorMessage('Discord 로그인을 시작하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        setErrorScope('action');
       }
     } catch {
       setErrorMessage('로그인 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      setErrorScope('action');
     } finally {
       setIsBusy(false);
     }
-  }, [client]);
+  }, [clearError, client]);
 
   const signOut = useCallback(async () => {
     if (!client) return;
     setIsBusy(true);
-    setErrorMessage(null);
+    clearError();
     try {
       const { error } = await client.auth.signOut();
       if (error) {
         setErrorMessage('로그아웃하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        setErrorScope('action');
       } else {
         setSession(null);
         setStatus('anonymous');
       }
     } catch {
       setErrorMessage('로그인 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      setErrorScope('action');
     } finally {
       setIsBusy(false);
     }
-  }, [client]);
+  }, [clearError, client]);
 
   const value = useMemo<AuthContextValue>(() => ({
     status,
@@ -144,10 +159,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     user: session?.user ?? null,
     isBusy,
     errorMessage,
+    errorScope,
     signInWithDiscord,
     signOut,
-    clearError: () => setErrorMessage(null),
-  }), [errorMessage, isBusy, session, signInWithDiscord, signOut, status]);
+    clearError,
+  }), [clearError, errorMessage, errorScope, isBusy, session, signInWithDiscord, signOut, status]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };


### PR DESCRIPTION
## Summary
- 인증 오류를 발생 위치 기준으로 `callback`/`action` 스코프로 분리
- OAuth 취소 등 callback 오류는 callback 화면 본문에만 표시하고 NavBar Header에서 숨김
- 로그인 시작/로그아웃 실패 같은 action 오류는 기존처럼 Header에 표시
- 재시도·로그아웃 시 이전 오류를 정리

## Verification
- focused test: 24/24 통과 (callback 스코프 오류 Header 미노출, action 오류 표시, dismiss 동작 포함)
- `yarn typecheck`: 통과

Follow-up to #82 (UX: callback 오류가 Header에 계속 남아 있던 문제)