### PR TITLE
feat: 회원 프로필·계정 삭제·개인정보 관리

### DIFF
--- a/api/account-delete.js
+++ b/api/account-delete.js
@@ -1,0 +1,103 @@
+const UPSTREAM_TIMEOUT_MS = 10 * 1000;
+const ALLOWED_METHODS = new Set(['POST']);
+
+/** 요청 Bearer 토큰을 검증해 삭제 대상 사용자를 서버가 직접 결정한다. 클라이언트가 보낸 사용자 ID는 신뢰하지 않는다. */
+function extractBearerToken(req) {
+  const authorization = req?.headers?.authorization;
+  if (typeof authorization !== 'string') return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+  return match ? match[1] : null;
+}
+
+function createAccountDeleteHandler({
+  fetchImpl = globalThis.fetch,
+  upstreamTimeoutMs = UPSTREAM_TIMEOUT_MS,
+  logger = console,
+} = {}) {
+  return async function handler(req, res) {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    res.setHeader('cache-control', 'no-store');
+    res.setHeader('x-content-type-options', 'nosniff');
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      res.status(503).json({ message: 'Account deletion is not configured.' });
+      return;
+    }
+
+    if (!ALLOWED_METHODS.has(req.method)) {
+      res.setHeader('Allow', 'POST');
+      res.status(405).json({ message: 'Method not allowed.' });
+      return;
+    }
+
+    const accessToken = extractBearerToken(req);
+    if (!accessToken) {
+      res.status(401).json({ message: 'Sign in is required to delete an account.' });
+      return;
+    }
+
+    const timeoutSignal = AbortSignal.timeout(upstreamTimeoutMs);
+
+    try {
+      const userResponse = await fetchImpl(`${supabaseUrl}/auth/v1/user`, {
+        headers: {
+          apikey: serviceRoleKey,
+          authorization: `Bearer ${accessToken}`,
+        },
+        signal: timeoutSignal,
+      });
+
+      if (userResponse.status === 401 || userResponse.status === 403) {
+        res.status(401).json({ message: 'Sign-in session is invalid or expired.' });
+        return;
+      }
+
+      if (!userResponse.ok) {
+        logger.error('Supabase user verification failed.', { status: userResponse.status });
+        res.status(502).json({ message: 'Account deletion is temporarily unavailable.' });
+        return;
+      }
+
+      const { id: userId } = await userResponse.json();
+      if (typeof userId !== 'string' || userId.length === 0) {
+        res.status(401).json({ message: 'Sign-in session is invalid or expired.' });
+        return;
+      }
+
+      // auth.users 삭제는 FK ON DELETE CASCADE로 lokki_* 소유 데이터를 같은 트랜잭션에서 제거한다.
+      // 이 호출이 실패하면 어떤 데이터도 삭제되지 않으므로 부분 삭제가 발생하지 않는다.
+      const deleteResponse = await fetchImpl(`${supabaseUrl}/auth/v1/admin/users/${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+        headers: {
+          apikey: serviceRoleKey,
+          authorization: `Bearer ${serviceRoleKey}`,
+        },
+        signal: timeoutSignal,
+      });
+
+      if (deleteResponse.ok || deleteResponse.status === 404) {
+        res.status(204).end();
+        return;
+      }
+
+      logger.error('Supabase user deletion failed.', { status: deleteResponse.status });
+      res.status(502).json({ message: 'Account deletion is temporarily unavailable.' });
+    } catch (error) {
+      const timedOut = timeoutSignal.aborted || error?.name === 'TimeoutError';
+      const status = timedOut ? 504 : 502;
+      const message = timedOut
+        ? 'Account deletion timed out. Try again.'
+        : 'Account deletion is temporarily unavailable.';
+
+      logger.error(message, { errorName: error?.name || 'UnknownError' });
+      res.status(status).json({ message });
+    }
+  };
+}
+
+const handler = createAccountDeleteHandler();
+
+module.exports = handler;
+module.exports.createAccountDeleteHandler = createAccountDeleteHandler;

--- a/api/account-delete.test.js
+++ b/api/account-delete.test.js
@@ -1,0 +1,190 @@
+const assert = require('node:assert/strict');
+const {
+  afterEach: nodeAfterEach,
+  beforeEach: nodeBeforeEach,
+  describe: nodeDescribe,
+  test: nodeTest,
+} = require('node:test');
+
+const { createAccountDeleteHandler } = require('./account-delete.js');
+
+const SUPABASE_URL = 'https://unit-test.supabase.co';
+const SERVICE_ROLE_KEY = 'unit-test-service-role-key';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const ACCESS_TOKEN = 'unit-test-access-token';
+
+function createRequest(overrides = {}) {
+  return {
+    method: 'POST',
+    headers: { authorization: `Bearer ${ACCESS_TOKEN}` },
+    ...overrides,
+  };
+}
+
+function createResponse() {
+  return {
+    headers: new Map(),
+    statusCode: null,
+    payload: undefined,
+    ended: false,
+    setHeader(name, value) {
+      this.headers.set(name.toLowerCase(), value);
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+function createUserResponse({ status = 200, userId = USER_ID } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (status === 200 ? { id: userId } : {}),
+  };
+}
+
+function createDeleteResponse({ status = 200 } = {}) {
+  return { ok: status >= 200 && status < 300, status, json: async () => ({}) };
+}
+
+function createHandler(fetchImpl) {
+  return createAccountDeleteHandler({
+    fetchImpl,
+    logger: { error() {} },
+  });
+}
+
+async function invoke(handler, req = createRequest(), res = createResponse()) {
+  await handler(req, res);
+  return res;
+}
+
+nodeDescribe('account delete endpoint', () => {
+  nodeBeforeEach(() => {
+    process.env.SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_ROLE_KEY;
+  });
+
+  nodeAfterEach(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  nodeTest('returns 503 when server configuration is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const res = await invoke(createHandler(() => assert.fail('must not call upstream')));
+
+    assert.equal(res.statusCode, 503);
+    assert.match(res.payload.message, /not configured/i);
+  });
+
+  nodeTest('rejects methods other than POST', async () => {
+    const res = await invoke(createHandler(() => assert.fail('must not call upstream')), createRequest({ method: 'GET' }));
+
+    assert.equal(res.statusCode, 405);
+    assert.equal(res.headers.get('allow'), 'POST');
+  });
+
+  nodeTest('rejects requests without a bearer token', async () => {
+    const res = await invoke(createHandler(() => assert.fail('must not call upstream')), createRequest({ headers: {} }));
+
+    assert.equal(res.statusCode, 401);
+  });
+
+  nodeTest('verifies the session and deletes the verified user only', async () => {
+    const calls = [];
+    const res = await invoke(
+      createHandler(async (url, init) => {
+        calls.push({ url: String(url), method: init?.method ?? 'GET', headers: init?.headers });
+        return String(url).endsWith('/auth/v1/user')
+          ? createUserResponse()
+          : createDeleteResponse();
+      }),
+    );
+
+    assert.equal(res.statusCode, 204);
+    assert.ok(res.ended);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].url, `${SUPABASE_URL}/auth/v1/user`);
+    assert.equal(calls[0].headers.authorization, `Bearer ${ACCESS_TOKEN}`);
+    assert.equal(calls[1].url, `${SUPABASE_URL}/auth/v1/admin/users/${USER_ID}`);
+    assert.equal(calls[1].method, 'DELETE');
+    assert.equal(calls[1].headers.authorization, `Bearer ${SERVICE_ROLE_KEY}`);
+  });
+
+  nodeTest('maps an invalid session to 401 without deleting anything', async () => {
+    const calls = [];
+    const res = await invoke(
+      createHandler(async (url, init) => {
+        calls.push(String(url));
+        return createUserResponse({ status: 401 });
+      }),
+    );
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(calls.length, 1);
+  });
+
+  nodeTest('returns 401 when the verified session has no user id', async () => {
+    const res = await invoke(
+      createHandler(async () => createUserResponse({ userId: '' })),
+    );
+
+    assert.equal(res.statusCode, 401);
+  });
+
+  nodeTest('treats an already-deleted user as success', async () => {
+    const res = await invoke(
+      createHandler(async (url) =>
+        String(url).endsWith('/auth/v1/user') ? createUserResponse() : createDeleteResponse({ status: 404 }),
+      ),
+    );
+
+    assert.equal(res.statusCode, 204);
+  });
+
+  nodeTest('returns 502 when the upstream user lookup fails', async () => {
+    const res = await invoke(createHandler(async () => createUserResponse({ status: 500 })));
+
+    assert.equal(res.statusCode, 502);
+  });
+
+  nodeTest('returns 502 when the upstream deletion fails without partial delete', async () => {
+    const res = await invoke(
+      createHandler(async (url) =>
+        String(url).endsWith('/auth/v1/user') ? createUserResponse() : createDeleteResponse({ status: 500 }),
+      ),
+    );
+
+    assert.equal(res.statusCode, 502);
+  });
+
+  nodeTest('returns 502 when the upstream is unreachable', async () => {
+    const res = await invoke(createHandler(async () => { throw new Error('network down'); }));
+
+    assert.equal(res.statusCode, 502);
+  });
+
+  nodeTest('returns 504 when the upstream times out', async () => {
+    const res = await invoke(
+      createAccountDeleteHandler({
+        fetchImpl: async () => { throw Object.assign(new Error('timed out'), { name: 'TimeoutError' }); },
+        upstreamTimeoutMs: 1,
+        logger: { error() {} },
+      }),
+    );
+
+    assert.equal(res.statusCode, 504);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:proxy": "node --test api/lostark/proxy.test.js",
+    "test:account-delete": "node --test api/account-delete.test.js",
     "typecheck": "tsc --noEmit"
   },
   "browserslist": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,6 +30,7 @@ vi.mock('./pages/Spending', () => ({ default: () => <div>Spending Page</div> }))
 vi.mock('./pages/Changelog', () => ({ default: () => <div>Changelog Page</div> }));
 vi.mock('./pages/Policy', () => ({ default: () => <div>Policy Page</div> }));
 vi.mock('./pages/AuthCallback', () => ({ default: () => <div>Auth Callback Page</div> }));
+vi.mock('./pages/AccountSettings', () => ({ default: () => <div>Account Settings Page</div> }));
 vi.mock('./pages/NotFound', () => ({ default: () => <div>Not Found Page</div> }));
 
 import App from './App';
@@ -86,6 +87,17 @@ test('matches the OAuth callback route', async () => {
   expect(await screen.findByText('Auth Callback Page')).toBeInTheDocument();
   expect(screen.queryByText('Not Found Page')).not.toBeInTheDocument();
   expect(document.title).toBe('Discord 로그인 - 로아끼욧');
+  expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
+});
+
+test('matches the account settings route', async () => {
+  mockPathname = '/account';
+
+  render(<App />);
+
+  expect(await screen.findByText('Account Settings Page')).toBeInTheDocument();
+  expect(screen.queryByText('Not Found Page')).not.toBeInTheDocument();
+  expect(document.title).toBe('계정 설정 - 로아끼욧');
   expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, follow');
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const Market = React.lazy(() => import(/* webpackChunkName: "route-market" */ '.
 const Changelog = React.lazy(() => import(/* webpackChunkName: "route-changelog" */ './pages/Changelog'));
 const Policy = React.lazy(() => import(/* webpackChunkName: "route-policy" */ './pages/Policy'));
 const AuthCallback = React.lazy(() => import(/* webpackChunkName: "route-auth-callback" */ './pages/AuthCallback'));
+const AccountSettings = React.lazy(() => import(/* webpackChunkName: "route-account" */ './pages/AccountSettings'));
 const NotFound = React.lazy(() => import(/* webpackChunkName: "route-not-found" */ './pages/NotFound'));
 
 const ChunkErrorBanner: React.FC = () => {
@@ -75,6 +76,7 @@ const AppContent: React.FC = () => {
               <Route path={ROUTES.changelog} element={<Changelog />} />
               <Route path={ROUTES.policy} element={<Policy />} />
               <Route path="/auth/callback" element={<AuthCallback />} />
+              <Route path={ROUTES.account} element={<AccountSettings />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </React.Suspense>

--- a/src/components/auth/AuthControls.test.tsx
+++ b/src/components/auth/AuthControls.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import type { User } from '@supabase/supabase-js';
 
@@ -30,7 +31,7 @@ beforeEach(() => {
 });
 
 test('anonymous users can start Discord login', async () => {
-  render(<AuthControls />);
+  render(<MemoryRouter><AuthControls /></MemoryRouter>);
 
   await userEvent.click(screen.getByRole('button', { name: 'Discord 로그인' }));
 
@@ -50,10 +51,11 @@ test('authenticated users see their profile and can log out', async () => {
   } as User;
   vi.mocked(useAuth).mockReturnValue(authValue({ status: 'authenticated', user }));
 
-  const { container } = render(<AuthControls />);
+  const { container } = render(<MemoryRouter><AuthControls /></MemoryRouter>);
 
   expect(screen.getByText('Lokki 사용자')).toBeInTheDocument();
   expect(container.querySelector('img')).toHaveAttribute('src', 'https://example.com/avatar.png');
+  expect(screen.getByRole('link', { name: '계정 설정' })).toHaveAttribute('href', '/account');
   await userEvent.click(screen.getByRole('button', { name: '로그아웃' }));
   expect(signOut).toHaveBeenCalledOnce();
 });
@@ -61,7 +63,7 @@ test('authenticated users see their profile and can log out', async () => {
 test('login errors are recoverable and dismissible', async () => {
   vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류', errorScope: 'action' }));
 
-  render(<AuthControls variant="mobile" />);
+  render(<MemoryRouter><AuthControls variant="mobile" /></MemoryRouter>);
 
   expect(screen.getByRole('alert')).toHaveTextContent('로그인 오류');
   await userEvent.click(screen.getByRole('button', { name: '닫기' }));
@@ -72,7 +74,7 @@ test('login errors are recoverable and dismissible', async () => {
 test('can suppress a callback error already shown by the page', () => {
   vi.mocked(useAuth).mockReturnValue(authValue({ errorMessage: '로그인 오류' }));
 
-  render(<AuthControls showError={false} />);
+  render(<MemoryRouter><AuthControls showError={false} /></MemoryRouter>);
 
   expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Discord 로그인' })).toBeEnabled();
@@ -83,7 +85,7 @@ test('callback-scoped errors are not shown in the header', () => {
     authValue({ errorMessage: 'Discord 로그인이 취소되었거나 완료되지 않았습니다.', errorScope: 'callback' }),
   );
 
-  render(<AuthControls />);
+  render(<MemoryRouter><AuthControls /></MemoryRouter>);
 
   expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 });
@@ -91,7 +93,7 @@ test('callback-scoped errors are not shown in the header', () => {
 test('does not render authentication UI when Supabase is not configured', () => {
   vi.mocked(useAuth).mockReturnValue(authValue({ status: 'unavailable' }));
 
-  const { container } = render(<AuthControls />);
+  const { container } = render(<MemoryRouter><AuthControls /></MemoryRouter>);
 
   expect(container).toBeEmptyDOMElement();
 });

--- a/src/components/auth/AuthControls.tsx
+++ b/src/components/auth/AuthControls.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
 type AuthControlsProps = {
@@ -73,6 +74,17 @@ export const AuthControls: React.FC<AuthControlsProps> = ({ variant = 'desktop',
         </span>
       </div>
       {showError && errorScope !== 'callback' && errorMessage && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{errorMessage}</p>}
+      <Link
+        to="/account"
+        aria-label="계정 설정"
+        title="계정 설정"
+        className={`${isMobile ? 'inline-flex min-h-10 w-full items-center justify-center' : 'inline-flex h-9 w-9 items-center justify-center'} rounded-lg text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-la-gold/40 dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white`}
+      >
+        <svg aria-hidden viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-5 w-5">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </Link>
       <button
         type="button"
         disabled={isBusy}

--- a/src/constants/routeSeo.json
+++ b/src/constants/routeSeo.json
@@ -94,5 +94,13 @@
     "robots": "index, follow",
     "lastmod": "2026-08-25",
     "priority": "0.3"
+  },
+  {
+    "path": "/account",
+    "title": "계정 설정 - 로아끼욧",
+    "description": "로아끼욧 계정의 프로필, 저장되는 데이터 범위 확인과 계정 삭제를 관리합니다.",
+    "robots": "noindex, follow",
+    "lastmod": "2026-09-04",
+    "priority": "0.2"
   }
 ]

--- a/src/lib/lokkiAccount.ts
+++ b/src/lib/lokkiAccount.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import type { IsoTimestamp, LokkiProfile } from '../types/lokkiAccount';
+
+const DISPLAY_NAME_MAX_LENGTH = 50;
+const AVATAR_URL_MAX_LENGTH = 2048;
+
+type SupabaseLike = Pick<SupabaseClient, 'from'>;
+
+const pickTrimmedString = (metadata: Record<string, unknown> | undefined, keys: readonly string[], maxLength: number): string | null => {
+  for (const key of keys) {
+    const value = metadata?.[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim().slice(0, maxLength);
+    }
+  }
+  return null;
+};
+
+export const getDiscordProfileFromMetadata = (user: User) => ({
+  displayName: pickTrimmedString(user.user_metadata, ['global_name', 'full_name', 'name'], DISPLAY_NAME_MAX_LENGTH),
+  avatarUrl: pickTrimmedString(user.user_metadata, ['avatar_url'], AVATAR_URL_MAX_LENGTH),
+});
+
+/** Discord 프로필 변경을 반영해 로아끼욧 프로필을 갱신한다. discord_id는 브라우저에서 쓸 수 없다. */
+export const syncLokkiProfile = async (client: SupabaseLike, user: User): Promise<boolean> => {
+  const { displayName, avatarUrl } = getDiscordProfileFromMetadata(user);
+  const { error } = await client
+    .from('lokki_profiles')
+    .upsert({ user_id: user.id, display_name: displayName, avatar_url: avatarUrl }, { onConflict: 'user_id' });
+  return !error;
+};
+
+export interface LokkiDataScopeSummary {
+  readonly profile: LokkiProfile | null;
+  readonly rosterCount: number;
+  readonly characterCount: number;
+  readonly weeklyStateCount: number;
+  readonly lastUpdatedAt: IsoTimestamp;
+}
+
+export const fetchLokkiDataScope = async (
+  client: SupabaseLike,
+  userId: string,
+): Promise<LokkiDataScopeSummary | null> => {
+  const [profileResult, rosterCountResult, characterCountResult, weeklyStateCountResult] = await Promise.all([
+    client.from('lokki_profiles').select('user_id, display_name, avatar_url, discord_id, created_at, updated_at').eq('user_id', userId).maybeSingle(),
+    client.from('lokki_rosters').select('user_id', { count: 'exact', head: true }).eq('user_id', userId),
+    client.from('lokki_characters').select('user_id', { count: 'exact', head: true }).eq('user_id', userId),
+    client.from('lokki_weekly_states').select('user_id', { count: 'exact', head: true }).eq('user_id', userId),
+  ]);
+
+  if (profileResult.error) return null;
+
+  return {
+    profile: profileResult.data ?? null,
+    rosterCount: rosterCountResult.count ?? 0,
+    characterCount: characterCountResult.count ?? 0,
+    weeklyStateCount: weeklyStateCountResult.count ?? 0,
+    lastUpdatedAt: profileResult.data?.updated_at ?? profileResult.data?.created_at ?? '',
+  };
+};

--- a/src/pages/AccountSettings.test.tsx
+++ b/src/pages/AccountSettings.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { User } from '@supabase/supabase-js';
+import type { LokkiDataScopeSummary } from '../lib/lokkiAccount';
+
+vi.mock('../context/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../lib/supabase', () => ({ getSupabaseBrowserClient: vi.fn() }));
+vi.mock('../lib/lokkiAccount', async () => {
+  const actual = await vi.importActual<typeof import('../lib/lokkiAccount')>('../lib/lokkiAccount');
+  return { ...actual, fetchLokkiDataScope: vi.fn(), syncLokkiProfile: vi.fn() };
+});
+
+import { useAuth } from '../context/AuthContext';
+import { getSupabaseBrowserClient } from '../lib/supabase';
+import { fetchLokkiDataScope, syncLokkiProfile } from '../lib/lokkiAccount';
+import AccountSettings from './AccountSettings';
+
+const client = { from: vi.fn() } as unknown as ReturnType<typeof getSupabaseBrowserClient>;
+const testUser = {
+  id: 'user-1',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  created_at: '2026-09-04T00:00:00Z',
+} as unknown as User;
+
+const scopeSummary: LokkiDataScopeSummary = {
+  profile: {
+    user_id: 'user-1',
+    display_name: '1_d_g',
+    avatar_url: null,
+    discord_id: null,
+    created_at: '2026-09-04T00:00:00Z',
+    updated_at: '2026-09-04T01:00:00Z',
+  },
+  rosterCount: 0,
+  characterCount: 0,
+  weeklyStateCount: 0,
+  lastUpdatedAt: '2026-09-04T01:00:00Z',
+};
+
+const authValue = (overrides: Partial<ReturnType<typeof useAuth>> = {}): ReturnType<typeof useAuth> => ({
+  status: 'authenticated',
+  session: { access_token: 'token-1' } as ReturnType<typeof useAuth>['session'],
+  user: testUser,
+  isBusy: false,
+  errorMessage: null,
+  errorScope: null,
+  signInWithDiscord: vi.fn(),
+  signOut: vi.fn(),
+  clearError: vi.fn(),
+  ...overrides,
+});
+
+const renderPage = (initialEntries = ['/account']) =>
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/account" element={<AccountSettings />} />
+        <Route path="/" element={<div>Home Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAuth).mockReturnValue(authValue());
+  vi.mocked(getSupabaseBrowserClient).mockReturnValue(client);
+  vi.mocked(fetchLokkiDataScope).mockResolvedValue(scopeSummary);
+  vi.mocked(syncLokkiProfile).mockResolvedValue(true);
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('shows the profile and stored data scope for a signed-in user', async () => {
+  renderPage();
+
+  expect(await screen.findByRole('heading', { name: '프로필' })).toBeInTheDocument();
+  expect(screen.getByText('1_d_g')).toBeInTheDocument();
+  expect(screen.getByText(/Discord 연동 대기 중/)).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: '저장 중인 데이터' })).toBeInTheDocument();
+  expect(screen.getByText(/마지막 갱신/)).toBeInTheDocument();
+  expect(screen.getByText('계정 설정', { selector: 'h1' })).toBeInTheDocument();
+  expect(syncLokkiProfile).toHaveBeenCalledWith(client, testUser);
+});
+
+test('refreshes the Discord profile on demand', async () => {
+  renderPage();
+
+  await userEvent.click(await screen.findByRole('button', { name: 'Discord 프로필 정보 갱신' }));
+
+  expect(await screen.findByRole('status')).toHaveTextContent('갱신했습니다');
+  expect(syncLokkiProfile).toHaveBeenCalledTimes(2);
+});
+
+test('redirects anonymous visitors to the home route', async () => {
+  vi.mocked(useAuth).mockReturnValue(authValue({ status: 'anonymous', user: null, session: null }));
+
+  renderPage();
+
+  expect(await screen.findByText('Home Page')).toBeInTheDocument();
+});
+
+test('shows a notice when auth is unavailable', async () => {
+  vi.mocked(useAuth).mockReturnValue(authValue({ status: 'unavailable', user: null, session: null }));
+
+  renderPage();
+
+  expect(await screen.findByText('현재 환경에는 로그인 기능이 설정되어 있지 않습니다.')).toBeInTheDocument();
+});
+
+test('requires typed confirmation before account deletion', async () => {
+  renderPage();
+
+  await userEvent.click(await screen.findByRole('button', { name: '계정 삭제' }));
+  const confirmButton = screen.getByRole('button', { name: '계정 영구 삭제' });
+  expect(confirmButton).toBeDisabled();
+
+  await userEvent.type(screen.getByLabelText(/계속하려면/), '삭제');
+
+  expect(confirmButton).toBeEnabled();
+});
+
+test('deletes the account with the session token and reloads the app', async () => {
+  const replaceMock = vi.fn();
+  const originalLocation = window.location;
+  Object.defineProperty(window, 'location', { configurable: true, value: { replace: replaceMock } });
+
+  try {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response);
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', { name: '계정 삭제' }));
+    await userEvent.type(screen.getByLabelText(/계속하려면/), '삭제');
+    await userEvent.click(screen.getByRole('button', { name: '계정 영구 삭제' }));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/'));
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith('/api/account-delete', {
+      method: 'POST',
+      headers: { authorization: 'Bearer token-1' },
+    });
+  } finally {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  }
+});
+
+test('shows a recovery message when deletion fails', async () => {
+  renderPage();
+
+  vi.mocked(fetch).mockResolvedValue({ ok: false, status: 502 } as Response);
+  await userEvent.click(await screen.findByRole('button', { name: '계정 삭제' }));
+  await userEvent.type(screen.getByLabelText(/계속하려면/), '삭제');
+  await userEvent.click(screen.getByRole('button', { name: '계정 영구 삭제' }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('계정을 삭제하지 못했습니다');
+});

--- a/src/pages/AccountSettings.tsx
+++ b/src/pages/AccountSettings.tsx
@@ -1,0 +1,236 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { getSupabaseBrowserClient } from '../lib/supabase';
+import { fetchLokkiDataScope, syncLokkiProfile, type LokkiDataScopeSummary } from '../lib/lokkiAccount';
+
+const DELETE_CONFIRM_TEXT = '삭제';
+
+const formatIsoTimestamp = (iso: string | null | undefined): string => {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+};
+
+const AccountSettings: React.FC = () => {
+  const navigate = useNavigate();
+  const { status, user, session } = useAuth();
+  const [scope, setScope] = useState<LokkiDataScopeSummary | null>(null);
+  const [isScopeLoading, setIsScopeLoading] = useState(false);
+  const [profileMessage, setProfileMessage] = useState<string | null>(null);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [deleteConfirmInput, setDeleteConfirmInput] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const client = useMemo(() => getSupabaseBrowserClient(), []);
+  const isAuthenticated = status === 'authenticated' && user != null && client != null;
+
+  const loadScope = useCallback(async () => {
+    if (!client || !user) return;
+    setIsScopeLoading(true);
+    try {
+      setScope(await fetchLokkiDataScope(client, user.id));
+    } finally {
+      setIsScopeLoading(false);
+    }
+  }, [client, user]);
+
+  useEffect(() => {
+    void loadScope();
+    setProfileMessage(null);
+    // 최초 로그인 이후 Discord 프로필 변경을 반영한다. 실패해도 화면 기능은 계속된다.
+    if (client && user) void syncLokkiProfile(client, user);
+  }, [client, user, loadScope]);
+
+  useEffect(() => {
+    if (status === 'anonymous') navigate('/', { replace: true });
+  }, [navigate, status]);
+
+  const handleProfileRefresh = async () => {
+    if (!client || !user) return;
+    setProfileMessage(null);
+    const synced = await syncLokkiProfile(client, user);
+    await loadScope();
+    setProfileMessage(synced ? 'Discord 프로필 정보를 갱신했습니다.' : '프로필을 갱신하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+  };
+
+  const handleDelete = async () => {
+    if (!session?.access_token) return;
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      const response = await fetch('/api/account-delete', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${session.access_token}` },
+      });
+      if (response.ok) {
+        // 계정이 삭제되어 세션이 무효화됐다. 상태를 확실히 초기화하기 위해 앱을 다시 적재한다.
+        window.location.replace('/');
+        return;
+      }
+      setDeleteError(
+        response.status === 401
+          ? '로그인 세션이 만료되었습니다. 다시 로그인한 뒤 삭제를 진행해 주세요.'
+          : '계정을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    } catch {
+      setDeleteError('계정을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (status === 'unavailable') {
+    return (
+      <div>
+        <main className="mx-auto max-w-xl px-4 py-12">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">계정 설정</h1>
+          <p className="mt-3 text-sm text-gray-600 dark:text-gray-300">
+            현재 환경에는 로그인 기능이 설정되어 있지 않습니다.
+          </p>
+        </main>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div>
+        <main className="mx-auto flex min-h-[50vh] max-w-xl items-center justify-center px-4 py-12">
+          <p role="status" className="text-sm text-gray-500 dark:text-gray-400">로그인 정보를 확인하는 중...</p>
+        </main>
+      </div>
+    );
+  }
+
+  const displayName = scope?.profile?.display_name ?? '로그인 사용자';
+  const avatarUrl = scope?.profile?.avatar_url;
+  const discordLinked = scope?.profile?.discord_id != null;
+
+  return (
+    <div>
+      <main className="mx-auto max-w-2xl space-y-6 px-4 py-10">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">계정 설정</h1>
+        <section aria-labelledby="account-profile-heading" className="rounded-2xl border border-gray-200/70 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/5">
+          <h2 id="account-profile-heading" className="text-base font-bold text-gray-900 dark:text-white">프로필</h2>
+          <div className="mt-4 flex items-center gap-3">
+            {avatarUrl ? (
+              <img src={avatarUrl} alt="" className="h-12 w-12 rounded-full" referrerPolicy="no-referrer" />
+            ) : (
+              <span aria-hidden className="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 text-base font-bold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300">
+                {displayName.slice(0, 1)}
+              </span>
+            )}
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-gray-900 dark:text-white" title={displayName}>{displayName}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Discord 연동 {discordLinked ? '완료' : '대기 중'} · 가입 {formatIsoTimestamp(scope?.profile?.created_at)}
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void handleProfileRefresh()}
+              className="min-h-10 rounded-lg bg-gray-100 px-4 text-sm font-semibold text-gray-700 hover:bg-gray-200 dark:bg-white/10 dark:text-gray-200 dark:hover:bg-white/15"
+            >
+              Discord 프로필 정보 갱신
+            </button>
+            {profileMessage && <p role="status" className="text-xs text-gray-600 dark:text-gray-300">{profileMessage}</p>}
+          </div>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            표시 이름과 프로필 이미지는 Discord 계정 정보를 따르며, 로그인할 때 자동으로 갱신됩니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="account-data-heading" className="rounded-2xl border border-gray-200/70 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/5">
+          <h2 id="account-data-heading" className="text-base font-bold text-gray-900 dark:text-white">저장 중인 데이터</h2>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            {isScopeLoading ? '불러오는 중...' : scope ? `마지막 갱신: ${formatIsoTimestamp(scope.lastUpdatedAt) || '정보 없음'}` : '정보를 불러오지 못했습니다.'}
+          </p>
+          <dl className="mt-4 space-y-3 text-sm">
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-gray-600 dark:text-gray-300">프로필 (표시 이름, 프로필 이미지)</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">{scope ? 1 : 0}건</dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-gray-600 dark:text-gray-300">원정대 대표 캐릭터</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">{scope?.rosterCount ?? 0}건</dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-gray-600 dark:text-gray-300">캐릭터 목록</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">{scope?.characterCount ?? 0}건</dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-gray-600 dark:text-gray-300">주간 활동 기록</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">{scope?.weeklyStateCount ?? 0}건</dd>
+            </div>
+          </dl>
+          <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+            로스트아크 계정 정보·STOVE 토큰·결제 원본 로그는 저장하지 않습니다. 캐릭터 데이터는 공개 API 조회 결과만 저장합니다.
+          </p>
+        </section>
+
+        <section aria-labelledby="account-delete-heading" className="rounded-2xl border border-red-200 bg-red-50/60 p-5 dark:border-red-500/30 dark:bg-red-500/10">
+          <h2 id="account-delete-heading" className="text-base font-bold text-red-700 dark:text-red-300">계정 삭제</h2>
+          <p className="mt-2 text-sm text-red-700/90 dark:text-red-300/90">
+            로그인 정보와 저장된 모든 데이터가 영구 삭제되며 되돌릴 수 없습니다.
+          </p>
+          {!isDeleteConfirmOpen ? (
+            <button
+              type="button"
+              onClick={() => setIsDeleteConfirmOpen(true)}
+              className="mt-4 min-h-10 rounded-lg bg-red-600 px-4 text-sm font-semibold text-white hover:bg-red-700"
+            >
+              계정 삭제
+            </button>
+          ) : (
+            <div className="mt-4 space-y-3">
+              <label htmlFor="delete-confirm-input" className="block text-sm text-red-700 dark:text-red-300">
+                계속하려면 <strong>삭제</strong>를 입력해 주세요.
+              </label>
+              <input
+                id="delete-confirm-input"
+                value={deleteConfirmInput}
+                onChange={(event) => setDeleteConfirmInput(event.target.value)}
+                autoComplete="off"
+                className="w-full rounded-lg border border-red-300 bg-white px-3 py-2 text-sm text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 dark:border-red-500/40 dark:bg-white/10 dark:text-white"
+              />
+              {deleteError && <p role="alert" className="text-xs text-red-700 dark:text-red-300">{deleteError}</p>}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={isDeleting || deleteConfirmInput !== DELETE_CONFIRM_TEXT}
+                  onClick={() => void handleDelete()}
+                  className="min-h-10 rounded-lg bg-red-600 px-4 text-sm font-semibold text-white hover:bg-red-700 disabled:cursor-wait disabled:opacity-60"
+                >
+                  {isDeleting ? '삭제 중...' : '계정 영구 삭제'}
+                </button>
+                <button
+                  type="button"
+                  disabled={isDeleting}
+                  onClick={() => {
+                    setIsDeleteConfirmOpen(false);
+                    setDeleteConfirmInput('');
+                    setDeleteError(null);
+                  }}
+                  className="min-h-10 rounded-lg bg-white px-4 text-sm font-semibold text-gray-700 hover:bg-gray-100 dark:bg-white/10 dark:text-gray-200 dark:hover:bg-white/15 disabled:opacity-60"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+          궁금한 점은 <Link to="/policy" className="underline">개인정보처리방침</Link>을 참고해 주세요.
+        </p>
+      </main>
+    </div>
+  );
+};
+
+export default AccountSettings;

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,15 +1,21 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import { useAuth } from '../context/AuthContext';
+import { syncLokkiProfile } from '../lib/lokkiAccount';
+import { getSupabaseBrowserClient } from '../lib/supabase';
 
 const AuthCallback: React.FC = () => {
   const navigate = useNavigate();
-  const { status, errorMessage, isBusy, signInWithDiscord } = useAuth();
+  const { status, user, errorMessage, isBusy, signInWithDiscord } = useAuth();
+  const client = useMemo(() => getSupabaseBrowserClient(), []);
 
   useEffect(() => {
-    if (status === 'authenticated') navigate('/', { replace: true });
-  }, [navigate, status]);
+    if (status !== 'authenticated') return;
+    // 로그인마다 Discord 프로필 변경을 반영한다. 실패해도 로그인 흐름을 막지 않는다.
+    if (client && user) void syncLokkiProfile(client, user);
+    navigate('/', { replace: true });
+  }, [client, navigate, status, user]);
 
   const isLoading = status === 'loading' || status === 'authenticated';
 

--- a/src/pages/Policy.test.tsx
+++ b/src/pages/Policy.test.tsx
@@ -1,14 +1,33 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Policy from './Policy';
 
 vi.mock('../components/NavBar', () => ({ default: () => <nav>Navigation</nav> }));
 
 test('describes the information handled by the service', () => {
-  render(<Policy />);
+  render(
+    <MemoryRouter>
+      <Policy />
+    </MemoryRouter>,
+  );
 
   expect(screen.getByRole('heading', { level: 1, name: '개인정보처리방침' })).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: '1. 처리하는 정보와 이용 목적' })).toBeInTheDocument();
   expect(screen.getByText(/캐릭터 닉네임을 처리합니다/)).toBeInTheDocument();
   expect(screen.getByText(/Vercel Analytics를 통해 처리될 수 있습니다/)).toBeInTheDocument();
-  expect(screen.getByText('시행일: 2026년 8월 25일')).toBeInTheDocument();
+  expect(screen.getByText('시행일: 2026년 9월 4일')).toBeInTheDocument();
+});
+
+test('describes account data storage and deletion', () => {
+  render(
+    <MemoryRouter>
+      <Policy />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByRole('heading', { name: '2. 회원 계정 정보의 저장과 삭제' })).toBeInTheDocument();
+  expect(screen.getByText(/주간 활동 기록은 회원 데이터베이스에 저장됩니다/)).toBeInTheDocument();
+  expect(screen.getByText(/계정 설정 화면에서 언제든지 확인할 수 있습니다/)).toBeInTheDocument();
+  expect(screen.getByText(/STOVE 토큰/)).toBeInTheDocument();
+  expect(screen.getByText(/영구 삭제됩니다/)).toBeInTheDocument();
 });

--- a/src/pages/Policy.tsx
+++ b/src/pages/Policy.tsx
@@ -11,7 +11,7 @@ const Policy: React.FC = () => (
         <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
           로아끼욧은 이용자의 정보를 안전하게 다루기 위해 다음과 같이 개인정보 처리 기준을 안내합니다.
         </p>
-        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">시행일: 2026년 8월 25일</p>
+        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">시행일: 2026년 9월 4일</p>
       </header>
 
       <GlassCard className="space-y-8 p-5 text-sm leading-7 text-gray-700 sm:p-8 dark:text-gray-300">
@@ -26,12 +26,29 @@ const Policy: React.FC = () => (
               Vercel Analytics를 통해 처리될 수 있습니다.
             </li>
             <li>회원가입, 실명, 연락처 또는 결제 정보를 직접 수집하지 않습니다.</li>
+            <li>
+              Discord 계정 연동을 선택하면 Discord 프로필의 표시 이름과 프로필 이미지 주소, 내부 계정
+              식별자를 회원 기능 제공을 위해 처리합니다. 로그인하지 않아도 모든 공개 기능을 그대로 이용할 수
+              있습니다.
+            </li>
+          </ul>
+        </section>
+
+        <section aria-labelledby="policy-account">
+          <h2 id="policy-account" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
+            2. 회원 계정 정보의 저장과 삭제
+          </h2>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>연동된 Discord 프로필 정보와 이용자가 저장한 원정대·캐릭터·주간 활동 기록은 회원 데이터베이스에 저장됩니다.</li>
+            <li>저장되는 항목과 마지막 갱신 시각은 계정 설정 화면에서 언제든지 확인할 수 있습니다.</li>
+            <li>로스트아크 계정 인증 정보(STOVE 토큰)와 결제 원문 로그는 저장하지 않습니다.</li>
+            <li>계정 설정 화면에서 본인 계정을 직접 삭제할 수 있으며, 삭제 시 회원 정보와 저장된 데이터가 함께 영구 삭제됩니다.</li>
           </ul>
         </section>
 
         <section aria-labelledby="policy-storage">
           <h2 id="policy-storage" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
-            2. 브라우저 저장 정보
+            3. 브라우저 저장 정보
           </h2>
           <p>
             최근 검색한 캐릭터 닉네임, 테마 설정, 시뮬레이션 및 숙제 관리 상태 등은 편의 기능 제공을 위해
@@ -42,39 +59,40 @@ const Policy: React.FC = () => (
 
         <section aria-labelledby="policy-retention">
           <h2 id="policy-retention" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
-            3. 보유 및 파기
+            4. 보유 및 파기
           </h2>
           <p>
-            캐릭터 조회 정보는 기능 제공 과정에서만 사용하며 별도의 회원 데이터베이스에 저장하지 않습니다.
-            브라우저 저장 정보는 이용자가 삭제할 때까지 보관되며, 분석 정보는 Vercel의 정책에 따라 보관 및
-            삭제됩니다.
+            캐릭터 조회 정보는 기능 제공 과정에서만 사용하며 별도로 저장하지 않습니다. 회원 계정 정보와
+            저장 데이터는 계정 삭제 시 즉시 파기됩니다. 브라우저 저장 정보는 이용자가 삭제할 때까지 보관되며,
+            분석 정보는 Vercel의 정책에 따라 보관 및 삭제됩니다.
           </p>
         </section>
 
         <section aria-labelledby="policy-third-party">
           <h2 id="policy-third-party" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
-            4. 외부 서비스 이용
+            5. 외부 서비스 이용
           </h2>
           <p>
-            로아끼욧은 캐릭터 및 게임 정보 제공을 위해 LOST ARK Open API를 이용하고, 서비스 배포와 이용 현황
-            분석을 위해 Vercel을 이용합니다. 각 외부 서비스에서 처리되는 정보에는 해당 서비스의 개인정보
-            처리방침이 적용됩니다.
+            로아끼욧은 캐릭터 및 게임 정보 제공을 위해 LOST ARK Open API를 이용하고, Discord 계정 연동을
+            위해 Supabase와 Discord 인증을, 서비스 배포와 이용 현황 분석을 위해 Vercel을 이용합니다. 각 외부
+            서비스에서 처리되는 정보에는 해당 서비스의 개인정보 처리방침이 적용됩니다.
           </p>
         </section>
 
         <section aria-labelledby="policy-rights">
           <h2 id="policy-rights" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
-            5. 이용자의 권리
+            6. 이용자의 권리
           </h2>
           <p>
             이용자는 브라우저에 저장된 정보를 직접 확인하거나 삭제할 수 있으며, 브라우저 설정 또는 콘텐츠
-            차단 기능을 통해 분석 정보 처리를 제한할 수 있습니다.
+            차단 기능을 통해 분석 정보 처리를 제한할 수 있습니다. 회원은 계정 설정 화면에서 저장 데이터
+            범위를 확인하고 프로필 정보를 갱신하거나 계정을 삭제할 수 있습니다.
           </p>
         </section>
 
         <section aria-labelledby="policy-changes">
           <h2 id="policy-changes" className="mb-2 text-base font-bold text-gray-900 dark:text-white">
-            6. 방침 변경
+            7. 방침 변경
           </h2>
           <p>
             이 방침의 내용이 변경되는 경우 시행 전에 서비스 내 공지 또는 이 페이지를 통해 안내합니다.

--- a/src/staticSeoGeneration.test.js
+++ b/src/staticSeoGeneration.test.js
@@ -78,15 +78,20 @@ test('generates route HTML with metadata matching routeSeo.json', () => {
       }),
     ]));
     const page = structuredData['@graph'].find((entry) => entry['@id'] === `${canonical}#webpage`);
-    expect(page).toMatchObject({
-      '@type': route.schemaType === 'WebApplication' ? 'WebApplication' : 'WebPage',
-      url: canonical,
-      name: route.name || route.title.replace(/\s[-|]\s로아끼욧$/, ''),
-      description: route.description,
-      inLanguage: 'ko-KR',
-    });
+    // noindex 라우트는 색인 대상이 아니므로 페이지/브레드크럼 스키마를 포함하지 않는다.
+    if (route.robots === 'index, follow') {
+      expect(page).toMatchObject({
+        '@type': route.schemaType === 'WebApplication' ? 'WebApplication' : 'WebPage',
+        url: canonical,
+        name: route.name || route.title.replace(/\s[-|]\s로아끼욧$/, ''),
+        description: route.description,
+        inLanguage: 'ko-KR',
+      });
+    } else {
+      expect(page).toBeUndefined();
+    }
 
-    if (route.path !== '/') {
+    if (route.path !== '/' && route.robots === 'index, follow') {
       expect(structuredData['@graph']).toEqual(expect.arrayContaining([
         expect.objectContaining({ '@type': 'BreadcrumbList', '@id': `${canonical}#breadcrumb` }),
       ]));
@@ -169,8 +174,8 @@ test('keeps API, known routes, missing routes, and static assets distinct in Ver
   const fallbackRewrite = rewrites[rewrites.length - 1];
   const pageRewrites = rewrites.filter((rewrite) =>
     rewrite.source !== '/auth/callback' && rewrite.destination.endsWith('/index.html'));
-  const indexablePageRoutes = routeSeoEntries
-    .filter((route) => route.path !== '/' && route.robots === 'index, follow')
+  const configuredPageRoutes = routeSeoEntries
+    .filter((route) => route.path !== '/')
     .map((route) => route.path)
     .sort();
 
@@ -194,7 +199,7 @@ test('keeps API, known routes, missing routes, and static assets distinct in Ver
     ],
   });
   expect(authCallbackRewrite).toEqual({ source: '/auth/callback', destination: '/index.html' });
-  expect(pageRewrites.map((rewrite) => rewrite.source).sort()).toEqual(indexablePageRoutes);
+  expect(pageRewrites.map((rewrite) => rewrite.source).sort()).toEqual(configuredPageRoutes);
   for (const rewrite of pageRewrites) {
     expect(rewrite.destination).toBe(`${rewrite.source}/index.html`);
   }

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -5,6 +5,7 @@
 export const ROUTES = {
   changelog: '/changelog',
   policy: '/policy',
+  account: '/account',
 } as const;
 
 /** 뒤따르는 슬래시를 제거한 경로. 루트('/', '//')는 항상 '/'로 수렴한다. */

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,7 @@
     { "source": "/changelog", "destination": "/changelog/index.html" },
     { "source": "/policy", "destination": "/policy/index.html" },
     { "source": "/auth/callback", "destination": "/index.html" },
+    { "source": "/account", "destination": "/account/index.html" },
     { "source": "/:path*", "destination": "/404.html" }
   ]
 }


### PR DESCRIPTION
Parent: #75
Closes #80

## Summary
- `/account` 계정 설정 화면: 프로필 확인·갱신, 저장 중인 데이터 범위와 마지막 갱신 시각 표시, 계정 삭제 재확인 흐름
- `api/account-delete.js` 서버 전용 계정 삭제 endpoint: Bearer 토큰을 검증해 서버가 삭제 대상 사용자를 직접 결정하고, auth.users 삭제가 FK CASCADE로 lokki_* 데이터를 원자적으로 제거
- 로그인 시 Discord 프로필 변경 자동 반영 (AuthCallback + 설정 화면 진입 시, `discord_id`는 브라우저에서 쓸 수 없음)
- NavBar 로그인 상태에 계정 설정 진입 링크 추가
- 개인정보처리방침에 인증·저장·삭제 항목 반영 (시행일 2026-09-04)
- `/account` 정적 SEO (noindex) + Vercel rewrite

## 보안 설계
- 삭제 endpoint는 POST 전용, 세션 Bearer 토큰 검증 후 해당 사용자만 삭제 (클라이언트가 보낸 사용자 ID 미신뢰)
- Service Role Key는 서버 환경변수로만 사용 (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`)
- upstream 실패 시 부분 삭제 없음 (삭제 실패하면 어떤 데이터도 제거되지 않음)

## Verification
- `yarn test:account-delete`: 11/11 통과
- focused vitest: 40/40 통과 (계정 설정 화면, 삭제 흐름, 라우트/SEO, 정책)
- `yarn typecheck`: 통과
- DB 변경 없음 (#81 마이그레이션의 트리거·RLS·CASCADE를 그대로 사용)

## 배포 전 필요 작업
- Vercel 환경변수에 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` 등록 (미설정 시 삭제 endpoint는 503)